### PR TITLE
Replace all instances of safeyes with safeeyes in the docs.

### DIFF
--- a/_includes/services.html
+++ b/_includes/services.html
@@ -37,7 +37,7 @@
                     </span>
                     <h4 class="service-heading">Debian</h4>
                     <p class="text-muted">Install the following dependencies:</p><pre align="left"><code align="left">gir1.2-appindicator3-0.1 gir1.2-notify-0.7  python3-pyaudio python3-psutil python3-xlib xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <pre align="left"><code align="left">sudo update-icon-caches /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
                 </div>
@@ -49,7 +49,7 @@
                     <h4 class="service-heading">Fedora</h4>
                     <p class="text-muted">Install the dependencies:</p><pre align="left"><code align="left">sudo dnf install libappindicator-gtk3 python3-pyaudio python3-psutil</code></pre>
                     <p class="text-muted">Install <code>xprintidle</code> manually (Available for Fedora 24)</p>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <p class="text-muted">Update the icon cache</p>
                     <pre align="left"><code align="left">sudo gtk-update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">env GDK_BACKEND=x11 safeeyes</code></pre>
@@ -62,7 +62,7 @@
                     <h4 class="service-heading">Arch Linux Manual</h4>
                     <p class="text-muted">Install the dependencies:</p><pre align="left"><code align="left">sudo pacman -S python-pip libappindicator-gtk3</code></pre>
                     <pre align="left"><code align="left">yaourt -S xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <p class="text-muted">Update the icon cache</p>
                     <pre align="left"><code align="left">sudo gtk-update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
@@ -84,7 +84,7 @@
                     </span>
                     <h4 class="service-heading">Others</h4>
                     <p class="text-muted">Install the following dependencies:</p><pre align="left"><code align="left">gir1.2-appindicator3-0.1 gir1.2-notify-0.7 python3-babel python3-dbus python3-psutil python3-pyaudio python3-xlib xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <pre align="left"><code align="left">sudo update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
                 </div> -->

--- a/_posts/2014-07-09-project-10.markdown
+++ b/_posts/2014-07-09-project-10.markdown
@@ -8,7 +8,7 @@ modal-url: safeeyes-plugins
 thumbnail: safeeyes-plugins-thumbnail.png
 alt: image-alt
 description: Running Safe Eyes in your computer requires some resources including memory and proecessor. Utilize them by extending Safe Eyes for some other tasks. What kind of tasks is totally dependning on your creativity. However, do not forget that Safe Eyes is not a fancy timer; it is a break reminder to take care of your health. Follow the steps to create a minimal todo plugin.
-steps: ['Create a new directory <code>plugins</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/plugins</code></pre>',
+steps: ['Create a new directory <code>plugins</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/plugins</code></pre>',
 		'Create a new file <code>todo.py</code> in <code>~/.config/safeeyes/plugins</code> with the following content:<pre><code>"""<br>
 		Safe Eyes todo plugin<br>
 		"""<br>

--- a/_posts/2014-07-10-project-9.markdown
+++ b/_posts/2014-07-10-project-9.markdown
@@ -8,7 +8,7 @@ modal-url: lock-screen
 thumbnail: lock-screen-thumbnail.png
 alt: image-alt
 description: To lock the screen after long breaks, Safe Eyes uses the default screen saver commands based on the system desktop environment. If you use a different lock screen than the default one or if your desktop environment is not suported by Safe Eyes, define your own lock screen command and leave the computer with no worries.
-steps: ['Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre>',
+steps: ['Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre>',
 		'Add the lock screen command as an array. For example, if you use gnome screen saver add the command like this: <pre><code>...<br>
 		"lock_screen_command": ["gnome-screensaver-command", "--lock"]<br>
 		...</code></pre><b>NOTE:</b> If Safe Eyes cannot guess the default screen saver of your system, the option will be inactive in the Settings. You can enable it by defining the lock screen command as above.<br>Also remember that some applications(Example: a virtual operating system running in virtual box) can prevent the the screensaver from locking the screen (This is not the fault of Safe Eyes).',

--- a/_posts/2014-07-11-project-8.markdown
+++ b/_posts/2014-07-11-project-8.markdown
@@ -8,7 +8,7 @@ modal-url: override-fullscreen
 thumbnail: override-fullscreen-thumbnail.png
 alt: image-alt
 description: By default, Safe Eyes does not show the break screen if the current window is in fullscreen mode. You can override this feature by specifying the <b>window-class</b> of the interested applications.
-steps: ['Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre>',
+steps: ['Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre>',
 		'Add <code>vlc</code> to <code>skip_break</code> array and <code>google-chrome</code> to <code>take_break</code> array to skip breaks if VLC is the active window either in fullscreen mode or not and to take break if Google Chrome is the active window without considering the window mode: <pre><code>...<br>
 		"active_window_class": {<br>
 		&nbsp;&nbsp;&nbsp;&nbsp;"skip_break": ["vlc"],<br>

--- a/_posts/2014-07-12-project-7.markdown
+++ b/_posts/2014-07-12-project-7.markdown
@@ -8,7 +8,7 @@ modal-url: disable-time
 thumbnail: disable-time-thumbnail.png
 alt: image-alt
 description: The default disable for a given time options provide <code>30 minutes</code>, <code>1 hour</code>, <code>2 hours</code> and <code>3 hours</code> only. If you want to customize them or if you want to add/remove time based disable option, you can configure them in the <code>safeeyes.json</code> file. To add an additional Disable for 45 minutes, modify the configuration as shown below.
-steps: ['Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre>',
+steps: ['Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre>',
 		'Add a new object to the <code>disable_options</code> object: <pre><code>...<br>
 		"disable_options": [<br>
 		&nbsp;&nbsp;&nbsp;&nbsp;{<br>

--- a/_posts/2014-07-14-project-5.markdown
+++ b/_posts/2014-07-14-project-5.markdown
@@ -8,8 +8,8 @@ modal-url: override-audio
 thumbnail: override-audio-thumbnail.png
 alt: image-alt
 description: Don't you like the default bell sound? Play your favorite song at the end of each break.
-steps: ['Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre>',
-		'Copy the new audio file <code>alert.wav</code> in the resource directory:<pre><code>cp my_audio.wav ~/.config/safeyes/resource/alert.wav</code></pre>'
+steps: ['Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre>',
+		'Copy the new audio file <code>alert.wav</code> in the resource directory:<pre><code>cp my_audio.wav ~/.config/safeeyes/resource/alert.wav</code></pre>'
 	]
 
 ---

--- a/_posts/2014-07-15-project-4.markdown
+++ b/_posts/2014-07-15-project-4.markdown
@@ -8,8 +8,8 @@ modal-url: override-image
 thumbnail: override-image-thumbnail.png
 alt: image-alt
 description: You can add image to the break screen by creating a new image in the resource directory. Make sure that the new image size is within <code>128x128px</code>
-steps: ['Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre>',
-		'Copy a new image to the resource directory:<pre><code>cp image.png ~/.config/safeyes/resource/short_break_close_eyes.png</code></pre>',
+steps: ['Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre>',
+		'Copy a new image to the resource directory:<pre><code>cp image.png ~/.config/safeeyes/resource/short_break_close_eyes.png</code></pre>',
 		'Create a new property <code>image</code> next to the break name : <pre><code>...<br>
 		"short_breaks": [<br>
 		&nbsp;&nbsp;&nbsp;&nbsp;{<br>

--- a/_posts/2014-07-16-project-3.markdown
+++ b/_posts/2014-07-16-project-3.markdown
@@ -8,7 +8,7 @@ modal-url: override-alert
 thumbnail: override-alert-thumbnail.png
 alt: image-alt
 description: Audible alert at the end of all the breaks may not make sense. You can enable or disable audible alert for selected breaks only.
-steps: ['Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre>',
+steps: ['Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre>',
 		'Add the <code>audible_alert</code> property with either<code>true</code> or <code>false</code> value to the desired breaks to override the default option: <pre><code>...<br>
 		"audible_alert": false,<br>
 		"short_breaks": [<br>

--- a/_posts/2014-07-17-project-2.markdown
+++ b/_posts/2014-07-17-project-2.markdown
@@ -8,7 +8,7 @@ modal-url: override-time
 thumbnail: override-time-thumbnail.png
 alt: image-alt
 description: The short and long break times in Settings dialog are common for all the breaks. However, as a user you have the freedom to override the individual break time.
-steps: ['Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre>',
+steps: ['Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre>',
 		'Add <code>time</code> in <b>seconds</b> to the desired breaks to override their default duration: <pre><code>...<br>
 		"short_breaks": [<br>
 		&nbsp;&nbsp;&nbsp;&nbsp;{<br>

--- a/_posts/2014-07-18-project-1.markdown
+++ b/_posts/2014-07-18-project-1.markdown
@@ -8,9 +8,9 @@ modal-url: custom-exercise
 thumbnail: custom-exercise-thumbnail.png
 alt: image-alt
 description: We're not going to pretend that the built-in list of exercises will be enough for everybody. So you can add your own! Break images are optional but if you use any image, make sure that the image size is within <code>128x128px</code>.
-steps: ['Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre>',
-		'Copy the break image to the resource directory:<pre><code>cp deep_breath.png ~/.config/safeyes/resource/deep_breath.png</code></pre>',
-		'Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre>',
+steps: ['Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre>',
+		'Copy the break image to the resource directory:<pre><code>cp deep_breath.png ~/.config/safeeyes/resource/deep_breath.png</code></pre>',
+		'Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre>',
 		'Modify the <code>custom_exercises</code> property (which is an empty object by default) like so: <pre><code>...<br>
 		"custom_exercises": {<br>
 		&nbsp;&nbsp;&nbsp;&nbsp;"deep_breath": "Take a deep breath",<br>

--- a/_site/2014/07/08/project-11/index.html
+++ b/_site/2014/07/08/project-11/index.html
@@ -138,7 +138,7 @@
                     </span>
                     <h4 class="service-heading">Debian</h4>
                     <p class="text-muted">Install the following dependencies:</p><pre align="left"><code align="left">gir1.2-appindicator3-0.1 gir1.2-notify-0.7  python3-pyaudio python3-psutil python3-xlib xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <pre align="left"><code align="left">sudo update-icon-caches /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
                 </div>
@@ -150,7 +150,7 @@
                     <h4 class="service-heading">Fedora</h4>
                     <p class="text-muted">Install the dependencies:</p><pre align="left"><code align="left">sudo dnf install libappindicator-gtk3 python3-pyaudio python3-psutil</code></pre>
                     <p class="text-muted">Install <code>xprintidle</code> manually (Available for Fedora 24)</p>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <p class="text-muted">Update the icon cache</p>
                     <pre align="left"><code align="left">sudo gtk-update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">env GDK_BACKEND=x11 safeeyes</code></pre>
@@ -163,7 +163,7 @@
                     <h4 class="service-heading">Arch Linux Manual</h4>
                     <p class="text-muted">Install the dependencies:</p><pre align="left"><code align="left">sudo pacman -S python-pip libappindicator-gtk3</code></pre>
                     <pre align="left"><code align="left">yaourt -S xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <p class="text-muted">Update the icon cache</p>
                     <pre align="left"><code align="left">sudo gtk-update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
@@ -185,7 +185,7 @@
                     </span>
                     <h4 class="service-heading">Others</h4>
                     <p class="text-muted">Install the following dependencies:</p><pre align="left"><code align="left">gir1.2-appindicator3-0.1 gir1.2-notify-0.7 python3-babel python3-dbus python3-psutil python3-pyaudio python3-xlib xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <pre align="left"><code align="left">sudo update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
                 </div> -->
@@ -764,11 +764,11 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy the break image to the resource directory:<pre><code>cp deep_breath.png ~/.config/safeyes/resource/deep_breath.png</code></pre></li>
+                                <li align="left">Copy the break image to the resource directory:<pre><code>cp deep_breath.png ~/.config/safeeyes/resource/deep_breath.png</code></pre></li>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Modify the <code>custom_exercises</code> property (which is an empty object by default) like so: <pre><code>...<br> "custom_exercises": {<br> &nbsp;&nbsp;&nbsp;&nbsp;"deep_breath": "Take a deep breath",<br> &nbsp;&nbsp;&nbsp;&nbsp;"pushups": "Do ten push-ups",<br> &nbsp;&nbsp;&nbsp;&nbsp;"other": "Other small things you should do on a regular basis"<br> }<br> ...</code></pre></li>
                             
@@ -807,7 +807,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add <code>time</code> in <b>seconds</b> to the desired breaks to override their default duration: <pre><code>...<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 30<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_roll_eyes"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...<br> "long_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "long_break_walk",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 300<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "long_break_lean_back"<br> &nbsp;&nbsp;&nbsp;&nbsp;}<br> ]<br> ...</code></pre></li>
                             
@@ -844,7 +844,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add the <code>audible_alert</code> property with either<code>true</code> or <code>false</code> value to the desired breaks to override the default option: <pre><code>...<br> "audible_alert": false,<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"audible_alert": true,<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_roll_eyes"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...</code></pre></li>
                             
@@ -881,9 +881,9 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy a new image to the resource directory:<pre><code>cp image.png ~/.config/safeyes/resource/short_break_close_eyes.png</code></pre></li>
+                                <li align="left">Copy a new image to the resource directory:<pre><code>cp image.png ~/.config/safeeyes/resource/short_break_close_eyes.png</code></pre></li>
                             
                                 <li align="left">Create a new property <code>image</code> next to the break name : <pre><code>...<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"image": "short_break_close_eyes.png"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...</code></pre></li>
                             
@@ -918,9 +918,9 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy the new audio file <code>alert.wav</code> in the resource directory:<pre><code>cp my_audio.wav ~/.config/safeyes/resource/alert.wav</code></pre></li>
+                                <li align="left">Copy the new audio file <code>alert.wav</code> in the resource directory:<pre><code>cp my_audio.wav ~/.config/safeeyes/resource/alert.wav</code></pre></li>
                             
                             </ol>
                             </p>
@@ -988,7 +988,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add a new object to the <code>disable_options</code> object: <pre><code>...<br> "disable_options": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_minutes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 30,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "minute"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_minutes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 45,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "minute"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_hour",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 1,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "hour"<br> &nbsp;&nbsp;&nbsp;&nbsp;}<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ]<br> ...</code></pre> The <code>unit</code> can be one of these case-insensitive constants: <code>second</code>, <code>seconds</code>, <code>minute</code>, <code>minutes</code>, <code>hour</code>, <code>hours</code></li>
                             
@@ -1025,7 +1025,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add <code>vlc</code> to <code>skip_break</code> array and <code>google-chrome</code> to <code>take_break</code> array to skip breaks if VLC is the active window either in fullscreen mode or not and to take break if Google Chrome is the active window without considering the window mode: <pre><code>...<br> "active_window_class": {<br> &nbsp;&nbsp;&nbsp;&nbsp;"skip_break": ["vlc"],<br> &nbsp;&nbsp;&nbsp;&nbsp;"take_break": ["google-chrome"]<br> },<br> ...</code></pre>The names <code>vlc</code> and <code>google-chrome</code> are not the application names but their window classes. Inorder to get the window class of an application, enter the following command in your terminal and click on the desired application. In the printed <code>WM_CLASS</code>, choose the second one.<pre><code>xprop WM_CLASS</code></pre></li>
                             
@@ -1062,7 +1062,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add the lock screen command as an array. For example, if you use gnome screen saver add the command like this: <pre><code>...<br> "lock_screen_command": ["gnome-screensaver-command", "--lock"]<br> ...</code></pre><b>NOTE:</b> If Safe Eyes cannot guess the default screen saver of your system, the option will be inactive in the Settings. You can enable it by defining the lock screen command as above.<br>Also remember that some applications(Example: a virtual operating system running in virtual box) can prevent the the screensaver from locking the screen (This is not the fault of Safe Eyes).</li>
                             
@@ -1099,7 +1099,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>plugins</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/plugins</code></pre></li>
+                                <li align="left">Create a new directory <code>plugins</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/plugins</code></pre></li>
                             
                                 <li align="left">Create a new file <code>todo.py</code> in <code>~/.config/safeeyes/plugins</code> with the following content:<pre><code>"""<br> Safe Eyes todo plugin<br> """<br> <br> def start(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on startup.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def pre_notification(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything before ntification.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def pre_break(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on before the break.<br> &nbsp;&nbsp;&nbsp;&nbsp;Optionally you can return a Pango markup content to be displayed<br> &nbsp;&nbsp;&nbsp;&nbsp;on the break screen. For more details about Pango: <br> &nbsp;&nbsp;&nbsp;&nbsp;https://developer.gnome.org/pygtk/stable/pango-markup-language.html<br> &nbsp;&nbsp;&nbsp;&nbsp;NOTE: This function should return the result within a second<br> &nbsp;&nbsp;&nbsp;&nbsp;The content can have several lines, but line length must not exceed<br> &nbsp;&nbsp;&nbsp;&nbsp;50 characters. If there is a line with more than 50 characters,<br> &nbsp;&nbsp;&nbsp;&nbsp;the entire data will be ignored by Safe Eyes.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;todo_list = """- Share Safe Eyes with friends<br> - Upvote Safe Eyes in alternativet.net"""<br> &nbsp;&nbsp;&nbsp;&nbsp;return "&#60;span color=&#39;white&#39;&#62;" + todo_list + "&#60;/span&#62;"<br> <br> def post_break(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;# Do nothing after the notification<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def exit(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on exit.<br> &nbsp;&nbsp;&nbsp;&nbsp;NOTE: This function should exit within a second<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass</code></pre></li>
                             

--- a/_site/2014/07/09/project-10/index.html
+++ b/_site/2014/07/09/project-10/index.html
@@ -138,7 +138,7 @@
                     </span>
                     <h4 class="service-heading">Debian</h4>
                     <p class="text-muted">Install the following dependencies:</p><pre align="left"><code align="left">gir1.2-appindicator3-0.1 gir1.2-notify-0.7  python3-pyaudio python3-psutil python3-xlib xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <pre align="left"><code align="left">sudo update-icon-caches /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
                 </div>
@@ -150,7 +150,7 @@
                     <h4 class="service-heading">Fedora</h4>
                     <p class="text-muted">Install the dependencies:</p><pre align="left"><code align="left">sudo dnf install libappindicator-gtk3 python3-pyaudio python3-psutil</code></pre>
                     <p class="text-muted">Install <code>xprintidle</code> manually (Available for Fedora 24)</p>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <p class="text-muted">Update the icon cache</p>
                     <pre align="left"><code align="left">sudo gtk-update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">env GDK_BACKEND=x11 safeeyes</code></pre>
@@ -163,7 +163,7 @@
                     <h4 class="service-heading">Arch Linux Manual</h4>
                     <p class="text-muted">Install the dependencies:</p><pre align="left"><code align="left">sudo pacman -S python-pip libappindicator-gtk3</code></pre>
                     <pre align="left"><code align="left">yaourt -S xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <p class="text-muted">Update the icon cache</p>
                     <pre align="left"><code align="left">sudo gtk-update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
@@ -185,7 +185,7 @@
                     </span>
                     <h4 class="service-heading">Others</h4>
                     <p class="text-muted">Install the following dependencies:</p><pre align="left"><code align="left">gir1.2-appindicator3-0.1 gir1.2-notify-0.7 python3-babel python3-dbus python3-psutil python3-pyaudio python3-xlib xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <pre align="left"><code align="left">sudo update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
                 </div> -->
@@ -764,11 +764,11 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy the break image to the resource directory:<pre><code>cp deep_breath.png ~/.config/safeyes/resource/deep_breath.png</code></pre></li>
+                                <li align="left">Copy the break image to the resource directory:<pre><code>cp deep_breath.png ~/.config/safeeyes/resource/deep_breath.png</code></pre></li>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Modify the <code>custom_exercises</code> property (which is an empty object by default) like so: <pre><code>...<br> "custom_exercises": {<br> &nbsp;&nbsp;&nbsp;&nbsp;"deep_breath": "Take a deep breath",<br> &nbsp;&nbsp;&nbsp;&nbsp;"pushups": "Do ten push-ups",<br> &nbsp;&nbsp;&nbsp;&nbsp;"other": "Other small things you should do on a regular basis"<br> }<br> ...</code></pre></li>
                             
@@ -807,7 +807,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add <code>time</code> in <b>seconds</b> to the desired breaks to override their default duration: <pre><code>...<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 30<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_roll_eyes"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...<br> "long_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "long_break_walk",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 300<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "long_break_lean_back"<br> &nbsp;&nbsp;&nbsp;&nbsp;}<br> ]<br> ...</code></pre></li>
                             
@@ -844,7 +844,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add the <code>audible_alert</code> property with either<code>true</code> or <code>false</code> value to the desired breaks to override the default option: <pre><code>...<br> "audible_alert": false,<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"audible_alert": true,<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_roll_eyes"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...</code></pre></li>
                             
@@ -881,9 +881,9 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy a new image to the resource directory:<pre><code>cp image.png ~/.config/safeyes/resource/short_break_close_eyes.png</code></pre></li>
+                                <li align="left">Copy a new image to the resource directory:<pre><code>cp image.png ~/.config/safeeyes/resource/short_break_close_eyes.png</code></pre></li>
                             
                                 <li align="left">Create a new property <code>image</code> next to the break name : <pre><code>...<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"image": "short_break_close_eyes.png"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...</code></pre></li>
                             
@@ -918,9 +918,9 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy the new audio file <code>alert.wav</code> in the resource directory:<pre><code>cp my_audio.wav ~/.config/safeyes/resource/alert.wav</code></pre></li>
+                                <li align="left">Copy the new audio file <code>alert.wav</code> in the resource directory:<pre><code>cp my_audio.wav ~/.config/safeeyes/resource/alert.wav</code></pre></li>
                             
                             </ol>
                             </p>
@@ -988,7 +988,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add a new object to the <code>disable_options</code> object: <pre><code>...<br> "disable_options": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_minutes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 30,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "minute"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_minutes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 45,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "minute"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_hour",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 1,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "hour"<br> &nbsp;&nbsp;&nbsp;&nbsp;}<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ]<br> ...</code></pre> The <code>unit</code> can be one of these case-insensitive constants: <code>second</code>, <code>seconds</code>, <code>minute</code>, <code>minutes</code>, <code>hour</code>, <code>hours</code></li>
                             
@@ -1025,7 +1025,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add <code>vlc</code> to <code>skip_break</code> array and <code>google-chrome</code> to <code>take_break</code> array to skip breaks if VLC is the active window either in fullscreen mode or not and to take break if Google Chrome is the active window without considering the window mode: <pre><code>...<br> "active_window_class": {<br> &nbsp;&nbsp;&nbsp;&nbsp;"skip_break": ["vlc"],<br> &nbsp;&nbsp;&nbsp;&nbsp;"take_break": ["google-chrome"]<br> },<br> ...</code></pre>The names <code>vlc</code> and <code>google-chrome</code> are not the application names but their window classes. Inorder to get the window class of an application, enter the following command in your terminal and click on the desired application. In the printed <code>WM_CLASS</code>, choose the second one.<pre><code>xprop WM_CLASS</code></pre></li>
                             
@@ -1062,7 +1062,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add the lock screen command as an array. For example, if you use gnome screen saver add the command like this: <pre><code>...<br> "lock_screen_command": ["gnome-screensaver-command", "--lock"]<br> ...</code></pre><b>NOTE:</b> If Safe Eyes cannot guess the default screen saver of your system, the option will be inactive in the Settings. You can enable it by defining the lock screen command as above.<br>Also remember that some applications(Example: a virtual operating system running in virtual box) can prevent the the screensaver from locking the screen (This is not the fault of Safe Eyes).</li>
                             
@@ -1099,7 +1099,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>plugins</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/plugins</code></pre></li>
+                                <li align="left">Create a new directory <code>plugins</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/plugins</code></pre></li>
                             
                                 <li align="left">Create a new file <code>todo.py</code> in <code>~/.config/safeeyes/plugins</code> with the following content:<pre><code>"""<br> Safe Eyes todo plugin<br> """<br> <br> def start(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on startup.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def pre_notification(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything before ntification.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def pre_break(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on before the break.<br> &nbsp;&nbsp;&nbsp;&nbsp;Optionally you can return a Pango markup content to be displayed<br> &nbsp;&nbsp;&nbsp;&nbsp;on the break screen. For more details about Pango: <br> &nbsp;&nbsp;&nbsp;&nbsp;https://developer.gnome.org/pygtk/stable/pango-markup-language.html<br> &nbsp;&nbsp;&nbsp;&nbsp;NOTE: This function should return the result within a second<br> &nbsp;&nbsp;&nbsp;&nbsp;The content can have several lines, but line length must not exceed<br> &nbsp;&nbsp;&nbsp;&nbsp;50 characters. If there is a line with more than 50 characters,<br> &nbsp;&nbsp;&nbsp;&nbsp;the entire data will be ignored by Safe Eyes.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;todo_list = """- Share Safe Eyes with friends<br> - Upvote Safe Eyes in alternativet.net"""<br> &nbsp;&nbsp;&nbsp;&nbsp;return "&#60;span color=&#39;white&#39;&#62;" + todo_list + "&#60;/span&#62;"<br> <br> def post_break(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;# Do nothing after the notification<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def exit(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on exit.<br> &nbsp;&nbsp;&nbsp;&nbsp;NOTE: This function should exit within a second<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass</code></pre></li>
                             

--- a/_site/2014/07/10/project-9/index.html
+++ b/_site/2014/07/10/project-9/index.html
@@ -138,7 +138,7 @@
                     </span>
                     <h4 class="service-heading">Debian</h4>
                     <p class="text-muted">Install the following dependencies:</p><pre align="left"><code align="left">gir1.2-appindicator3-0.1 gir1.2-notify-0.7  python3-pyaudio python3-psutil python3-xlib xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <pre align="left"><code align="left">sudo update-icon-caches /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
                 </div>
@@ -150,7 +150,7 @@
                     <h4 class="service-heading">Fedora</h4>
                     <p class="text-muted">Install the dependencies:</p><pre align="left"><code align="left">sudo dnf install libappindicator-gtk3 python3-pyaudio python3-psutil</code></pre>
                     <p class="text-muted">Install <code>xprintidle</code> manually (Available for Fedora 24)</p>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <p class="text-muted">Update the icon cache</p>
                     <pre align="left"><code align="left">sudo gtk-update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">env GDK_BACKEND=x11 safeeyes</code></pre>
@@ -163,7 +163,7 @@
                     <h4 class="service-heading">Arch Linux Manual</h4>
                     <p class="text-muted">Install the dependencies:</p><pre align="left"><code align="left">sudo pacman -S python-pip libappindicator-gtk3</code></pre>
                     <pre align="left"><code align="left">yaourt -S xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <p class="text-muted">Update the icon cache</p>
                     <pre align="left"><code align="left">sudo gtk-update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
@@ -185,7 +185,7 @@
                     </span>
                     <h4 class="service-heading">Others</h4>
                     <p class="text-muted">Install the following dependencies:</p><pre align="left"><code align="left">gir1.2-appindicator3-0.1 gir1.2-notify-0.7 python3-babel python3-dbus python3-psutil python3-pyaudio python3-xlib xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <pre align="left"><code align="left">sudo update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
                 </div> -->
@@ -764,11 +764,11 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy the break image to the resource directory:<pre><code>cp deep_breath.png ~/.config/safeyes/resource/deep_breath.png</code></pre></li>
+                                <li align="left">Copy the break image to the resource directory:<pre><code>cp deep_breath.png ~/.config/safeeyes/resource/deep_breath.png</code></pre></li>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Modify the <code>custom_exercises</code> property (which is an empty object by default) like so: <pre><code>...<br> "custom_exercises": {<br> &nbsp;&nbsp;&nbsp;&nbsp;"deep_breath": "Take a deep breath",<br> &nbsp;&nbsp;&nbsp;&nbsp;"pushups": "Do ten push-ups",<br> &nbsp;&nbsp;&nbsp;&nbsp;"other": "Other small things you should do on a regular basis"<br> }<br> ...</code></pre></li>
                             
@@ -807,7 +807,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add <code>time</code> in <b>seconds</b> to the desired breaks to override their default duration: <pre><code>...<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 30<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_roll_eyes"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...<br> "long_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "long_break_walk",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 300<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "long_break_lean_back"<br> &nbsp;&nbsp;&nbsp;&nbsp;}<br> ]<br> ...</code></pre></li>
                             
@@ -844,7 +844,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add the <code>audible_alert</code> property with either<code>true</code> or <code>false</code> value to the desired breaks to override the default option: <pre><code>...<br> "audible_alert": false,<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"audible_alert": true,<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_roll_eyes"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...</code></pre></li>
                             
@@ -881,9 +881,9 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy a new image to the resource directory:<pre><code>cp image.png ~/.config/safeyes/resource/short_break_close_eyes.png</code></pre></li>
+                                <li align="left">Copy a new image to the resource directory:<pre><code>cp image.png ~/.config/safeeyes/resource/short_break_close_eyes.png</code></pre></li>
                             
                                 <li align="left">Create a new property <code>image</code> next to the break name : <pre><code>...<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"image": "short_break_close_eyes.png"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...</code></pre></li>
                             
@@ -918,9 +918,9 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy the new audio file <code>alert.wav</code> in the resource directory:<pre><code>cp my_audio.wav ~/.config/safeyes/resource/alert.wav</code></pre></li>
+                                <li align="left">Copy the new audio file <code>alert.wav</code> in the resource directory:<pre><code>cp my_audio.wav ~/.config/safeeyes/resource/alert.wav</code></pre></li>
                             
                             </ol>
                             </p>
@@ -988,7 +988,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add a new object to the <code>disable_options</code> object: <pre><code>...<br> "disable_options": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_minutes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 30,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "minute"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_minutes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 45,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "minute"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_hour",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 1,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "hour"<br> &nbsp;&nbsp;&nbsp;&nbsp;}<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ]<br> ...</code></pre> The <code>unit</code> can be one of these case-insensitive constants: <code>second</code>, <code>seconds</code>, <code>minute</code>, <code>minutes</code>, <code>hour</code>, <code>hours</code></li>
                             
@@ -1025,7 +1025,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add <code>vlc</code> to <code>skip_break</code> array and <code>google-chrome</code> to <code>take_break</code> array to skip breaks if VLC is the active window either in fullscreen mode or not and to take break if Google Chrome is the active window without considering the window mode: <pre><code>...<br> "active_window_class": {<br> &nbsp;&nbsp;&nbsp;&nbsp;"skip_break": ["vlc"],<br> &nbsp;&nbsp;&nbsp;&nbsp;"take_break": ["google-chrome"]<br> },<br> ...</code></pre>The names <code>vlc</code> and <code>google-chrome</code> are not the application names but their window classes. Inorder to get the window class of an application, enter the following command in your terminal and click on the desired application. In the printed <code>WM_CLASS</code>, choose the second one.<pre><code>xprop WM_CLASS</code></pre></li>
                             
@@ -1062,7 +1062,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add the lock screen command as an array. For example, if you use gnome screen saver add the command like this: <pre><code>...<br> "lock_screen_command": ["gnome-screensaver-command", "--lock"]<br> ...</code></pre><b>NOTE:</b> If Safe Eyes cannot guess the default screen saver of your system, the option will be inactive in the Settings. You can enable it by defining the lock screen command as above.<br>Also remember that some applications(Example: a virtual operating system running in virtual box) can prevent the the screensaver from locking the screen (This is not the fault of Safe Eyes).</li>
                             
@@ -1099,7 +1099,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>plugins</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/plugins</code></pre></li>
+                                <li align="left">Create a new directory <code>plugins</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/plugins</code></pre></li>
                             
                                 <li align="left">Create a new file <code>todo.py</code> in <code>~/.config/safeeyes/plugins</code> with the following content:<pre><code>"""<br> Safe Eyes todo plugin<br> """<br> <br> def start(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on startup.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def pre_notification(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything before ntification.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def pre_break(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on before the break.<br> &nbsp;&nbsp;&nbsp;&nbsp;Optionally you can return a Pango markup content to be displayed<br> &nbsp;&nbsp;&nbsp;&nbsp;on the break screen. For more details about Pango: <br> &nbsp;&nbsp;&nbsp;&nbsp;https://developer.gnome.org/pygtk/stable/pango-markup-language.html<br> &nbsp;&nbsp;&nbsp;&nbsp;NOTE: This function should return the result within a second<br> &nbsp;&nbsp;&nbsp;&nbsp;The content can have several lines, but line length must not exceed<br> &nbsp;&nbsp;&nbsp;&nbsp;50 characters. If there is a line with more than 50 characters,<br> &nbsp;&nbsp;&nbsp;&nbsp;the entire data will be ignored by Safe Eyes.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;todo_list = """- Share Safe Eyes with friends<br> - Upvote Safe Eyes in alternativet.net"""<br> &nbsp;&nbsp;&nbsp;&nbsp;return "&#60;span color=&#39;white&#39;&#62;" + todo_list + "&#60;/span&#62;"<br> <br> def post_break(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;# Do nothing after the notification<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def exit(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on exit.<br> &nbsp;&nbsp;&nbsp;&nbsp;NOTE: This function should exit within a second<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass</code></pre></li>
                             

--- a/_site/2014/07/11/project-8/index.html
+++ b/_site/2014/07/11/project-8/index.html
@@ -138,7 +138,7 @@
                     </span>
                     <h4 class="service-heading">Debian</h4>
                     <p class="text-muted">Install the following dependencies:</p><pre align="left"><code align="left">gir1.2-appindicator3-0.1 gir1.2-notify-0.7  python3-pyaudio python3-psutil python3-xlib xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <pre align="left"><code align="left">sudo update-icon-caches /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
                 </div>
@@ -150,7 +150,7 @@
                     <h4 class="service-heading">Fedora</h4>
                     <p class="text-muted">Install the dependencies:</p><pre align="left"><code align="left">sudo dnf install libappindicator-gtk3 python3-pyaudio python3-psutil</code></pre>
                     <p class="text-muted">Install <code>xprintidle</code> manually (Available for Fedora 24)</p>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <p class="text-muted">Update the icon cache</p>
                     <pre align="left"><code align="left">sudo gtk-update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">env GDK_BACKEND=x11 safeeyes</code></pre>
@@ -163,7 +163,7 @@
                     <h4 class="service-heading">Arch Linux Manual</h4>
                     <p class="text-muted">Install the dependencies:</p><pre align="left"><code align="left">sudo pacman -S python-pip libappindicator-gtk3</code></pre>
                     <pre align="left"><code align="left">yaourt -S xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <p class="text-muted">Update the icon cache</p>
                     <pre align="left"><code align="left">sudo gtk-update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
@@ -185,7 +185,7 @@
                     </span>
                     <h4 class="service-heading">Others</h4>
                     <p class="text-muted">Install the following dependencies:</p><pre align="left"><code align="left">gir1.2-appindicator3-0.1 gir1.2-notify-0.7 python3-babel python3-dbus python3-psutil python3-pyaudio python3-xlib xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <pre align="left"><code align="left">sudo update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
                 </div> -->
@@ -764,11 +764,11 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy the break image to the resource directory:<pre><code>cp deep_breath.png ~/.config/safeyes/resource/deep_breath.png</code></pre></li>
+                                <li align="left">Copy the break image to the resource directory:<pre><code>cp deep_breath.png ~/.config/safeeyes/resource/deep_breath.png</code></pre></li>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Modify the <code>custom_exercises</code> property (which is an empty object by default) like so: <pre><code>...<br> "custom_exercises": {<br> &nbsp;&nbsp;&nbsp;&nbsp;"deep_breath": "Take a deep breath",<br> &nbsp;&nbsp;&nbsp;&nbsp;"pushups": "Do ten push-ups",<br> &nbsp;&nbsp;&nbsp;&nbsp;"other": "Other small things you should do on a regular basis"<br> }<br> ...</code></pre></li>
                             
@@ -807,7 +807,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add <code>time</code> in <b>seconds</b> to the desired breaks to override their default duration: <pre><code>...<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 30<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_roll_eyes"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...<br> "long_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "long_break_walk",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 300<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "long_break_lean_back"<br> &nbsp;&nbsp;&nbsp;&nbsp;}<br> ]<br> ...</code></pre></li>
                             
@@ -844,7 +844,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add the <code>audible_alert</code> property with either<code>true</code> or <code>false</code> value to the desired breaks to override the default option: <pre><code>...<br> "audible_alert": false,<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"audible_alert": true,<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_roll_eyes"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...</code></pre></li>
                             
@@ -881,9 +881,9 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy a new image to the resource directory:<pre><code>cp image.png ~/.config/safeyes/resource/short_break_close_eyes.png</code></pre></li>
+                                <li align="left">Copy a new image to the resource directory:<pre><code>cp image.png ~/.config/safeeyes/resource/short_break_close_eyes.png</code></pre></li>
                             
                                 <li align="left">Create a new property <code>image</code> next to the break name : <pre><code>...<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"image": "short_break_close_eyes.png"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...</code></pre></li>
                             
@@ -918,9 +918,9 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy the new audio file <code>alert.wav</code> in the resource directory:<pre><code>cp my_audio.wav ~/.config/safeyes/resource/alert.wav</code></pre></li>
+                                <li align="left">Copy the new audio file <code>alert.wav</code> in the resource directory:<pre><code>cp my_audio.wav ~/.config/safeeyes/resource/alert.wav</code></pre></li>
                             
                             </ol>
                             </p>
@@ -988,7 +988,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add a new object to the <code>disable_options</code> object: <pre><code>...<br> "disable_options": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_minutes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 30,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "minute"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_minutes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 45,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "minute"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_hour",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 1,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "hour"<br> &nbsp;&nbsp;&nbsp;&nbsp;}<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ]<br> ...</code></pre> The <code>unit</code> can be one of these case-insensitive constants: <code>second</code>, <code>seconds</code>, <code>minute</code>, <code>minutes</code>, <code>hour</code>, <code>hours</code></li>
                             
@@ -1025,7 +1025,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add <code>vlc</code> to <code>skip_break</code> array and <code>google-chrome</code> to <code>take_break</code> array to skip breaks if VLC is the active window either in fullscreen mode or not and to take break if Google Chrome is the active window without considering the window mode: <pre><code>...<br> "active_window_class": {<br> &nbsp;&nbsp;&nbsp;&nbsp;"skip_break": ["vlc"],<br> &nbsp;&nbsp;&nbsp;&nbsp;"take_break": ["google-chrome"]<br> },<br> ...</code></pre>The names <code>vlc</code> and <code>google-chrome</code> are not the application names but their window classes. Inorder to get the window class of an application, enter the following command in your terminal and click on the desired application. In the printed <code>WM_CLASS</code>, choose the second one.<pre><code>xprop WM_CLASS</code></pre></li>
                             
@@ -1062,7 +1062,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add the lock screen command as an array. For example, if you use gnome screen saver add the command like this: <pre><code>...<br> "lock_screen_command": ["gnome-screensaver-command", "--lock"]<br> ...</code></pre><b>NOTE:</b> If Safe Eyes cannot guess the default screen saver of your system, the option will be inactive in the Settings. You can enable it by defining the lock screen command as above.<br>Also remember that some applications(Example: a virtual operating system running in virtual box) can prevent the the screensaver from locking the screen (This is not the fault of Safe Eyes).</li>
                             
@@ -1099,7 +1099,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>plugins</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/plugins</code></pre></li>
+                                <li align="left">Create a new directory <code>plugins</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/plugins</code></pre></li>
                             
                                 <li align="left">Create a new file <code>todo.py</code> in <code>~/.config/safeeyes/plugins</code> with the following content:<pre><code>"""<br> Safe Eyes todo plugin<br> """<br> <br> def start(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on startup.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def pre_notification(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything before ntification.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def pre_break(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on before the break.<br> &nbsp;&nbsp;&nbsp;&nbsp;Optionally you can return a Pango markup content to be displayed<br> &nbsp;&nbsp;&nbsp;&nbsp;on the break screen. For more details about Pango: <br> &nbsp;&nbsp;&nbsp;&nbsp;https://developer.gnome.org/pygtk/stable/pango-markup-language.html<br> &nbsp;&nbsp;&nbsp;&nbsp;NOTE: This function should return the result within a second<br> &nbsp;&nbsp;&nbsp;&nbsp;The content can have several lines, but line length must not exceed<br> &nbsp;&nbsp;&nbsp;&nbsp;50 characters. If there is a line with more than 50 characters,<br> &nbsp;&nbsp;&nbsp;&nbsp;the entire data will be ignored by Safe Eyes.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;todo_list = """- Share Safe Eyes with friends<br> - Upvote Safe Eyes in alternativet.net"""<br> &nbsp;&nbsp;&nbsp;&nbsp;return "&#60;span color=&#39;white&#39;&#62;" + todo_list + "&#60;/span&#62;"<br> <br> def post_break(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;# Do nothing after the notification<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def exit(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on exit.<br> &nbsp;&nbsp;&nbsp;&nbsp;NOTE: This function should exit within a second<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass</code></pre></li>
                             

--- a/_site/2014/07/12/project-7/index.html
+++ b/_site/2014/07/12/project-7/index.html
@@ -138,7 +138,7 @@
                     </span>
                     <h4 class="service-heading">Debian</h4>
                     <p class="text-muted">Install the following dependencies:</p><pre align="left"><code align="left">gir1.2-appindicator3-0.1 gir1.2-notify-0.7  python3-pyaudio python3-psutil python3-xlib xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <pre align="left"><code align="left">sudo update-icon-caches /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
                 </div>
@@ -150,7 +150,7 @@
                     <h4 class="service-heading">Fedora</h4>
                     <p class="text-muted">Install the dependencies:</p><pre align="left"><code align="left">sudo dnf install libappindicator-gtk3 python3-pyaudio python3-psutil</code></pre>
                     <p class="text-muted">Install <code>xprintidle</code> manually (Available for Fedora 24)</p>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <p class="text-muted">Update the icon cache</p>
                     <pre align="left"><code align="left">sudo gtk-update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">env GDK_BACKEND=x11 safeeyes</code></pre>
@@ -163,7 +163,7 @@
                     <h4 class="service-heading">Arch Linux Manual</h4>
                     <p class="text-muted">Install the dependencies:</p><pre align="left"><code align="left">sudo pacman -S python-pip libappindicator-gtk3</code></pre>
                     <pre align="left"><code align="left">yaourt -S xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <p class="text-muted">Update the icon cache</p>
                     <pre align="left"><code align="left">sudo gtk-update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
@@ -185,7 +185,7 @@
                     </span>
                     <h4 class="service-heading">Others</h4>
                     <p class="text-muted">Install the following dependencies:</p><pre align="left"><code align="left">gir1.2-appindicator3-0.1 gir1.2-notify-0.7 python3-babel python3-dbus python3-psutil python3-pyaudio python3-xlib xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <pre align="left"><code align="left">sudo update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
                 </div> -->
@@ -764,11 +764,11 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy the break image to the resource directory:<pre><code>cp deep_breath.png ~/.config/safeyes/resource/deep_breath.png</code></pre></li>
+                                <li align="left">Copy the break image to the resource directory:<pre><code>cp deep_breath.png ~/.config/safeeyes/resource/deep_breath.png</code></pre></li>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Modify the <code>custom_exercises</code> property (which is an empty object by default) like so: <pre><code>...<br> "custom_exercises": {<br> &nbsp;&nbsp;&nbsp;&nbsp;"deep_breath": "Take a deep breath",<br> &nbsp;&nbsp;&nbsp;&nbsp;"pushups": "Do ten push-ups",<br> &nbsp;&nbsp;&nbsp;&nbsp;"other": "Other small things you should do on a regular basis"<br> }<br> ...</code></pre></li>
                             
@@ -807,7 +807,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add <code>time</code> in <b>seconds</b> to the desired breaks to override their default duration: <pre><code>...<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 30<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_roll_eyes"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...<br> "long_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "long_break_walk",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 300<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "long_break_lean_back"<br> &nbsp;&nbsp;&nbsp;&nbsp;}<br> ]<br> ...</code></pre></li>
                             
@@ -844,7 +844,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add the <code>audible_alert</code> property with either<code>true</code> or <code>false</code> value to the desired breaks to override the default option: <pre><code>...<br> "audible_alert": false,<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"audible_alert": true,<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_roll_eyes"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...</code></pre></li>
                             
@@ -881,9 +881,9 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy a new image to the resource directory:<pre><code>cp image.png ~/.config/safeyes/resource/short_break_close_eyes.png</code></pre></li>
+                                <li align="left">Copy a new image to the resource directory:<pre><code>cp image.png ~/.config/safeeyes/resource/short_break_close_eyes.png</code></pre></li>
                             
                                 <li align="left">Create a new property <code>image</code> next to the break name : <pre><code>...<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"image": "short_break_close_eyes.png"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...</code></pre></li>
                             
@@ -918,9 +918,9 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy the new audio file <code>alert.wav</code> in the resource directory:<pre><code>cp my_audio.wav ~/.config/safeyes/resource/alert.wav</code></pre></li>
+                                <li align="left">Copy the new audio file <code>alert.wav</code> in the resource directory:<pre><code>cp my_audio.wav ~/.config/safeeyes/resource/alert.wav</code></pre></li>
                             
                             </ol>
                             </p>
@@ -988,7 +988,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add a new object to the <code>disable_options</code> object: <pre><code>...<br> "disable_options": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_minutes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 30,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "minute"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_minutes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 45,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "minute"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_hour",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 1,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "hour"<br> &nbsp;&nbsp;&nbsp;&nbsp;}<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ]<br> ...</code></pre> The <code>unit</code> can be one of these case-insensitive constants: <code>second</code>, <code>seconds</code>, <code>minute</code>, <code>minutes</code>, <code>hour</code>, <code>hours</code></li>
                             
@@ -1025,7 +1025,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add <code>vlc</code> to <code>skip_break</code> array and <code>google-chrome</code> to <code>take_break</code> array to skip breaks if VLC is the active window either in fullscreen mode or not and to take break if Google Chrome is the active window without considering the window mode: <pre><code>...<br> "active_window_class": {<br> &nbsp;&nbsp;&nbsp;&nbsp;"skip_break": ["vlc"],<br> &nbsp;&nbsp;&nbsp;&nbsp;"take_break": ["google-chrome"]<br> },<br> ...</code></pre>The names <code>vlc</code> and <code>google-chrome</code> are not the application names but their window classes. Inorder to get the window class of an application, enter the following command in your terminal and click on the desired application. In the printed <code>WM_CLASS</code>, choose the second one.<pre><code>xprop WM_CLASS</code></pre></li>
                             
@@ -1062,7 +1062,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add the lock screen command as an array. For example, if you use gnome screen saver add the command like this: <pre><code>...<br> "lock_screen_command": ["gnome-screensaver-command", "--lock"]<br> ...</code></pre><b>NOTE:</b> If Safe Eyes cannot guess the default screen saver of your system, the option will be inactive in the Settings. You can enable it by defining the lock screen command as above.<br>Also remember that some applications(Example: a virtual operating system running in virtual box) can prevent the the screensaver from locking the screen (This is not the fault of Safe Eyes).</li>
                             
@@ -1099,7 +1099,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>plugins</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/plugins</code></pre></li>
+                                <li align="left">Create a new directory <code>plugins</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/plugins</code></pre></li>
                             
                                 <li align="left">Create a new file <code>todo.py</code> in <code>~/.config/safeeyes/plugins</code> with the following content:<pre><code>"""<br> Safe Eyes todo plugin<br> """<br> <br> def start(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on startup.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def pre_notification(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything before ntification.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def pre_break(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on before the break.<br> &nbsp;&nbsp;&nbsp;&nbsp;Optionally you can return a Pango markup content to be displayed<br> &nbsp;&nbsp;&nbsp;&nbsp;on the break screen. For more details about Pango: <br> &nbsp;&nbsp;&nbsp;&nbsp;https://developer.gnome.org/pygtk/stable/pango-markup-language.html<br> &nbsp;&nbsp;&nbsp;&nbsp;NOTE: This function should return the result within a second<br> &nbsp;&nbsp;&nbsp;&nbsp;The content can have several lines, but line length must not exceed<br> &nbsp;&nbsp;&nbsp;&nbsp;50 characters. If there is a line with more than 50 characters,<br> &nbsp;&nbsp;&nbsp;&nbsp;the entire data will be ignored by Safe Eyes.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;todo_list = """- Share Safe Eyes with friends<br> - Upvote Safe Eyes in alternativet.net"""<br> &nbsp;&nbsp;&nbsp;&nbsp;return "&#60;span color=&#39;white&#39;&#62;" + todo_list + "&#60;/span&#62;"<br> <br> def post_break(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;# Do nothing after the notification<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def exit(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on exit.<br> &nbsp;&nbsp;&nbsp;&nbsp;NOTE: This function should exit within a second<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass</code></pre></li>
                             

--- a/_site/2014/07/13/project-6/index.html
+++ b/_site/2014/07/13/project-6/index.html
@@ -138,7 +138,7 @@
                     </span>
                     <h4 class="service-heading">Debian</h4>
                     <p class="text-muted">Install the following dependencies:</p><pre align="left"><code align="left">gir1.2-appindicator3-0.1 gir1.2-notify-0.7  python3-pyaudio python3-psutil python3-xlib xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <pre align="left"><code align="left">sudo update-icon-caches /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
                 </div>
@@ -150,7 +150,7 @@
                     <h4 class="service-heading">Fedora</h4>
                     <p class="text-muted">Install the dependencies:</p><pre align="left"><code align="left">sudo dnf install libappindicator-gtk3 python3-pyaudio python3-psutil</code></pre>
                     <p class="text-muted">Install <code>xprintidle</code> manually (Available for Fedora 24)</p>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <p class="text-muted">Update the icon cache</p>
                     <pre align="left"><code align="left">sudo gtk-update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">env GDK_BACKEND=x11 safeeyes</code></pre>
@@ -163,7 +163,7 @@
                     <h4 class="service-heading">Arch Linux Manual</h4>
                     <p class="text-muted">Install the dependencies:</p><pre align="left"><code align="left">sudo pacman -S python-pip libappindicator-gtk3</code></pre>
                     <pre align="left"><code align="left">yaourt -S xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <p class="text-muted">Update the icon cache</p>
                     <pre align="left"><code align="left">sudo gtk-update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
@@ -185,7 +185,7 @@
                     </span>
                     <h4 class="service-heading">Others</h4>
                     <p class="text-muted">Install the following dependencies:</p><pre align="left"><code align="left">gir1.2-appindicator3-0.1 gir1.2-notify-0.7 python3-babel python3-dbus python3-psutil python3-pyaudio python3-xlib xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <pre align="left"><code align="left">sudo update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
                 </div> -->
@@ -764,11 +764,11 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy the break image to the resource directory:<pre><code>cp deep_breath.png ~/.config/safeyes/resource/deep_breath.png</code></pre></li>
+                                <li align="left">Copy the break image to the resource directory:<pre><code>cp deep_breath.png ~/.config/safeeyes/resource/deep_breath.png</code></pre></li>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Modify the <code>custom_exercises</code> property (which is an empty object by default) like so: <pre><code>...<br> "custom_exercises": {<br> &nbsp;&nbsp;&nbsp;&nbsp;"deep_breath": "Take a deep breath",<br> &nbsp;&nbsp;&nbsp;&nbsp;"pushups": "Do ten push-ups",<br> &nbsp;&nbsp;&nbsp;&nbsp;"other": "Other small things you should do on a regular basis"<br> }<br> ...</code></pre></li>
                             
@@ -807,7 +807,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add <code>time</code> in <b>seconds</b> to the desired breaks to override their default duration: <pre><code>...<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 30<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_roll_eyes"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...<br> "long_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "long_break_walk",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 300<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "long_break_lean_back"<br> &nbsp;&nbsp;&nbsp;&nbsp;}<br> ]<br> ...</code></pre></li>
                             
@@ -844,7 +844,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add the <code>audible_alert</code> property with either<code>true</code> or <code>false</code> value to the desired breaks to override the default option: <pre><code>...<br> "audible_alert": false,<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"audible_alert": true,<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_roll_eyes"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...</code></pre></li>
                             
@@ -881,9 +881,9 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy a new image to the resource directory:<pre><code>cp image.png ~/.config/safeyes/resource/short_break_close_eyes.png</code></pre></li>
+                                <li align="left">Copy a new image to the resource directory:<pre><code>cp image.png ~/.config/safeeyes/resource/short_break_close_eyes.png</code></pre></li>
                             
                                 <li align="left">Create a new property <code>image</code> next to the break name : <pre><code>...<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"image": "short_break_close_eyes.png"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...</code></pre></li>
                             
@@ -918,9 +918,9 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy the new audio file <code>alert.wav</code> in the resource directory:<pre><code>cp my_audio.wav ~/.config/safeyes/resource/alert.wav</code></pre></li>
+                                <li align="left">Copy the new audio file <code>alert.wav</code> in the resource directory:<pre><code>cp my_audio.wav ~/.config/safeeyes/resource/alert.wav</code></pre></li>
                             
                             </ol>
                             </p>
@@ -988,7 +988,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add a new object to the <code>disable_options</code> object: <pre><code>...<br> "disable_options": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_minutes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 30,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "minute"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_minutes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 45,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "minute"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_hour",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 1,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "hour"<br> &nbsp;&nbsp;&nbsp;&nbsp;}<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ]<br> ...</code></pre> The <code>unit</code> can be one of these case-insensitive constants: <code>second</code>, <code>seconds</code>, <code>minute</code>, <code>minutes</code>, <code>hour</code>, <code>hours</code></li>
                             
@@ -1025,7 +1025,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add <code>vlc</code> to <code>skip_break</code> array and <code>google-chrome</code> to <code>take_break</code> array to skip breaks if VLC is the active window either in fullscreen mode or not and to take break if Google Chrome is the active window without considering the window mode: <pre><code>...<br> "active_window_class": {<br> &nbsp;&nbsp;&nbsp;&nbsp;"skip_break": ["vlc"],<br> &nbsp;&nbsp;&nbsp;&nbsp;"take_break": ["google-chrome"]<br> },<br> ...</code></pre>The names <code>vlc</code> and <code>google-chrome</code> are not the application names but their window classes. Inorder to get the window class of an application, enter the following command in your terminal and click on the desired application. In the printed <code>WM_CLASS</code>, choose the second one.<pre><code>xprop WM_CLASS</code></pre></li>
                             
@@ -1062,7 +1062,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add the lock screen command as an array. For example, if you use gnome screen saver add the command like this: <pre><code>...<br> "lock_screen_command": ["gnome-screensaver-command", "--lock"]<br> ...</code></pre><b>NOTE:</b> If Safe Eyes cannot guess the default screen saver of your system, the option will be inactive in the Settings. You can enable it by defining the lock screen command as above.<br>Also remember that some applications(Example: a virtual operating system running in virtual box) can prevent the the screensaver from locking the screen (This is not the fault of Safe Eyes).</li>
                             
@@ -1099,7 +1099,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>plugins</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/plugins</code></pre></li>
+                                <li align="left">Create a new directory <code>plugins</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/plugins</code></pre></li>
                             
                                 <li align="left">Create a new file <code>todo.py</code> in <code>~/.config/safeeyes/plugins</code> with the following content:<pre><code>"""<br> Safe Eyes todo plugin<br> """<br> <br> def start(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on startup.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def pre_notification(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything before ntification.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def pre_break(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on before the break.<br> &nbsp;&nbsp;&nbsp;&nbsp;Optionally you can return a Pango markup content to be displayed<br> &nbsp;&nbsp;&nbsp;&nbsp;on the break screen. For more details about Pango: <br> &nbsp;&nbsp;&nbsp;&nbsp;https://developer.gnome.org/pygtk/stable/pango-markup-language.html<br> &nbsp;&nbsp;&nbsp;&nbsp;NOTE: This function should return the result within a second<br> &nbsp;&nbsp;&nbsp;&nbsp;The content can have several lines, but line length must not exceed<br> &nbsp;&nbsp;&nbsp;&nbsp;50 characters. If there is a line with more than 50 characters,<br> &nbsp;&nbsp;&nbsp;&nbsp;the entire data will be ignored by Safe Eyes.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;todo_list = """- Share Safe Eyes with friends<br> - Upvote Safe Eyes in alternativet.net"""<br> &nbsp;&nbsp;&nbsp;&nbsp;return "&#60;span color=&#39;white&#39;&#62;" + todo_list + "&#60;/span&#62;"<br> <br> def post_break(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;# Do nothing after the notification<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def exit(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on exit.<br> &nbsp;&nbsp;&nbsp;&nbsp;NOTE: This function should exit within a second<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass</code></pre></li>
                             

--- a/_site/2014/07/14/project-5/index.html
+++ b/_site/2014/07/14/project-5/index.html
@@ -138,7 +138,7 @@
                     </span>
                     <h4 class="service-heading">Debian</h4>
                     <p class="text-muted">Install the following dependencies:</p><pre align="left"><code align="left">gir1.2-appindicator3-0.1 gir1.2-notify-0.7  python3-pyaudio python3-psutil python3-xlib xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <pre align="left"><code align="left">sudo update-icon-caches /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
                 </div>
@@ -150,7 +150,7 @@
                     <h4 class="service-heading">Fedora</h4>
                     <p class="text-muted">Install the dependencies:</p><pre align="left"><code align="left">sudo dnf install libappindicator-gtk3 python3-pyaudio python3-psutil</code></pre>
                     <p class="text-muted">Install <code>xprintidle</code> manually (Available for Fedora 24)</p>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <p class="text-muted">Update the icon cache</p>
                     <pre align="left"><code align="left">sudo gtk-update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">env GDK_BACKEND=x11 safeeyes</code></pre>
@@ -163,7 +163,7 @@
                     <h4 class="service-heading">Arch Linux Manual</h4>
                     <p class="text-muted">Install the dependencies:</p><pre align="left"><code align="left">sudo pacman -S python-pip libappindicator-gtk3</code></pre>
                     <pre align="left"><code align="left">yaourt -S xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <p class="text-muted">Update the icon cache</p>
                     <pre align="left"><code align="left">sudo gtk-update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
@@ -185,7 +185,7 @@
                     </span>
                     <h4 class="service-heading">Others</h4>
                     <p class="text-muted">Install the following dependencies:</p><pre align="left"><code align="left">gir1.2-appindicator3-0.1 gir1.2-notify-0.7 python3-babel python3-dbus python3-psutil python3-pyaudio python3-xlib xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <pre align="left"><code align="left">sudo update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
                 </div> -->
@@ -764,11 +764,11 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy the break image to the resource directory:<pre><code>cp deep_breath.png ~/.config/safeyes/resource/deep_breath.png</code></pre></li>
+                                <li align="left">Copy the break image to the resource directory:<pre><code>cp deep_breath.png ~/.config/safeeyes/resource/deep_breath.png</code></pre></li>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Modify the <code>custom_exercises</code> property (which is an empty object by default) like so: <pre><code>...<br> "custom_exercises": {<br> &nbsp;&nbsp;&nbsp;&nbsp;"deep_breath": "Take a deep breath",<br> &nbsp;&nbsp;&nbsp;&nbsp;"pushups": "Do ten push-ups",<br> &nbsp;&nbsp;&nbsp;&nbsp;"other": "Other small things you should do on a regular basis"<br> }<br> ...</code></pre></li>
                             
@@ -807,7 +807,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add <code>time</code> in <b>seconds</b> to the desired breaks to override their default duration: <pre><code>...<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 30<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_roll_eyes"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...<br> "long_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "long_break_walk",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 300<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "long_break_lean_back"<br> &nbsp;&nbsp;&nbsp;&nbsp;}<br> ]<br> ...</code></pre></li>
                             
@@ -844,7 +844,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add the <code>audible_alert</code> property with either<code>true</code> or <code>false</code> value to the desired breaks to override the default option: <pre><code>...<br> "audible_alert": false,<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"audible_alert": true,<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_roll_eyes"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...</code></pre></li>
                             
@@ -881,9 +881,9 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy a new image to the resource directory:<pre><code>cp image.png ~/.config/safeyes/resource/short_break_close_eyes.png</code></pre></li>
+                                <li align="left">Copy a new image to the resource directory:<pre><code>cp image.png ~/.config/safeeyes/resource/short_break_close_eyes.png</code></pre></li>
                             
                                 <li align="left">Create a new property <code>image</code> next to the break name : <pre><code>...<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"image": "short_break_close_eyes.png"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...</code></pre></li>
                             
@@ -918,9 +918,9 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy the new audio file <code>alert.wav</code> in the resource directory:<pre><code>cp my_audio.wav ~/.config/safeyes/resource/alert.wav</code></pre></li>
+                                <li align="left">Copy the new audio file <code>alert.wav</code> in the resource directory:<pre><code>cp my_audio.wav ~/.config/safeeyes/resource/alert.wav</code></pre></li>
                             
                             </ol>
                             </p>
@@ -988,7 +988,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add a new object to the <code>disable_options</code> object: <pre><code>...<br> "disable_options": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_minutes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 30,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "minute"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_minutes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 45,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "minute"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_hour",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 1,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "hour"<br> &nbsp;&nbsp;&nbsp;&nbsp;}<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ]<br> ...</code></pre> The <code>unit</code> can be one of these case-insensitive constants: <code>second</code>, <code>seconds</code>, <code>minute</code>, <code>minutes</code>, <code>hour</code>, <code>hours</code></li>
                             
@@ -1025,7 +1025,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add <code>vlc</code> to <code>skip_break</code> array and <code>google-chrome</code> to <code>take_break</code> array to skip breaks if VLC is the active window either in fullscreen mode or not and to take break if Google Chrome is the active window without considering the window mode: <pre><code>...<br> "active_window_class": {<br> &nbsp;&nbsp;&nbsp;&nbsp;"skip_break": ["vlc"],<br> &nbsp;&nbsp;&nbsp;&nbsp;"take_break": ["google-chrome"]<br> },<br> ...</code></pre>The names <code>vlc</code> and <code>google-chrome</code> are not the application names but their window classes. Inorder to get the window class of an application, enter the following command in your terminal and click on the desired application. In the printed <code>WM_CLASS</code>, choose the second one.<pre><code>xprop WM_CLASS</code></pre></li>
                             
@@ -1062,7 +1062,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add the lock screen command as an array. For example, if you use gnome screen saver add the command like this: <pre><code>...<br> "lock_screen_command": ["gnome-screensaver-command", "--lock"]<br> ...</code></pre><b>NOTE:</b> If Safe Eyes cannot guess the default screen saver of your system, the option will be inactive in the Settings. You can enable it by defining the lock screen command as above.<br>Also remember that some applications(Example: a virtual operating system running in virtual box) can prevent the the screensaver from locking the screen (This is not the fault of Safe Eyes).</li>
                             
@@ -1099,7 +1099,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>plugins</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/plugins</code></pre></li>
+                                <li align="left">Create a new directory <code>plugins</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/plugins</code></pre></li>
                             
                                 <li align="left">Create a new file <code>todo.py</code> in <code>~/.config/safeeyes/plugins</code> with the following content:<pre><code>"""<br> Safe Eyes todo plugin<br> """<br> <br> def start(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on startup.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def pre_notification(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything before ntification.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def pre_break(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on before the break.<br> &nbsp;&nbsp;&nbsp;&nbsp;Optionally you can return a Pango markup content to be displayed<br> &nbsp;&nbsp;&nbsp;&nbsp;on the break screen. For more details about Pango: <br> &nbsp;&nbsp;&nbsp;&nbsp;https://developer.gnome.org/pygtk/stable/pango-markup-language.html<br> &nbsp;&nbsp;&nbsp;&nbsp;NOTE: This function should return the result within a second<br> &nbsp;&nbsp;&nbsp;&nbsp;The content can have several lines, but line length must not exceed<br> &nbsp;&nbsp;&nbsp;&nbsp;50 characters. If there is a line with more than 50 characters,<br> &nbsp;&nbsp;&nbsp;&nbsp;the entire data will be ignored by Safe Eyes.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;todo_list = """- Share Safe Eyes with friends<br> - Upvote Safe Eyes in alternativet.net"""<br> &nbsp;&nbsp;&nbsp;&nbsp;return "&#60;span color=&#39;white&#39;&#62;" + todo_list + "&#60;/span&#62;"<br> <br> def post_break(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;# Do nothing after the notification<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def exit(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on exit.<br> &nbsp;&nbsp;&nbsp;&nbsp;NOTE: This function should exit within a second<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass</code></pre></li>
                             

--- a/_site/2014/07/15/project-4/index.html
+++ b/_site/2014/07/15/project-4/index.html
@@ -138,7 +138,7 @@
                     </span>
                     <h4 class="service-heading">Debian</h4>
                     <p class="text-muted">Install the following dependencies:</p><pre align="left"><code align="left">gir1.2-appindicator3-0.1 gir1.2-notify-0.7  python3-pyaudio python3-psutil python3-xlib xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <pre align="left"><code align="left">sudo update-icon-caches /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
                 </div>
@@ -150,7 +150,7 @@
                     <h4 class="service-heading">Fedora</h4>
                     <p class="text-muted">Install the dependencies:</p><pre align="left"><code align="left">sudo dnf install libappindicator-gtk3 python3-pyaudio python3-psutil</code></pre>
                     <p class="text-muted">Install <code>xprintidle</code> manually (Available for Fedora 24)</p>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <p class="text-muted">Update the icon cache</p>
                     <pre align="left"><code align="left">sudo gtk-update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">env GDK_BACKEND=x11 safeeyes</code></pre>
@@ -163,7 +163,7 @@
                     <h4 class="service-heading">Arch Linux Manual</h4>
                     <p class="text-muted">Install the dependencies:</p><pre align="left"><code align="left">sudo pacman -S python-pip libappindicator-gtk3</code></pre>
                     <pre align="left"><code align="left">yaourt -S xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <p class="text-muted">Update the icon cache</p>
                     <pre align="left"><code align="left">sudo gtk-update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
@@ -185,7 +185,7 @@
                     </span>
                     <h4 class="service-heading">Others</h4>
                     <p class="text-muted">Install the following dependencies:</p><pre align="left"><code align="left">gir1.2-appindicator3-0.1 gir1.2-notify-0.7 python3-babel python3-dbus python3-psutil python3-pyaudio python3-xlib xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <pre align="left"><code align="left">sudo update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
                 </div> -->
@@ -764,11 +764,11 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy the break image to the resource directory:<pre><code>cp deep_breath.png ~/.config/safeyes/resource/deep_breath.png</code></pre></li>
+                                <li align="left">Copy the break image to the resource directory:<pre><code>cp deep_breath.png ~/.config/safeeyes/resource/deep_breath.png</code></pre></li>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Modify the <code>custom_exercises</code> property (which is an empty object by default) like so: <pre><code>...<br> "custom_exercises": {<br> &nbsp;&nbsp;&nbsp;&nbsp;"deep_breath": "Take a deep breath",<br> &nbsp;&nbsp;&nbsp;&nbsp;"pushups": "Do ten push-ups",<br> &nbsp;&nbsp;&nbsp;&nbsp;"other": "Other small things you should do on a regular basis"<br> }<br> ...</code></pre></li>
                             
@@ -807,7 +807,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add <code>time</code> in <b>seconds</b> to the desired breaks to override their default duration: <pre><code>...<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 30<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_roll_eyes"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...<br> "long_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "long_break_walk",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 300<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "long_break_lean_back"<br> &nbsp;&nbsp;&nbsp;&nbsp;}<br> ]<br> ...</code></pre></li>
                             
@@ -844,7 +844,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add the <code>audible_alert</code> property with either<code>true</code> or <code>false</code> value to the desired breaks to override the default option: <pre><code>...<br> "audible_alert": false,<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"audible_alert": true,<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_roll_eyes"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...</code></pre></li>
                             
@@ -881,9 +881,9 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy a new image to the resource directory:<pre><code>cp image.png ~/.config/safeyes/resource/short_break_close_eyes.png</code></pre></li>
+                                <li align="left">Copy a new image to the resource directory:<pre><code>cp image.png ~/.config/safeeyes/resource/short_break_close_eyes.png</code></pre></li>
                             
                                 <li align="left">Create a new property <code>image</code> next to the break name : <pre><code>...<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"image": "short_break_close_eyes.png"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...</code></pre></li>
                             
@@ -918,9 +918,9 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy the new audio file <code>alert.wav</code> in the resource directory:<pre><code>cp my_audio.wav ~/.config/safeyes/resource/alert.wav</code></pre></li>
+                                <li align="left">Copy the new audio file <code>alert.wav</code> in the resource directory:<pre><code>cp my_audio.wav ~/.config/safeeyes/resource/alert.wav</code></pre></li>
                             
                             </ol>
                             </p>
@@ -988,7 +988,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add a new object to the <code>disable_options</code> object: <pre><code>...<br> "disable_options": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_minutes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 30,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "minute"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_minutes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 45,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "minute"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_hour",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 1,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "hour"<br> &nbsp;&nbsp;&nbsp;&nbsp;}<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ]<br> ...</code></pre> The <code>unit</code> can be one of these case-insensitive constants: <code>second</code>, <code>seconds</code>, <code>minute</code>, <code>minutes</code>, <code>hour</code>, <code>hours</code></li>
                             
@@ -1025,7 +1025,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add <code>vlc</code> to <code>skip_break</code> array and <code>google-chrome</code> to <code>take_break</code> array to skip breaks if VLC is the active window either in fullscreen mode or not and to take break if Google Chrome is the active window without considering the window mode: <pre><code>...<br> "active_window_class": {<br> &nbsp;&nbsp;&nbsp;&nbsp;"skip_break": ["vlc"],<br> &nbsp;&nbsp;&nbsp;&nbsp;"take_break": ["google-chrome"]<br> },<br> ...</code></pre>The names <code>vlc</code> and <code>google-chrome</code> are not the application names but their window classes. Inorder to get the window class of an application, enter the following command in your terminal and click on the desired application. In the printed <code>WM_CLASS</code>, choose the second one.<pre><code>xprop WM_CLASS</code></pre></li>
                             
@@ -1062,7 +1062,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add the lock screen command as an array. For example, if you use gnome screen saver add the command like this: <pre><code>...<br> "lock_screen_command": ["gnome-screensaver-command", "--lock"]<br> ...</code></pre><b>NOTE:</b> If Safe Eyes cannot guess the default screen saver of your system, the option will be inactive in the Settings. You can enable it by defining the lock screen command as above.<br>Also remember that some applications(Example: a virtual operating system running in virtual box) can prevent the the screensaver from locking the screen (This is not the fault of Safe Eyes).</li>
                             
@@ -1099,7 +1099,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>plugins</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/plugins</code></pre></li>
+                                <li align="left">Create a new directory <code>plugins</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/plugins</code></pre></li>
                             
                                 <li align="left">Create a new file <code>todo.py</code> in <code>~/.config/safeeyes/plugins</code> with the following content:<pre><code>"""<br> Safe Eyes todo plugin<br> """<br> <br> def start(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on startup.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def pre_notification(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything before ntification.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def pre_break(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on before the break.<br> &nbsp;&nbsp;&nbsp;&nbsp;Optionally you can return a Pango markup content to be displayed<br> &nbsp;&nbsp;&nbsp;&nbsp;on the break screen. For more details about Pango: <br> &nbsp;&nbsp;&nbsp;&nbsp;https://developer.gnome.org/pygtk/stable/pango-markup-language.html<br> &nbsp;&nbsp;&nbsp;&nbsp;NOTE: This function should return the result within a second<br> &nbsp;&nbsp;&nbsp;&nbsp;The content can have several lines, but line length must not exceed<br> &nbsp;&nbsp;&nbsp;&nbsp;50 characters. If there is a line with more than 50 characters,<br> &nbsp;&nbsp;&nbsp;&nbsp;the entire data will be ignored by Safe Eyes.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;todo_list = """- Share Safe Eyes with friends<br> - Upvote Safe Eyes in alternativet.net"""<br> &nbsp;&nbsp;&nbsp;&nbsp;return "&#60;span color=&#39;white&#39;&#62;" + todo_list + "&#60;/span&#62;"<br> <br> def post_break(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;# Do nothing after the notification<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def exit(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on exit.<br> &nbsp;&nbsp;&nbsp;&nbsp;NOTE: This function should exit within a second<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass</code></pre></li>
                             

--- a/_site/2014/07/16/project-3/index.html
+++ b/_site/2014/07/16/project-3/index.html
@@ -138,7 +138,7 @@
                     </span>
                     <h4 class="service-heading">Debian</h4>
                     <p class="text-muted">Install the following dependencies:</p><pre align="left"><code align="left">gir1.2-appindicator3-0.1 gir1.2-notify-0.7  python3-pyaudio python3-psutil python3-xlib xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <pre align="left"><code align="left">sudo update-icon-caches /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
                 </div>
@@ -150,7 +150,7 @@
                     <h4 class="service-heading">Fedora</h4>
                     <p class="text-muted">Install the dependencies:</p><pre align="left"><code align="left">sudo dnf install libappindicator-gtk3 python3-pyaudio python3-psutil</code></pre>
                     <p class="text-muted">Install <code>xprintidle</code> manually (Available for Fedora 24)</p>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <p class="text-muted">Update the icon cache</p>
                     <pre align="left"><code align="left">sudo gtk-update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">env GDK_BACKEND=x11 safeeyes</code></pre>
@@ -163,7 +163,7 @@
                     <h4 class="service-heading">Arch Linux Manual</h4>
                     <p class="text-muted">Install the dependencies:</p><pre align="left"><code align="left">sudo pacman -S python-pip libappindicator-gtk3</code></pre>
                     <pre align="left"><code align="left">yaourt -S xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <p class="text-muted">Update the icon cache</p>
                     <pre align="left"><code align="left">sudo gtk-update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
@@ -185,7 +185,7 @@
                     </span>
                     <h4 class="service-heading">Others</h4>
                     <p class="text-muted">Install the following dependencies:</p><pre align="left"><code align="left">gir1.2-appindicator3-0.1 gir1.2-notify-0.7 python3-babel python3-dbus python3-psutil python3-pyaudio python3-xlib xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <pre align="left"><code align="left">sudo update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
                 </div> -->
@@ -764,11 +764,11 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy the break image to the resource directory:<pre><code>cp deep_breath.png ~/.config/safeyes/resource/deep_breath.png</code></pre></li>
+                                <li align="left">Copy the break image to the resource directory:<pre><code>cp deep_breath.png ~/.config/safeeyes/resource/deep_breath.png</code></pre></li>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Modify the <code>custom_exercises</code> property (which is an empty object by default) like so: <pre><code>...<br> "custom_exercises": {<br> &nbsp;&nbsp;&nbsp;&nbsp;"deep_breath": "Take a deep breath",<br> &nbsp;&nbsp;&nbsp;&nbsp;"pushups": "Do ten push-ups",<br> &nbsp;&nbsp;&nbsp;&nbsp;"other": "Other small things you should do on a regular basis"<br> }<br> ...</code></pre></li>
                             
@@ -807,7 +807,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add <code>time</code> in <b>seconds</b> to the desired breaks to override their default duration: <pre><code>...<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 30<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_roll_eyes"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...<br> "long_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "long_break_walk",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 300<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "long_break_lean_back"<br> &nbsp;&nbsp;&nbsp;&nbsp;}<br> ]<br> ...</code></pre></li>
                             
@@ -844,7 +844,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add the <code>audible_alert</code> property with either<code>true</code> or <code>false</code> value to the desired breaks to override the default option: <pre><code>...<br> "audible_alert": false,<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"audible_alert": true,<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_roll_eyes"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...</code></pre></li>
                             
@@ -881,9 +881,9 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy a new image to the resource directory:<pre><code>cp image.png ~/.config/safeyes/resource/short_break_close_eyes.png</code></pre></li>
+                                <li align="left">Copy a new image to the resource directory:<pre><code>cp image.png ~/.config/safeeyes/resource/short_break_close_eyes.png</code></pre></li>
                             
                                 <li align="left">Create a new property <code>image</code> next to the break name : <pre><code>...<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"image": "short_break_close_eyes.png"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...</code></pre></li>
                             
@@ -918,9 +918,9 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy the new audio file <code>alert.wav</code> in the resource directory:<pre><code>cp my_audio.wav ~/.config/safeyes/resource/alert.wav</code></pre></li>
+                                <li align="left">Copy the new audio file <code>alert.wav</code> in the resource directory:<pre><code>cp my_audio.wav ~/.config/safeeyes/resource/alert.wav</code></pre></li>
                             
                             </ol>
                             </p>
@@ -988,7 +988,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add a new object to the <code>disable_options</code> object: <pre><code>...<br> "disable_options": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_minutes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 30,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "minute"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_minutes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 45,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "minute"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_hour",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 1,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "hour"<br> &nbsp;&nbsp;&nbsp;&nbsp;}<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ]<br> ...</code></pre> The <code>unit</code> can be one of these case-insensitive constants: <code>second</code>, <code>seconds</code>, <code>minute</code>, <code>minutes</code>, <code>hour</code>, <code>hours</code></li>
                             
@@ -1025,7 +1025,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add <code>vlc</code> to <code>skip_break</code> array and <code>google-chrome</code> to <code>take_break</code> array to skip breaks if VLC is the active window either in fullscreen mode or not and to take break if Google Chrome is the active window without considering the window mode: <pre><code>...<br> "active_window_class": {<br> &nbsp;&nbsp;&nbsp;&nbsp;"skip_break": ["vlc"],<br> &nbsp;&nbsp;&nbsp;&nbsp;"take_break": ["google-chrome"]<br> },<br> ...</code></pre>The names <code>vlc</code> and <code>google-chrome</code> are not the application names but their window classes. Inorder to get the window class of an application, enter the following command in your terminal and click on the desired application. In the printed <code>WM_CLASS</code>, choose the second one.<pre><code>xprop WM_CLASS</code></pre></li>
                             
@@ -1062,7 +1062,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add the lock screen command as an array. For example, if you use gnome screen saver add the command like this: <pre><code>...<br> "lock_screen_command": ["gnome-screensaver-command", "--lock"]<br> ...</code></pre><b>NOTE:</b> If Safe Eyes cannot guess the default screen saver of your system, the option will be inactive in the Settings. You can enable it by defining the lock screen command as above.<br>Also remember that some applications(Example: a virtual operating system running in virtual box) can prevent the the screensaver from locking the screen (This is not the fault of Safe Eyes).</li>
                             
@@ -1099,7 +1099,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>plugins</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/plugins</code></pre></li>
+                                <li align="left">Create a new directory <code>plugins</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/plugins</code></pre></li>
                             
                                 <li align="left">Create a new file <code>todo.py</code> in <code>~/.config/safeeyes/plugins</code> with the following content:<pre><code>"""<br> Safe Eyes todo plugin<br> """<br> <br> def start(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on startup.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def pre_notification(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything before ntification.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def pre_break(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on before the break.<br> &nbsp;&nbsp;&nbsp;&nbsp;Optionally you can return a Pango markup content to be displayed<br> &nbsp;&nbsp;&nbsp;&nbsp;on the break screen. For more details about Pango: <br> &nbsp;&nbsp;&nbsp;&nbsp;https://developer.gnome.org/pygtk/stable/pango-markup-language.html<br> &nbsp;&nbsp;&nbsp;&nbsp;NOTE: This function should return the result within a second<br> &nbsp;&nbsp;&nbsp;&nbsp;The content can have several lines, but line length must not exceed<br> &nbsp;&nbsp;&nbsp;&nbsp;50 characters. If there is a line with more than 50 characters,<br> &nbsp;&nbsp;&nbsp;&nbsp;the entire data will be ignored by Safe Eyes.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;todo_list = """- Share Safe Eyes with friends<br> - Upvote Safe Eyes in alternativet.net"""<br> &nbsp;&nbsp;&nbsp;&nbsp;return "&#60;span color=&#39;white&#39;&#62;" + todo_list + "&#60;/span&#62;"<br> <br> def post_break(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;# Do nothing after the notification<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def exit(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on exit.<br> &nbsp;&nbsp;&nbsp;&nbsp;NOTE: This function should exit within a second<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass</code></pre></li>
                             

--- a/_site/2014/07/17/project-2/index.html
+++ b/_site/2014/07/17/project-2/index.html
@@ -138,7 +138,7 @@
                     </span>
                     <h4 class="service-heading">Debian</h4>
                     <p class="text-muted">Install the following dependencies:</p><pre align="left"><code align="left">gir1.2-appindicator3-0.1 gir1.2-notify-0.7  python3-pyaudio python3-psutil python3-xlib xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <pre align="left"><code align="left">sudo update-icon-caches /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
                 </div>
@@ -150,7 +150,7 @@
                     <h4 class="service-heading">Fedora</h4>
                     <p class="text-muted">Install the dependencies:</p><pre align="left"><code align="left">sudo dnf install libappindicator-gtk3 python3-pyaudio python3-psutil</code></pre>
                     <p class="text-muted">Install <code>xprintidle</code> manually (Available for Fedora 24)</p>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <p class="text-muted">Update the icon cache</p>
                     <pre align="left"><code align="left">sudo gtk-update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">env GDK_BACKEND=x11 safeeyes</code></pre>
@@ -163,7 +163,7 @@
                     <h4 class="service-heading">Arch Linux Manual</h4>
                     <p class="text-muted">Install the dependencies:</p><pre align="left"><code align="left">sudo pacman -S python-pip libappindicator-gtk3</code></pre>
                     <pre align="left"><code align="left">yaourt -S xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <p class="text-muted">Update the icon cache</p>
                     <pre align="left"><code align="left">sudo gtk-update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
@@ -185,7 +185,7 @@
                     </span>
                     <h4 class="service-heading">Others</h4>
                     <p class="text-muted">Install the following dependencies:</p><pre align="left"><code align="left">gir1.2-appindicator3-0.1 gir1.2-notify-0.7 python3-babel python3-dbus python3-psutil python3-pyaudio python3-xlib xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <pre align="left"><code align="left">sudo update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
                 </div> -->
@@ -764,11 +764,11 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy the break image to the resource directory:<pre><code>cp deep_breath.png ~/.config/safeyes/resource/deep_breath.png</code></pre></li>
+                                <li align="left">Copy the break image to the resource directory:<pre><code>cp deep_breath.png ~/.config/safeeyes/resource/deep_breath.png</code></pre></li>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Modify the <code>custom_exercises</code> property (which is an empty object by default) like so: <pre><code>...<br> "custom_exercises": {<br> &nbsp;&nbsp;&nbsp;&nbsp;"deep_breath": "Take a deep breath",<br> &nbsp;&nbsp;&nbsp;&nbsp;"pushups": "Do ten push-ups",<br> &nbsp;&nbsp;&nbsp;&nbsp;"other": "Other small things you should do on a regular basis"<br> }<br> ...</code></pre></li>
                             
@@ -807,7 +807,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add <code>time</code> in <b>seconds</b> to the desired breaks to override their default duration: <pre><code>...<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 30<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_roll_eyes"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...<br> "long_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "long_break_walk",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 300<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "long_break_lean_back"<br> &nbsp;&nbsp;&nbsp;&nbsp;}<br> ]<br> ...</code></pre></li>
                             
@@ -844,7 +844,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add the <code>audible_alert</code> property with either<code>true</code> or <code>false</code> value to the desired breaks to override the default option: <pre><code>...<br> "audible_alert": false,<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"audible_alert": true,<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_roll_eyes"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...</code></pre></li>
                             
@@ -881,9 +881,9 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy a new image to the resource directory:<pre><code>cp image.png ~/.config/safeyes/resource/short_break_close_eyes.png</code></pre></li>
+                                <li align="left">Copy a new image to the resource directory:<pre><code>cp image.png ~/.config/safeeyes/resource/short_break_close_eyes.png</code></pre></li>
                             
                                 <li align="left">Create a new property <code>image</code> next to the break name : <pre><code>...<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"image": "short_break_close_eyes.png"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...</code></pre></li>
                             
@@ -918,9 +918,9 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy the new audio file <code>alert.wav</code> in the resource directory:<pre><code>cp my_audio.wav ~/.config/safeyes/resource/alert.wav</code></pre></li>
+                                <li align="left">Copy the new audio file <code>alert.wav</code> in the resource directory:<pre><code>cp my_audio.wav ~/.config/safeeyes/resource/alert.wav</code></pre></li>
                             
                             </ol>
                             </p>
@@ -988,7 +988,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add a new object to the <code>disable_options</code> object: <pre><code>...<br> "disable_options": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_minutes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 30,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "minute"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_minutes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 45,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "minute"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_hour",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 1,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "hour"<br> &nbsp;&nbsp;&nbsp;&nbsp;}<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ]<br> ...</code></pre> The <code>unit</code> can be one of these case-insensitive constants: <code>second</code>, <code>seconds</code>, <code>minute</code>, <code>minutes</code>, <code>hour</code>, <code>hours</code></li>
                             
@@ -1025,7 +1025,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add <code>vlc</code> to <code>skip_break</code> array and <code>google-chrome</code> to <code>take_break</code> array to skip breaks if VLC is the active window either in fullscreen mode or not and to take break if Google Chrome is the active window without considering the window mode: <pre><code>...<br> "active_window_class": {<br> &nbsp;&nbsp;&nbsp;&nbsp;"skip_break": ["vlc"],<br> &nbsp;&nbsp;&nbsp;&nbsp;"take_break": ["google-chrome"]<br> },<br> ...</code></pre>The names <code>vlc</code> and <code>google-chrome</code> are not the application names but their window classes. Inorder to get the window class of an application, enter the following command in your terminal and click on the desired application. In the printed <code>WM_CLASS</code>, choose the second one.<pre><code>xprop WM_CLASS</code></pre></li>
                             
@@ -1062,7 +1062,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add the lock screen command as an array. For example, if you use gnome screen saver add the command like this: <pre><code>...<br> "lock_screen_command": ["gnome-screensaver-command", "--lock"]<br> ...</code></pre><b>NOTE:</b> If Safe Eyes cannot guess the default screen saver of your system, the option will be inactive in the Settings. You can enable it by defining the lock screen command as above.<br>Also remember that some applications(Example: a virtual operating system running in virtual box) can prevent the the screensaver from locking the screen (This is not the fault of Safe Eyes).</li>
                             
@@ -1099,7 +1099,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>plugins</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/plugins</code></pre></li>
+                                <li align="left">Create a new directory <code>plugins</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/plugins</code></pre></li>
                             
                                 <li align="left">Create a new file <code>todo.py</code> in <code>~/.config/safeeyes/plugins</code> with the following content:<pre><code>"""<br> Safe Eyes todo plugin<br> """<br> <br> def start(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on startup.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def pre_notification(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything before ntification.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def pre_break(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on before the break.<br> &nbsp;&nbsp;&nbsp;&nbsp;Optionally you can return a Pango markup content to be displayed<br> &nbsp;&nbsp;&nbsp;&nbsp;on the break screen. For more details about Pango: <br> &nbsp;&nbsp;&nbsp;&nbsp;https://developer.gnome.org/pygtk/stable/pango-markup-language.html<br> &nbsp;&nbsp;&nbsp;&nbsp;NOTE: This function should return the result within a second<br> &nbsp;&nbsp;&nbsp;&nbsp;The content can have several lines, but line length must not exceed<br> &nbsp;&nbsp;&nbsp;&nbsp;50 characters. If there is a line with more than 50 characters,<br> &nbsp;&nbsp;&nbsp;&nbsp;the entire data will be ignored by Safe Eyes.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;todo_list = """- Share Safe Eyes with friends<br> - Upvote Safe Eyes in alternativet.net"""<br> &nbsp;&nbsp;&nbsp;&nbsp;return "&#60;span color=&#39;white&#39;&#62;" + todo_list + "&#60;/span&#62;"<br> <br> def post_break(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;# Do nothing after the notification<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def exit(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on exit.<br> &nbsp;&nbsp;&nbsp;&nbsp;NOTE: This function should exit within a second<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass</code></pre></li>
                             

--- a/_site/2014/07/18/project-1/index.html
+++ b/_site/2014/07/18/project-1/index.html
@@ -138,7 +138,7 @@
                     </span>
                     <h4 class="service-heading">Debian</h4>
                     <p class="text-muted">Install the following dependencies:</p><pre align="left"><code align="left">gir1.2-appindicator3-0.1 gir1.2-notify-0.7  python3-pyaudio python3-psutil python3-xlib xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <pre align="left"><code align="left">sudo update-icon-caches /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
                 </div>
@@ -150,7 +150,7 @@
                     <h4 class="service-heading">Fedora</h4>
                     <p class="text-muted">Install the dependencies:</p><pre align="left"><code align="left">sudo dnf install libappindicator-gtk3 python3-pyaudio python3-psutil</code></pre>
                     <p class="text-muted">Install <code>xprintidle</code> manually (Available for Fedora 24)</p>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <p class="text-muted">Update the icon cache</p>
                     <pre align="left"><code align="left">sudo gtk-update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">env GDK_BACKEND=x11 safeeyes</code></pre>
@@ -163,7 +163,7 @@
                     <h4 class="service-heading">Arch Linux Manual</h4>
                     <p class="text-muted">Install the dependencies:</p><pre align="left"><code align="left">sudo pacman -S python-pip libappindicator-gtk3</code></pre>
                     <pre align="left"><code align="left">yaourt -S xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <p class="text-muted">Update the icon cache</p>
                     <pre align="left"><code align="left">sudo gtk-update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
@@ -185,7 +185,7 @@
                     </span>
                     <h4 class="service-heading">Others</h4>
                     <p class="text-muted">Install the following dependencies:</p><pre align="left"><code align="left">gir1.2-appindicator3-0.1 gir1.2-notify-0.7 python3-babel python3-dbus python3-psutil python3-pyaudio python3-xlib xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <pre align="left"><code align="left">sudo update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
                 </div> -->
@@ -764,11 +764,11 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy the break image to the resource directory:<pre><code>cp deep_breath.png ~/.config/safeyes/resource/deep_breath.png</code></pre></li>
+                                <li align="left">Copy the break image to the resource directory:<pre><code>cp deep_breath.png ~/.config/safeeyes/resource/deep_breath.png</code></pre></li>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Modify the <code>custom_exercises</code> property (which is an empty object by default) like so: <pre><code>...<br> "custom_exercises": {<br> &nbsp;&nbsp;&nbsp;&nbsp;"deep_breath": "Take a deep breath",<br> &nbsp;&nbsp;&nbsp;&nbsp;"pushups": "Do ten push-ups",<br> &nbsp;&nbsp;&nbsp;&nbsp;"other": "Other small things you should do on a regular basis"<br> }<br> ...</code></pre></li>
                             
@@ -807,7 +807,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add <code>time</code> in <b>seconds</b> to the desired breaks to override their default duration: <pre><code>...<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 30<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_roll_eyes"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...<br> "long_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "long_break_walk",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 300<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "long_break_lean_back"<br> &nbsp;&nbsp;&nbsp;&nbsp;}<br> ]<br> ...</code></pre></li>
                             
@@ -844,7 +844,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add the <code>audible_alert</code> property with either<code>true</code> or <code>false</code> value to the desired breaks to override the default option: <pre><code>...<br> "audible_alert": false,<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"audible_alert": true,<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_roll_eyes"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...</code></pre></li>
                             
@@ -881,9 +881,9 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy a new image to the resource directory:<pre><code>cp image.png ~/.config/safeyes/resource/short_break_close_eyes.png</code></pre></li>
+                                <li align="left">Copy a new image to the resource directory:<pre><code>cp image.png ~/.config/safeeyes/resource/short_break_close_eyes.png</code></pre></li>
                             
                                 <li align="left">Create a new property <code>image</code> next to the break name : <pre><code>...<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"image": "short_break_close_eyes.png"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...</code></pre></li>
                             
@@ -918,9 +918,9 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy the new audio file <code>alert.wav</code> in the resource directory:<pre><code>cp my_audio.wav ~/.config/safeyes/resource/alert.wav</code></pre></li>
+                                <li align="left">Copy the new audio file <code>alert.wav</code> in the resource directory:<pre><code>cp my_audio.wav ~/.config/safeeyes/resource/alert.wav</code></pre></li>
                             
                             </ol>
                             </p>
@@ -988,7 +988,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add a new object to the <code>disable_options</code> object: <pre><code>...<br> "disable_options": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_minutes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 30,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "minute"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_minutes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 45,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "minute"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_hour",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 1,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "hour"<br> &nbsp;&nbsp;&nbsp;&nbsp;}<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ]<br> ...</code></pre> The <code>unit</code> can be one of these case-insensitive constants: <code>second</code>, <code>seconds</code>, <code>minute</code>, <code>minutes</code>, <code>hour</code>, <code>hours</code></li>
                             
@@ -1025,7 +1025,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add <code>vlc</code> to <code>skip_break</code> array and <code>google-chrome</code> to <code>take_break</code> array to skip breaks if VLC is the active window either in fullscreen mode or not and to take break if Google Chrome is the active window without considering the window mode: <pre><code>...<br> "active_window_class": {<br> &nbsp;&nbsp;&nbsp;&nbsp;"skip_break": ["vlc"],<br> &nbsp;&nbsp;&nbsp;&nbsp;"take_break": ["google-chrome"]<br> },<br> ...</code></pre>The names <code>vlc</code> and <code>google-chrome</code> are not the application names but their window classes. Inorder to get the window class of an application, enter the following command in your terminal and click on the desired application. In the printed <code>WM_CLASS</code>, choose the second one.<pre><code>xprop WM_CLASS</code></pre></li>
                             
@@ -1062,7 +1062,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add the lock screen command as an array. For example, if you use gnome screen saver add the command like this: <pre><code>...<br> "lock_screen_command": ["gnome-screensaver-command", "--lock"]<br> ...</code></pre><b>NOTE:</b> If Safe Eyes cannot guess the default screen saver of your system, the option will be inactive in the Settings. You can enable it by defining the lock screen command as above.<br>Also remember that some applications(Example: a virtual operating system running in virtual box) can prevent the the screensaver from locking the screen (This is not the fault of Safe Eyes).</li>
                             
@@ -1099,7 +1099,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>plugins</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/plugins</code></pre></li>
+                                <li align="left">Create a new directory <code>plugins</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/plugins</code></pre></li>
                             
                                 <li align="left">Create a new file <code>todo.py</code> in <code>~/.config/safeeyes/plugins</code> with the following content:<pre><code>"""<br> Safe Eyes todo plugin<br> """<br> <br> def start(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on startup.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def pre_notification(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything before ntification.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def pre_break(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on before the break.<br> &nbsp;&nbsp;&nbsp;&nbsp;Optionally you can return a Pango markup content to be displayed<br> &nbsp;&nbsp;&nbsp;&nbsp;on the break screen. For more details about Pango: <br> &nbsp;&nbsp;&nbsp;&nbsp;https://developer.gnome.org/pygtk/stable/pango-markup-language.html<br> &nbsp;&nbsp;&nbsp;&nbsp;NOTE: This function should return the result within a second<br> &nbsp;&nbsp;&nbsp;&nbsp;The content can have several lines, but line length must not exceed<br> &nbsp;&nbsp;&nbsp;&nbsp;50 characters. If there is a line with more than 50 characters,<br> &nbsp;&nbsp;&nbsp;&nbsp;the entire data will be ignored by Safe Eyes.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;todo_list = """- Share Safe Eyes with friends<br> - Upvote Safe Eyes in alternativet.net"""<br> &nbsp;&nbsp;&nbsp;&nbsp;return "&#60;span color=&#39;white&#39;&#62;" + todo_list + "&#60;/span&#62;"<br> <br> def post_break(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;# Do nothing after the notification<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def exit(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on exit.<br> &nbsp;&nbsp;&nbsp;&nbsp;NOTE: This function should exit within a second<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass</code></pre></li>
                             

--- a/_site/index.html
+++ b/_site/index.html
@@ -138,7 +138,7 @@
                     </span>
                     <h4 class="service-heading">Debian</h4>
                     <p class="text-muted">Install the following dependencies:</p><pre align="left"><code align="left">gir1.2-appindicator3-0.1 gir1.2-notify-0.7  python3-pyaudio python3-psutil python3-xlib xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <pre align="left"><code align="left">sudo update-icon-caches /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
                 </div>
@@ -150,7 +150,7 @@
                     <h4 class="service-heading">Fedora</h4>
                     <p class="text-muted">Install the dependencies:</p><pre align="left"><code align="left">sudo dnf install libappindicator-gtk3 python3-pyaudio python3-psutil</code></pre>
                     <p class="text-muted">Install <code>xprintidle</code> manually (Available for Fedora 24)</p>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <p class="text-muted">Update the icon cache</p>
                     <pre align="left"><code align="left">sudo gtk-update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">env GDK_BACKEND=x11 safeeyes</code></pre>
@@ -163,7 +163,7 @@
                     <h4 class="service-heading">Arch Linux Manual</h4>
                     <p class="text-muted">Install the dependencies:</p><pre align="left"><code align="left">sudo pacman -S python-pip libappindicator-gtk3</code></pre>
                     <pre align="left"><code align="left">yaourt -S xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <p class="text-muted">Update the icon cache</p>
                     <pre align="left"><code align="left">sudo gtk-update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
@@ -185,7 +185,7 @@
                     </span>
                     <h4 class="service-heading">Others</h4>
                     <p class="text-muted">Install the following dependencies:</p><pre align="left"><code align="left">gir1.2-appindicator3-0.1 gir1.2-notify-0.7 python3-babel python3-dbus python3-psutil python3-pyaudio python3-xlib xprintidle</code></pre>
-                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeyes</code></pre>
+                    <p class="text-muted">Install Safe Eyes from PyPI.</p><pre align="left"><code align="left">sudo pip3 install safeeyes</code></pre>
                     <pre align="left"><code align="left">sudo update-icon-cache /usr/share/icons/hicolor</code></pre>
                     <pre align="left"><code align="left">safeeyes</code></pre>
                 </div> -->
@@ -764,11 +764,11 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy the break image to the resource directory:<pre><code>cp deep_breath.png ~/.config/safeyes/resource/deep_breath.png</code></pre></li>
+                                <li align="left">Copy the break image to the resource directory:<pre><code>cp deep_breath.png ~/.config/safeeyes/resource/deep_breath.png</code></pre></li>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Modify the <code>custom_exercises</code> property (which is an empty object by default) like so: <pre><code>...<br> "custom_exercises": {<br> &nbsp;&nbsp;&nbsp;&nbsp;"deep_breath": "Take a deep breath",<br> &nbsp;&nbsp;&nbsp;&nbsp;"pushups": "Do ten push-ups",<br> &nbsp;&nbsp;&nbsp;&nbsp;"other": "Other small things you should do on a regular basis"<br> }<br> ...</code></pre></li>
                             
@@ -807,7 +807,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add <code>time</code> in <b>seconds</b> to the desired breaks to override their default duration: <pre><code>...<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 30<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_roll_eyes"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...<br> "long_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "long_break_walk",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 300<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "long_break_lean_back"<br> &nbsp;&nbsp;&nbsp;&nbsp;}<br> ]<br> ...</code></pre></li>
                             
@@ -844,7 +844,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add the <code>audible_alert</code> property with either<code>true</code> or <code>false</code> value to the desired breaks to override the default option: <pre><code>...<br> "audible_alert": false,<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"audible_alert": true,<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_roll_eyes"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...</code></pre></li>
                             
@@ -881,9 +881,9 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy a new image to the resource directory:<pre><code>cp image.png ~/.config/safeyes/resource/short_break_close_eyes.png</code></pre></li>
+                                <li align="left">Copy a new image to the resource directory:<pre><code>cp image.png ~/.config/safeeyes/resource/short_break_close_eyes.png</code></pre></li>
                             
                                 <li align="left">Create a new property <code>image</code> next to the break name : <pre><code>...<br> "short_breaks": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name": "short_break_close_eyes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"image": "short_break_close_eyes.png"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ],<br> ...</code></pre></li>
                             
@@ -918,9 +918,9 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/resource</code></pre></li>
+                                <li align="left">Create a new directory <code>resource</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/resource</code></pre></li>
                             
-                                <li align="left">Copy the new audio file <code>alert.wav</code> in the resource directory:<pre><code>cp my_audio.wav ~/.config/safeyes/resource/alert.wav</code></pre></li>
+                                <li align="left">Copy the new audio file <code>alert.wav</code> in the resource directory:<pre><code>cp my_audio.wav ~/.config/safeeyes/resource/alert.wav</code></pre></li>
                             
                             </ol>
                             </p>
@@ -988,7 +988,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add a new object to the <code>disable_options</code> object: <pre><code>...<br> "disable_options": [<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_minutes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 30,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "minute"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_minutes",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 45,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "minute"<br> &nbsp;&nbsp;&nbsp;&nbsp;},<br> &nbsp;&nbsp;&nbsp;&nbsp;{<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"label": "for_x_hour",<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"time": 1,<br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"unit": "hour"<br> &nbsp;&nbsp;&nbsp;&nbsp;}<br> &nbsp;&nbsp;&nbsp;&nbsp;...<br> ]<br> ...</code></pre> The <code>unit</code> can be one of these case-insensitive constants: <code>second</code>, <code>seconds</code>, <code>minute</code>, <code>minutes</code>, <code>hour</code>, <code>hours</code></li>
                             
@@ -1025,7 +1025,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add <code>vlc</code> to <code>skip_break</code> array and <code>google-chrome</code> to <code>take_break</code> array to skip breaks if VLC is the active window either in fullscreen mode or not and to take break if Google Chrome is the active window without considering the window mode: <pre><code>...<br> "active_window_class": {<br> &nbsp;&nbsp;&nbsp;&nbsp;"skip_break": ["vlc"],<br> &nbsp;&nbsp;&nbsp;&nbsp;"take_break": ["google-chrome"]<br> },<br> ...</code></pre>The names <code>vlc</code> and <code>google-chrome</code> are not the application names but their window classes. Inorder to get the window class of an application, enter the following command in your terminal and click on the desired application. In the printed <code>WM_CLASS</code>, choose the second one.<pre><code>xprop WM_CLASS</code></pre></li>
                             
@@ -1062,7 +1062,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeyes/safeeyes.json</code></pre></li>
+                                <li align="left">Edit <code>safeeyes.json</code>:<pre><code>gedit ~/.config/safeeyes/safeeyes.json</code></pre></li>
                             
                                 <li align="left">Add the lock screen command as an array. For example, if you use gnome screen saver add the command like this: <pre><code>...<br> "lock_screen_command": ["gnome-screensaver-command", "--lock"]<br> ...</code></pre><b>NOTE:</b> If Safe Eyes cannot guess the default screen saver of your system, the option will be inactive in the Settings. You can enable it by defining the lock screen command as above.<br>Also remember that some applications(Example: a virtual operating system running in virtual box) can prevent the the screensaver from locking the screen (This is not the fault of Safe Eyes).</li>
                             
@@ -1099,7 +1099,7 @@
                             <p align="left">
                             <ol>
                             
-                                <li align="left">Create a new directory <code>plugins</code> if it does not exist:<pre><code>mkdir ~/.config/safeyes/plugins</code></pre></li>
+                                <li align="left">Create a new directory <code>plugins</code> if it does not exist:<pre><code>mkdir ~/.config/safeeyes/plugins</code></pre></li>
                             
                                 <li align="left">Create a new file <code>todo.py</code> in <code>~/.config/safeeyes/plugins</code> with the following content:<pre><code>"""<br> Safe Eyes todo plugin<br> """<br> <br> def start(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on startup.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def pre_notification(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything before ntification.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def pre_break(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on before the break.<br> &nbsp;&nbsp;&nbsp;&nbsp;Optionally you can return a Pango markup content to be displayed<br> &nbsp;&nbsp;&nbsp;&nbsp;on the break screen. For more details about Pango: <br> &nbsp;&nbsp;&nbsp;&nbsp;https://developer.gnome.org/pygtk/stable/pango-markup-language.html<br> &nbsp;&nbsp;&nbsp;&nbsp;NOTE: This function should return the result within a second<br> &nbsp;&nbsp;&nbsp;&nbsp;The content can have several lines, but line length must not exceed<br> &nbsp;&nbsp;&nbsp;&nbsp;50 characters. If there is a line with more than 50 characters,<br> &nbsp;&nbsp;&nbsp;&nbsp;the entire data will be ignored by Safe Eyes.<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;todo_list = """- Share Safe Eyes with friends<br> - Upvote Safe Eyes in alternativet.net"""<br> &nbsp;&nbsp;&nbsp;&nbsp;return "&#60;span color=&#39;white&#39;&#62;" + todo_list + "&#60;/span&#62;"<br> <br> def post_break(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;# Do nothing after the notification<br> &nbsp;&nbsp;&nbsp;&nbsp;pass<br> <br> def exit(context):<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;Do not return anything here.<br> &nbsp;&nbsp;&nbsp;&nbsp;Use this function if you want to do anything on exit.<br> &nbsp;&nbsp;&nbsp;&nbsp;NOTE: This function should exit within a second<br> &nbsp;&nbsp;&nbsp;&nbsp;"""<br> &nbsp;&nbsp;&nbsp;&nbsp;pass</code></pre></li>
                             


### PR DESCRIPTION
The docs told me to create a `safeyes` directory in `.config`. 

There was already a `safeeyes` dir there from installation. 

It also said `pip install safeyes` but pip has no `safeyes`, only `safeeyes`. 

This caused me to believe that instances of "safe yes" are probably typographical errors. This PR is the result of `find ./ -type f -exec sed -i 's/safeyes/safeeyes/g' {} \;` in the root of the gh-pages branch. 

If any of those instances of "safe yes" were intentional, I apologize for the inconvenience and please close this PR :)