### PR TITLE
xscreensaver support

### DIFF
--- a/safeeyes/Utility.py
+++ b/safeeyes/Utility.py
@@ -326,6 +326,9 @@ def lock_screen_command():
 			if 'deprecated' not in os.environ.get('GNOME_DESKTOP_SESSION_ID') and command_exist('gnome-screensaver-command'):
 				# Gnome 2
 				return ['gnome-screensaver-command', '--lock']
+                elif command_exist('xscreensaver-command'):
+                        # this will fail if the daemon is not running
+                        return os.system('xscreensaver-command -version > /dev/null') == 0
 	return None
 
 


### PR DESCRIPTION
this should work on non-standard desktop environments (e.g. mine is
Xmonad) by detecting if the daemon is running when the command exists

obviously, if a user is running a xscreensaver in a standard DE, that
won't work, but that should be uncommon enough to not cause problems