### PR TITLE
Made contributions section text more cogent, fixed grammar

### DIFF
--- a/_includes/contribute.html
+++ b/_includes/contribute.html
@@ -107,7 +107,7 @@
             </div>
             <div class="row">
                 <div class="col-lg-8 col-lg-offset-2 text-center">
-                    <p class="large text-muted">I maintain this software as one of my hobby project. I don't need any donations, but I recommend you to support open source peojects by donating atlease few dollars. If you really like Safe Eyes and want to donate, please donate to other open source projects that are in need.</p>
+                    <p class="large text-muted">I maintain this software as one of my hobby projects. I don't need any donations, but please consider donating to other open source projects that are in need instead.</p>
                     <br>
                 </div>
             </div>


### PR DESCRIPTION
I just downloaded SafeEyes and was going through [the homepage](http://slgobinath.github.io/SafeEyes/), when I noticed that the contributions section had a few grammatical and redundancy errors. I changed that section of text from:

> I maintain this software as one of my hobby project. I don't need any donations, but I recommend you to support open source peojects by donating atlease few dollars. If you really like Safe Eyes and want to donate, please donate to other open source projects that are in need.

To:

> I maintain this software as one of my hobby projects. I don't need any donations, but please consider donating to other open source projects that are in need instead.

