### PR TITLE
.desktop: Address validity issues

### DIFF
--- a/share/applications/safeeyes.desktop
+++ b/share/applications/safeeyes.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Encoding=UTF-8
 Name=Safe Eyes
 Comment=Protect your eyes from eye strain
 Comment[ge]=დაიცავით თქვენი თვალები დაღლილობისაგან
@@ -15,7 +14,7 @@ Comment[es]=Protege tus ojos de la fatiga ocular
 Comment[ru]=Защитите свои глаза от зрительного перенапряжения
 Exec=env GDK_BACKEND=x11 safeeyes
 Icon=safeeyes
-Version=1.2.0
+Version=1.1
 Terminal=false
 Type=Application
 Categories=Utility;


### PR DESCRIPTION
My earlier f70fd1b4f3cdc434ab41c8b7fa15d4e60d4cf329 first introduced the bug so I just owe you a pull request on that one, I guess :)

```
$ desktop-file-validate ./share/applications/safeeyes.desktop
./share/applications/safeeyes.desktop: warning: key "Encoding" in group "Desktop Entry" is deprecated
./share/applications/safeeyes.desktop: error: value "1.2.0" for key "Version" in group "Desktop Entry" is not a known version
```

Notes:
* UTF-8 encoding is required by now so the key can be dropped
* Version relates to the version of the [Desktop Entry Specification standard](https://specifications.freedesktop.org/desktop-entry-spec/1.1/) not SafeEyes