### PR TITLE
Show a popup notification if pyaudio is not installed

### DIFF
--- a/safeeyes/SettingsDialog.py
+++ b/safeeyes/SettingsDialog.py
@@ -86,7 +86,6 @@ class SettingsDialog:
 		self.spin_idle_time_to_pause.set_sensitive(Utility.command_exist('xprintidle'))
 
 		# Enable optional audible alert only if pyaudio is available
-		self.switch_audible_alert.set_sensitive(Utility.pyaudio is not None)
 		self.switch_audible_alert.set_active(Utility.pyaudio is not None and config['audible_alert'])
 
 		self.switch_screen_lock.set_sensitive(able_to_lock_screen)
@@ -182,11 +181,17 @@ class SettingsDialog:
 		self.config['postpone_duration'] = self.spin_postpone_duration.get_value_as_int()
 		self.config['show_time_in_tray'] = self.switch_show_time_in_tray.get_active()
 		self.config['strict_break'] = self.switch_strict_break.get_active()
-		self.config['audible_alert'] = self.switch_audible_alert.get_active()
 		self.config['language'] = self.languages[self.cmb_language.get_active()]
 		self.config['time_to_screen_lock'] = self.spin_time_to_screen_lock.get_value_as_int()
 		self.config['enable_screen_lock'] = self.switch_screen_lock.get_active()
 		self.config['allow_postpone'] = self.switch_postpone.get_active()
+	        # Check if pyaudio is installed when turning audible notifications on
+       		if self.switch_audible_alert.get_active() and not Utility.pyaudio:
+            		# Notify user that pyaudio is not installed
+            		Utility.pyaudio_popup(self, self.language)
+			self.config['audible_alert'] = False
+        	else:
+            		self.config['audible_alert'] = self.switch_audible_alert.get_active()
 
 		self.on_save_settings(self.config)	# Call the provided save method
 		self.window.destroy()	# Close the settings window

--- a/safeeyes/Utility.py
+++ b/safeeyes/Utility.py
@@ -18,7 +18,7 @@
 
 import gi
 gi.require_version('Gdk', '3.0')
-from gi.repository import Gdk, GLib
+from gi.repository import Gtk, Gdk, GLib
 from html.parser import HTMLParser
 from distutils.version import LooseVersion
 from logging.handlers import RotatingFileHandler
@@ -39,8 +39,19 @@ pyaudio = None
 try:
 	pyaudio = __import__("pyaudio")
 except ImportError:
-	pass
+	logging.warning('Install pyaudio for audible notifications.')
 
+def pyaudio_popup(parent, language):
+	"""
+	Show a popup informing user to install pyaudio.
+	"""
+	dialog = Gtk.MessageDialog(
+		parent, 0, Gtk.MessageType.WARNING, Gtk.ButtonsType.OK,
+		language['ui_controls']['pyaudio_not_installed'])
+	dialog.format_secondary_text(
+	        language['ui_controls']['pyaudio_explanation'])
+	dialog.run()
+	dialog.destroy()
 
 def play_notification():
 	"""

--- a/safeeyes/config/lang/ca.json
+++ b/safeeyes/config/lang/ca.json
@@ -43,6 +43,8 @@
         "no_of_short_breaks_between_two_long_breaks": "Nombre de pauses breus entre dues pauses llargues",
         "postpone": "Posposa",
         "postpone_duration": "Durada d'una posposició (en minuts)",
+        "pyaudio_not_installed": "Cannot enable audible notifications",
+        "pyaudio_explanation": "To enable them, install pyaudio",
         "quit": "Tanca",
         "save": "Desa",
         "settings": "Configuració",

--- a/safeeyes/config/lang/cs.json
+++ b/safeeyes/config/lang/cs.json
@@ -43,6 +43,8 @@
         "no_of_short_breaks_between_two_long_breaks": "Počet krátkých přestávek mezi dvěma dlouhými",
         "postpone": "Odložit",
         "postpone_duration": "O kolik odložit (v minutách)",
+        "pyaudio_not_installed": "Nelze zapnout zvuková upozornění",
+        "pyaudio_explanation": "Nejdříve musíte nainstalovat pyaudio",
         "quit": "Ukončit",
         "save": "Uložit",
         "settings": "Nastavení",

--- a/safeeyes/config/lang/de.json
+++ b/safeeyes/config/lang/de.json
@@ -43,6 +43,8 @@
         "no_of_short_breaks_between_two_long_breaks": "Anzahl von kleinen Pausen zwischen zwei langen Pausen",
         "postpone": "Verzögernn",
         "postpone_duration": "Verzögerungsdauer (in Minuten)",
+        "pyaudio_not_installed": "Cannot enable audible notifications",
+        "pyaudio_explanation": "To enable them, install pyaudio",
         "quit": "Schließen",
         "save": "Speichern",
         "settings": "Einstellungen",

--- a/safeeyes/config/lang/en.json
+++ b/safeeyes/config/lang/en.json
@@ -43,6 +43,8 @@
         "no_of_short_breaks_between_two_long_breaks": "Number of short breaks between two long breaks",
         "postpone": "Postpone",
         "postpone_duration": "Postpone duration (in minutes)",
+        "pyaudio_not_installed": "Cannot enable audible notifications",
+        "pyaudio_explanation": "To enable them, install pyaudio",
         "quit": "Quit",
         "save": "Save",
         "settings": "Settings",

--- a/safeeyes/config/lang/es.json
+++ b/safeeyes/config/lang/es.json
@@ -43,6 +43,8 @@
         "no_of_short_breaks_between_two_long_breaks": "Número de pausas cortas entre dos pausas largas",
         "postpone": "Posponer",
         "postpone_duration": "Duración de cada posposición (en minutos)",
+        "pyaudio_not_installed": "Cannot enable audible notifications",
+        "pyaudio_explanation": "To enable them, install pyaudio",
         "quit": "Salir",
         "save": "Guardar",
         "settings": "Preferencias",

--- a/safeeyes/config/lang/fa.json
+++ b/safeeyes/config/lang/fa.json
@@ -43,6 +43,8 @@
         "no_of_short_breaks_between_two_long_breaks": "تعداد استراحت های کوتاه بین هر دو استراحت بلند",
         "postpone": "به تعویق انداختن",
         "postpone_duration": "زمان به تعویق انداختن (به دقیقه)",
+        "pyaudio_not_installed": "Cannot enable audible notifications",
+        "pyaudio_explanation": "To enable them, install pyaudio",
         "quit": "خروج",
         "save": "ذخیره",
         "settings": "تنظیمات",

--- a/safeeyes/config/lang/fr.json
+++ b/safeeyes/config/lang/fr.json
@@ -43,6 +43,8 @@
         "no_of_short_breaks_between_two_long_breaks": "Nombre de pauses courtes entre deux pauses longues",
         "postpone": "Reporter",
         "postpone_duration": "Durée de report (en minutes)",
+        "pyaudio_not_installed": "Cannot enable audible notifications",
+        "pyaudio_explanation": "To enable them, install pyaudio",
         "quit": "Quitter",
         "save": "Enregistrer",
         "settings": "Paramètres",

--- a/safeeyes/config/lang/ge.json
+++ b/safeeyes/config/lang/ge.json
@@ -43,6 +43,8 @@
         "no_of_short_breaks_between_two_long_breaks": "მცირე შესვენებების რაოდენობა ორ დიდ შესვენებას შორის",
         "postpone": "Postpone",
         "postpone_duration": "Postpone duration (in minutes)",
+        "pyaudio_not_installed": "Cannot enable audible notifications",
+        "pyaudio_explanation": "To enable them, install pyaudio",
         "quit": "გასვლა",
         "save": "დამახსოვრება",
         "settings": "პარამეტრები",

--- a/safeeyes/config/lang/hi.json
+++ b/safeeyes/config/lang/hi.json
@@ -43,6 +43,8 @@
         "no_of_short_breaks_between_two_long_breaks": "दो बड़े आराम के बीच कितने छोटे आराम",
         "postpone": "Postpone",
         "postpone_duration": "Postpone duration (in minutes)",
+        "pyaudio_not_installed": "Cannot enable audible notifications",
+        "pyaudio_explanation": "To enable them, install pyaudio",
         "quit": "बंद",
         "save": "रखें",
         "settings": "सेटिंग्स",

--- a/safeeyes/config/lang/hu.json
+++ b/safeeyes/config/lang/hu.json
@@ -43,6 +43,8 @@
         "no_of_short_breaks_between_two_long_breaks": "Hány rövid szünet legyen a hosszabbak között?",
         "postpone": "Postpone",
         "postpone_duration": "Postpone duration (in minutes)",
+        "pyaudio_not_installed": "Cannot enable audible notifications",
+        "pyaudio_explanation": "To enable them, install pyaudio",
         "quit": "Kilépés",
         "save": "Mentés",
         "settings": "Beállítások",

--- a/safeeyes/config/lang/id.json
+++ b/safeeyes/config/lang/id.json
@@ -43,6 +43,8 @@
 			"no_of_short_breaks_between_two_long_breaks": "Jumlah istirahat singkat di antara dua istirahat panjang",
 			"postpone": "Postpone",
 			"postpone_duration": "Postpone duration (in minutes)",
+            "pyaudio_not_installed": "Cannot enable audible notifications",
+            "pyaudio_explanation": "To enable them, install pyaudio",
 			"quit": "Keluar",
 			"save": "Simpan",
 			"settings": "Pengaturan",

--- a/safeeyes/config/lang/mk.json
+++ b/safeeyes/config/lang/mk.json
@@ -43,6 +43,8 @@
         "no_of_short_breaks_between_two_long_breaks": "Број на кратки паузи помеѓу две долги",
         "postpone": "Одложи",
         "postpone_duration": "Траење на одложувањето (Во секунди)",
+        "pyaudio_not_installed": "Cannot enable audible notifications",
+        "pyaudio_explanation": "To enable them, install pyaudio",
         "quit": "Исклучи",
         "save": "Зачувај",
         "settings": "Подесувања",

--- a/safeeyes/config/lang/pl.json
+++ b/safeeyes/config/lang/pl.json
@@ -43,6 +43,8 @@
         "no_of_short_breaks_between_two_long_breaks": "Liczba krótkich przerw między długimi przerwami",
         "postpone": "Odrocz",
         "postpone_duration": "Odroczenie przerwy (w minutach)",
+        "pyaudio_not_installed": "Cannot enable audible notifications",
+        "pyaudio_explanation": "To enable them, install pyaudio",
         "quit": "Wyjdź",
         "save": "Zapisz",
         "settings": "Ustawienia",

--- a/safeeyes/config/lang/pt.json
+++ b/safeeyes/config/lang/pt.json
@@ -43,6 +43,8 @@
         "no_of_short_breaks_between_two_long_breaks": "Número de pausas curtas entre duas pausas longas",
         "postpone": "Adiar",
         "postpone_duration": "Duração do adiamento (em minutos)",
+        "pyaudio_not_installed": "Cannot enable audible notifications",
+        "pyaudio_explanation": "To enable them, install pyaudio",
         "quit": "Sair",
         "save": "Salvar",
         "settings": "Configuração",

--- a/safeeyes/config/lang/ru.json
+++ b/safeeyes/config/lang/ru.json
@@ -43,6 +43,8 @@
         "no_of_short_breaks_between_two_long_breaks": "Количество коротких перерывов между двумя длинными",
         "postpone": "Отложить",
         "postpone_duration": "Отложить на время (в минутах)",
+        "pyaudio_not_installed": "Cannot enable audible notifications",
+        "pyaudio_explanation": "To enable them, install pyaudio",
         "quit": "Выйти",
         "save": "Сохранить",
         "settings": "Настройки",

--- a/safeeyes/config/lang/sk.json
+++ b/safeeyes/config/lang/sk.json
@@ -43,6 +43,8 @@
         "no_of_short_breaks_between_two_long_breaks": "Počet krátkych prestávok medzi dvomi dlhými prestávkami",
         "postpone": "Odložiť",
         "postpone_duration": "O koĺko odložiť (minút)",
+        "pyaudio_not_installed": "Nieje možné zapnúť zvukové upozornenie",
+        "pyaudio_explanation": "Pro ích povolenie nainstalujte pyaudio",
         "quit": "Koniec",
         "save": "Uložiť",
         "settings": "Nastavenia",

--- a/safeeyes/config/lang/ta.json
+++ b/safeeyes/config/lang/ta.json
@@ -43,6 +43,8 @@
         "no_of_short_breaks_between_two_long_breaks": "இரண்டு நீண்ட இடைவேளைகளுக்கிடையிலான குறுகிய இடைவேளைகள்",
         "postpone": "ஒத்தி வை",
         "postpone_duration": "இடைவேளையை ஒத்தி வைக்கும் காலம் (நிமிடங்களில்)",
+        "pyaudio_not_installed": "Cannot enable audible notifications",
+        "pyaudio_explanation": "To enable them, install pyaudio",
         "quit": "நிறுத்து",
         "save": "சேமி",
         "settings": "அமைப்பு",

--- a/safeeyes/config/lang/tr.json
+++ b/safeeyes/config/lang/tr.json
@@ -43,6 +43,8 @@
         "no_of_short_breaks_between_two_long_breaks": "İki uzun mola arasındaki kısa mola sayısı",
         "postpone": "Ertele",
         "postpone_duration": "Ertelme süresi (dakika)",
+        "pyaudio_not_installed": "Cannot enable audible notifications",
+        "pyaudio_explanation": "To enable them, install pyaudio",
         "quit": "Çıkış",
         "save": "Kaydet",
         "settings": "Ayarlar",

--- a/safeeyes/config/lang/uk.json
+++ b/safeeyes/config/lang/uk.json
@@ -43,6 +43,8 @@
         "no_of_short_breaks_between_two_long_breaks": "Кількість коротких перерв між двома довгими",
         "postpone": "Відкласти",
         "postpone_duration": "На скільки відкласти (в хвилинах)",
+        "pyaudio_not_installed": "Cannot enable audible notifications",
+        "pyaudio_explanation": "To enable them, install pyaudio",
         "quit": "Вийти",
         "save": "Зберегти",
         "settings": "Налаштування",

--- a/safeeyes/config/lang/vi.json
+++ b/safeeyes/config/lang/vi.json
@@ -48,6 +48,8 @@
         "no_of_short_breaks_between_two_long_breaks": "Số lần nghỉ ngơi ngắn giữa hai lần nghỉ ngơi dài",
         "postpone": "Tạm hoãn",
         "postpone_duration": "Thời gian tạm hoãn (tính bằng phút)",
+        "pyaudio_not_installed": "Cannot enable audible notifications",
+        "pyaudio_explanation": "To enable them, install pyaudio",
         "quit": "Thoát",
         "save": "Lưu",
         "settings": "Cài đặt",


### PR DESCRIPTION
Instead of just making the audible alerts setting unclickable, show a popup informing the user they need to install pyaudio.