### PR TITLE
Make lower bound on time to prepare 1 second

### DIFF
--- a/safeeyes/safeeyes/glade/settings_dialog.glade
+++ b/safeeyes/safeeyes/glade/settings_dialog.glade
@@ -47,7 +47,7 @@
     <property name="page_increment">5</property>
   </object>
   <object class="GtkAdjustment" id="adjust_time_to_prepare">
-    <property name="lower">10</property>
+    <property name="lower">1</property>
     <property name="upper">60</property>
     <property name="step_increment">1</property>
     <property name="page_increment">5</property>


### PR DESCRIPTION
Thanks for making safeeyes, it works really well, and keeps getting better.

I really dislike the 10 seconds lower bound on time to prepare, i want it on 1 seconds, as otherwise I "lose" another 10 seconds of work. This PR changes the lower bound.