### PR TITLE
Update cs.json

### DIFF
--- a/safeeyes/safeeyes/config/lang/cs.json
+++ b/safeeyes/safeeyes/config/lang/cs.json
@@ -6,7 +6,7 @@
     "exercises": {
         "long_break_exercises": [
             "Na chvíli se projděte",
-            "Zakloňte se v křesle a relaxujte"
+            "Opřete se do křesla a relaxujte"
         ],
         "short_break_exercises": [
             "Zavřete oči",
@@ -30,9 +30,9 @@
         "interval_between_two_breaks": "Interval mezi dvěma přestávkami",
         "no_of_short_breaks_between_two_long_breaks": "Počet krátkých přestávek mezi dvěma dlouhými přestávkami",
         "time_to_prepare_for_break": "Čas k přípravě na přestávku (v sekundách)",
-        "idle_time": "Minimum idle time to pause (in minutes)",
+        "idle_time": "Pozastavit při nečinnosti delší než (v minutách)",
         "strict_break": "Povinná přestávka (Skrýt tlačítko pro přeskočení)",
-        "audible_alert": "Audible alert at the end of break",
+        "audible_alert": "Zvukové upozornění na konec přestávky",
         "language": "Jazyk",
         "enable": "Povolit Safe Eyes",
         "settings": "Nastavení",


### PR DESCRIPTION
Translated some new strings.

Also...
> "Opřete se do křesla a relaxujte"

If we tried to translate the present line back to English, it would look like "tilt your head back in your chair and relax", since "zaklonit" means to slightly rotate your head back so your chin rises. I believe this is not the intended meaning. "Opřete se do křesla a relaxujte" evokes the motion of leaning back in the chair and thus letting the backrest to carry more of your weight.