### PR TITLE
Decouple strict breaks and postponing breaks.

### DIFF
--- a/safeeyes/BreakScreen.py
+++ b/safeeyes/BreakScreen.py
@@ -185,15 +185,15 @@ class BreakScreen(object):
                 toolbar_button.show()
 
             # Add the buttons
-            if not self.strict_break:
+            if self.enable_postpone:
                 # Add postpone button
-                if self.enable_postpone:
-                    btn_postpone = Gtk.Button(_('Postpone'))
-                    btn_postpone.get_style_context().add_class('btn_postpone')
-                    btn_postpone.connect('clicked', self.on_postpone_clicked)
-                    btn_postpone.set_visible(True)
-                    box_buttons.pack_start(btn_postpone, True, True, 0)
+                btn_postpone = Gtk.Button(_('Postpone'))
+                btn_postpone.get_style_context().add_class('btn_postpone')
+                btn_postpone.connect('clicked', self.on_postpone_clicked)
+                btn_postpone.set_visible(True)
+                box_buttons.pack_start(btn_postpone, True, True, 0)
 
+            if not self.strict_break:
                 # Add the skip button
                 btn_skip = Gtk.Button(_('Skip'))
                 btn_skip.get_style_context().add_class('btn_skip')

--- a/safeeyes/settings.py
+++ b/safeeyes/settings.py
@@ -106,7 +106,7 @@ class SettingsDialog(object):
         self.spin_postpone_duration.set_value(config.get('postpone_duration'))
         self.spin_disable_keyboard_shortcut.set_value(config.get('shortcut_disable_time'))
         self.switch_strict_break.set_active(config.get('strict_break'))
-        self.switch_postpone.set_active(config.get('allow_postpone') and not config.get('strict_break'))
+        self.switch_postpone.set_active(config.get('allow_postpone'))
         self.switch_persist.set_active(config.get('persist_state'))
         self.infobar_long_break_shown = False
 


### PR DESCRIPTION
Addresses issue #316.

Because there's already separate options for skipping and postponing breaks, this PR decouples skips and postpones. Previously, if strict break was enabled, there would be no way to postpone the break even if the user had "allow postponing" on. This PR allows the user to choose to postpone but not skip breaks in the settings menu.