### PR TITLE
Lock screen feature

### DIFF
--- a/safeeyes/SafeEyesCore.py
+++ b/safeeyes/SafeEyesCore.py
@@ -65,7 +65,8 @@ class SafeEyesCore:
 		self.skip_break_window_classes = [x.lower() for x in config['active_window_class']['skip_break']]
 		self.take_break_window_classes = [x.lower() for x in config['active_window_class']['take_break']]
 		self.custom_exercises = config['custom_exercises']
-		self.time_to_screen_lock = config.get('time_to_screen_lock', -1) 
+		self.time_to_screen_lock = config.get('time_to_screen_lock', -1)
+		self.enable_screen_lock = config.get('enable_screen_lock', False)
 
 		exercises = language['exercises']
 		for short_break_config in config['short_breaks']:
@@ -292,6 +293,10 @@ class SafeEyesCore:
 				audible_alert = self.short_break_exercises[self.short_break_message_index][2]
 				image = self.short_break_exercises[self.short_break_message_index][3]
 			
+
+			if (Utility.is_desktop_lock_supported() and self.enable_screen_lock and self.time_to_screen_lock < seconds):
+				Utility.lock_desktop()
+
 			# Show the break screen
 			self.start_break(message, image)		
 

--- a/safeeyes/SafeEyesCore.py
+++ b/safeeyes/SafeEyesCore.py
@@ -294,8 +294,9 @@ class SafeEyesCore:
 				image = self.short_break_exercises[self.short_break_message_index][3]
 			
 
-			if (Utility.is_desktop_lock_supported() and self.enable_screen_lock and self.time_to_screen_lock < seconds):
-				Utility.lock_desktop()
+			total_break_time = seconds
+			# Should we lock screen potentially?
+			consider_screen_lock = Utility.is_desktop_lock_supported() and self.enable_screen_lock
 
 			# Show the break screen
 			self.start_break(message, image)		
@@ -307,6 +308,8 @@ class SafeEyesCore:
 				self.on_countdown(timeformat)
 				time.sleep(1)	# Sleep for 1 second
 				seconds -= 1
+				if consider_screen_lock and self.time_to_screen_lock == total_break_time - seconds:
+					Utility.lock_desktop()
 
 			# Loop terminated because of timeout (not skipped) -> Close the break alert
 			if not self.skipped and not self.postponed:

--- a/safeeyes/SafeEyesCore.py
+++ b/safeeyes/SafeEyesCore.py
@@ -65,6 +65,7 @@ class SafeEyesCore:
 		self.skip_break_window_classes = [x.lower() for x in config['active_window_class']['skip_break']]
 		self.take_break_window_classes = [x.lower() for x in config['active_window_class']['take_break']]
 		self.custom_exercises = config['custom_exercises']
+		self.time_to_screen_lock = config.get('time_to_screen_lock', -1) 
 
 		exercises = language['exercises']
 		for short_break_config in config['short_breaks']:

--- a/safeeyes/SettingsDialog.py
+++ b/safeeyes/SettingsDialog.py
@@ -45,6 +45,7 @@ class SettingsDialog:
 		self.switch_strict_break = builder.get_object('switch_strict_break')
 		self.switch_audible_alert = builder.get_object('switch_audible_alert')
 		self.cmb_language = builder.get_object('cmb_language')
+		self.switch_screen_lock = builder.get_object('switch_screen_lock')
 		self.spin_time_to_screen_lock = builder.get_object('spin_time_to_screen_lock')
 
 		builder.get_object('lbl_short_break').set_label(language['ui_controls']['short_break_duration'])
@@ -57,6 +58,7 @@ class SettingsDialog:
 		builder.get_object('lbl_strict_break').set_label(language['ui_controls']['strict_break'])
 		builder.get_object('lbl_audible_alert').set_label(language['ui_controls']['audible_alert'])
 		builder.get_object('lbl_language').set_label(language['ui_controls']['language'])
+		builder.get_object('lbl_enable_screen_lock').set_label(language['ui_controls']['enable_screen_lock'])
 		builder.get_object('lbl_lock_screen_after').set_label(language['ui_controls']['time_to_screen_lock'])
 		builder.get_object('btn_cancel').set_label(language['ui_controls']['cancel'])
 		builder.get_object('btn_save').set_label(language['ui_controls']['save'])
@@ -70,7 +72,9 @@ class SettingsDialog:
 		self.spin_postpone_duration.set_value(config['postpone_duration'])
 		self.switch_strict_break.set_active(config['strict_break'])
 		self.switch_audible_alert.set_active(config['audible_alert'])
-		self.time_to_screen_lock = self.config.get('time_to_screen_lock', -1)
+		self.switch_screen_lock.set_active(self.config.get('enable_screen_lock', True))
+		self.spin_time_to_screen_lock.set_value(self.config.get('time_to_screen_lock', 20))
+		self.on_switch_screen_lock_activate(self.switch_screen_lock, self.switch_screen_lock.get_active())
 
 		# Initialize the language combobox
 		language_list_store = Gtk.ListStore(GObject.TYPE_STRING)
@@ -104,6 +108,9 @@ class SettingsDialog:
 	def show(self):
 		self.window.show_all()
 
+	def on_switch_screen_lock_activate(self, switch, state):
+		self.spin_time_to_screen_lock.set_sensitive(self.switch_screen_lock.get_active())
+
 	def on_window_delete(self, *args):
 		self.window.destroy()
 
@@ -119,7 +126,7 @@ class SettingsDialog:
 		self.config['audible_alert'] = self.switch_audible_alert.get_active()
 		self.config['language'] = self.languages[self.cmb_language.get_active()]
 		self.config['time_to_screen_lock'] = self.spin_time_to_screen_lock.get_value_as_int()
-		print(self.config['time_to_screen_lock'])
+		self.config['enable_screen_lock'] = self.switch_screen_lock.get_active()
 
 		self.on_save_settings(self.config)	# Call the provided save method
 		self.window.destroy()	# Close the settings window

--- a/safeeyes/SettingsDialog.py
+++ b/safeeyes/SettingsDialog.py
@@ -73,7 +73,7 @@ class SettingsDialog:
 		self.switch_strict_break.set_active(config['strict_break'])
 		self.switch_audible_alert.set_active(config['audible_alert'])
 		self.switch_screen_lock.set_sensitive(Utility.is_desktop_lock_supported())
-		self.switch_screen_lock.set_active(Utility.is_desktop_lock_supported() and self.config.get('enable_screen_lock', True))
+		self.switch_screen_lock.set_active(Utility.is_desktop_lock_supported() and self.config.get('enable_screen_lock', False))
 		self.spin_time_to_screen_lock.set_value(self.config.get('time_to_screen_lock', 20))
 		self.on_switch_screen_lock_activate(self.switch_screen_lock, self.switch_screen_lock.get_active())
 

--- a/safeeyes/SettingsDialog.py
+++ b/safeeyes/SettingsDialog.py
@@ -72,7 +72,8 @@ class SettingsDialog:
 		self.spin_postpone_duration.set_value(config['postpone_duration'])
 		self.switch_strict_break.set_active(config['strict_break'])
 		self.switch_audible_alert.set_active(config['audible_alert'])
-		self.switch_screen_lock.set_active(self.config.get('enable_screen_lock', True))
+		self.switch_screen_lock.set_sensitive(Utility.is_desktop_lock_supported())
+		self.switch_screen_lock.set_active(Utility.is_desktop_lock_supported() and self.config.get('enable_screen_lock', True))
 		self.spin_time_to_screen_lock.set_value(self.config.get('time_to_screen_lock', 20))
 		self.on_switch_screen_lock_activate(self.switch_screen_lock, self.switch_screen_lock.get_active())
 

--- a/safeeyes/SettingsDialog.py
+++ b/safeeyes/SettingsDialog.py
@@ -45,6 +45,7 @@ class SettingsDialog:
 		self.switch_strict_break = builder.get_object('switch_strict_break')
 		self.switch_audible_alert = builder.get_object('switch_audible_alert')
 		self.cmb_language = builder.get_object('cmb_language')
+		self.spin_time_to_screen_lock = builder.get_object('spin_time_to_screen_lock')
 
 		builder.get_object('lbl_short_break').set_label(language['ui_controls']['short_break_duration'])
 		builder.get_object('lbl_long_break').set_label(language['ui_controls']['long_break_duration'])
@@ -56,6 +57,7 @@ class SettingsDialog:
 		builder.get_object('lbl_strict_break').set_label(language['ui_controls']['strict_break'])
 		builder.get_object('lbl_audible_alert').set_label(language['ui_controls']['audible_alert'])
 		builder.get_object('lbl_language').set_label(language['ui_controls']['language'])
+		builder.get_object('lbl_lock_screen_after').set_label(language['ui_controls']['time_to_screen_lock'])
 		builder.get_object('btn_cancel').set_label(language['ui_controls']['cancel'])
 		builder.get_object('btn_save').set_label(language['ui_controls']['save'])
 
@@ -68,6 +70,7 @@ class SettingsDialog:
 		self.spin_postpone_duration.set_value(config['postpone_duration'])
 		self.switch_strict_break.set_active(config['strict_break'])
 		self.switch_audible_alert.set_active(config['audible_alert'])
+		self.time_to_screen_lock = self.config.get('time_to_screen_lock', -1)
 
 		# Initialize the language combobox
 		language_list_store = Gtk.ListStore(GObject.TYPE_STRING)
@@ -115,6 +118,8 @@ class SettingsDialog:
 		self.config['strict_break'] = self.switch_strict_break.get_active()
 		self.config['audible_alert'] = self.switch_audible_alert.get_active()
 		self.config['language'] = self.languages[self.cmb_language.get_active()]
+		self.config['time_to_screen_lock'] = self.spin_time_to_screen_lock.get_value_as_int()
+		print(self.config['time_to_screen_lock'])
 
 		self.on_save_settings(self.config)	# Call the provided save method
 		self.window.destroy()	# Close the settings window

--- a/safeeyes/Utility.py
+++ b/safeeyes/Utility.py
@@ -257,4 +257,4 @@ def is_desktop_lock_supported():
 	return desktop_envinroment() in ['unity', 'gnome']
 
 def lock_desktop(): 
-	os.system("gnome-screensaver-command --lock")	
+	subprocess.call(["gnome-screensaver-command","--lock",])

--- a/safeeyes/Utility.py
+++ b/safeeyes/Utility.py
@@ -256,3 +256,5 @@ def desktop_envinroment():
 def is_desktop_lock_supported():
 	return desktop_envinroment() in ['unity', 'gnome']
 
+def lock_desktop(): 
+	os.system("gnome-screensaver-command --lock")	

--- a/safeeyes/Utility.py
+++ b/safeeyes/Utility.py
@@ -240,3 +240,19 @@ def read_lang_files():
 				languages[lang_file_name.lower().replace('.json', '')] = lang['meta_info']['language_name']
 
 	return languages
+
+def desktop_envinroment():
+	"""
+	Function tries to detect current envinroment
+	Possible results: unity, gnome or None if nothing detected
+	"""
+	if 'unity' == os.environ.get('XDG_CURRENT_DESKTOP', '').lower():
+		return 'unity'
+	elif 'gnome' == os.environ.get('DESKTOP_SESSION', '').lower():
+		return 'gnome'
+	
+	return None
+
+def is_desktop_lock_supported():
+	return desktop_envinroment() in ['unity', 'gnome']
+

--- a/safeeyes/config/lang/en.json
+++ b/safeeyes/config/lang/en.json
@@ -45,6 +45,7 @@
         "system_language": "System Language",
         "time_to_prepare_for_break": "Time to prepare for break (in seconds)",
         "until_restart": "Until restart",
-        "time_to_screen_lock": "Lock screen if break is longer than (in seconds)"
+        "time_to_screen_lock": "Lock screen if break is longer than (in seconds)",
+        "enable_screen_lock": "Enable screen lock for long breaks"
     }
 }

--- a/safeeyes/config/lang/en.json
+++ b/safeeyes/config/lang/en.json
@@ -44,6 +44,7 @@
         "strict_break": "Strict break (Hide skip button)",
         "system_language": "System Language",
         "time_to_prepare_for_break": "Time to prepare for break (in seconds)",
-        "until_restart": "Until restart"
+        "until_restart": "Until restart",
+        "time_to_screen_lock": "Lock screen if break is longer than (in seconds)"
     }
 }

--- a/safeeyes/config/lang/ru.json
+++ b/safeeyes/config/lang/ru.json
@@ -44,6 +44,8 @@
         "strict_break": "Обязательный перерыв (Скрыть кнопку 'Пропустить')",
         "system_language": "System Language",
         "time_to_prepare_for_break": "Время подготовки в перерыву (в секундах)",
-        "until_restart": "До перезагрузки"
+        "until_restart": "До перезагрузки",
+        "time_to_screen_lock": "Заблокировать экран если перерыв дольше(в секундах)",
+        "enable_screen_lock": "Включить блокировку экрана"
     }
 }

--- a/safeeyes/glade/settings_dialog.glade
+++ b/safeeyes/glade/settings_dialog.glade
@@ -46,7 +46,19 @@
     <property name="step_increment">1</property>
     <property name="page_increment">5</property>
   </object>
+  <object class="GtkAdjustment" id="adjust_postpone_duration">
+    <property name="lower">1</property>
+    <property name="upper">15</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">5</property>
+  </object>
   <object class="GtkAdjustment" id="adjust_short_break_duration">
+    <property name="lower">1</property>
+    <property name="upper">60</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">5</property>
+  </object>
+  <object class="GtkAdjustment" id="adjust_time_to_lock_screen">
     <property name="lower">1</property>
     <property name="upper">60</property>
     <property name="step_increment">1</property>
@@ -55,12 +67,6 @@
   <object class="GtkAdjustment" id="adjust_time_to_prepare">
     <property name="lower">1</property>
     <property name="upper">60</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">5</property>
-  </object>
-  <object class="GtkAdjustment" id="adjust_postpone_duration">
-    <property name="lower">1</property>
-    <property name="upper">15</property>
     <property name="step_increment">1</property>
     <property name="page_increment">5</property>
   </object>
@@ -197,32 +203,6 @@
               <packing>
                 <property name="left_attach">0</property>
                 <property name="top_attach">7</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="lbl_audible_alert">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="valign">center</property>
-                <property name="label" translatable="yes">Audible alert at the end of break</property>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">8</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="lbl_language">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="valign">center</property>
-                <property name="label" translatable="yes">Language</property>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">9</property>
               </packing>
             </child>
             <child>
@@ -377,6 +357,19 @@
               </packing>
             </child>
             <child>
+              <object class="GtkLabel" id="lbl_audible_alert">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes">Audible alert at the end of break</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">8</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkComboBox" id="cmb_language">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
@@ -387,10 +380,49 @@
               </packing>
             </child>
             <child>
-              <placeholder/>
+              <object class="GtkLabel" id="lbl_language">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes">Language</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">9</property>
+              </packing>
             </child>
             <child>
-              <placeholder/>
+              <object class="GtkLabel" id="lbl_lock_screen_after">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes">Lock screen if break is longer than (in seconds)</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">10</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSpinButton" id="spin_time_to_screen_lock">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="halign">end</property>
+                <property name="valign">center</property>
+                <property name="text" translatable="yes">1</property>
+                <property name="input_purpose">number</property>
+                <property name="adjustment">adjust_time_to_prepare</property>
+                <property name="climb_rate">1</property>
+                <property name="numeric">True</property>
+                <property name="update_policy">if-valid</property>
+                <property name="value">1</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">10</property>
+              </packing>
             </child>
           </object>
           <packing>

--- a/safeeyes/glade/settings_dialog.glade
+++ b/safeeyes/glade/settings_dialog.glade
@@ -402,7 +402,7 @@
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="top_attach">10</property>
+                <property name="top_attach">11</property>
               </packing>
             </child>
             <child>
@@ -418,6 +418,31 @@
                 <property name="numeric">True</property>
                 <property name="update_policy">if-valid</property>
                 <property name="value">1</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">11</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="lbl_enable_screen_lock">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <property name="label" translatable="yes">Enable screen lock for long breaks</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">10</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="switch_screen_lock">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <signal name="activate" handler="on_switch_screen_lock_activate" swapped="no"/>
+                <signal name="state-set" handler="on_switch_screen_lock_activate" swapped="no"/>
               </object>
               <packing>
                 <property name="left_attach">1</property>


### PR DESCRIPTION
As we discussed in #102 : user can enable automatic screen locking if break is longer than specified time

What is done:
* Switch for feature which become enabled only on supported systems
* Timeout input which allows to sent minimum interval of break before screen is locked
* Currently supports only ubuntu/unity and gnome (seems like they user the same command)

If user click 'postpone' or 'skip' button before specified time interval screen won't be locked 
I didn't touch config version variable but added optional config keys instead