### PR TITLE
Remove duplicate keyboard release

### DIFF
--- a/safeeyes/BreakScreen.py
+++ b/safeeyes/BreakScreen.py
@@ -94,7 +94,6 @@ class BreakScreen(object):
         Window close event handler.
         """
         logging.info("Closing the break screen")
-        self.__release_keyboard()
         self.close()
 
     def on_skip_clicked(self, button):


### PR DESCRIPTION
Remove call to `self.__release_keyboard()` in `on_window_delete()` method, since `self.close()` calls `self.__release_keyboard()`.