### PR TITLE
Move the break screen window after presenting

### DIFF
--- a/safeeyes/BreakScreen.py
+++ b/safeeyes/BreakScreen.py
@@ -182,10 +182,10 @@ class BreakScreen:
 				# Fix flickering screen in KDE by setting opacity to 1
 				window.set_opacity(0.9)
 
-			window.move(x, y)
 			window.stick()
 			window.set_keep_above(True)
 			window.present()
+			window.move(x, y)
 			window.fullscreen()
 
 	def __update_count_down(self, count):


### PR DESCRIPTION
Some window managers do not honor the location set on a window before
presentation. (see http://www.pygtk.org/pygtk2reference/class-gtkwindow.html#method-gtkwindow--move) This can cause multi-display setups to show all break screens
on the same display. By calling window.move() after presenting the window,
more window managers will move the windows to the correct display. 

I have specifically seen this problem when using the i3 tiling window manager.