### PR TITLE
smartpause: use X API instead of xprintidle subprocess

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ sudo emerge -av x11-misc/safeeyes
 ### Debian
 
 ```bash
-sudo apt-get install gir1.2-appindicator3-0.1 gir1.2-notify-0.7 python3-psutil python3-xlib xprintidle python3-pip
+sudo apt-get install gir1.2-appindicator3-0.1 gir1.2-notify-0.7 python3-psutil python3-xlib python3-xcffib python3-pip
 sudo pip3 install safeeyes
 sudo update-icon-caches /usr/share/icons/hicolor
 ```
@@ -72,7 +72,7 @@ sudo apt-get install safeeyes
 ### Fedora
 
 ```bash
-sudo dnf install libappindicator-gtk3 python3-psutil cairo-devel python3-devel gobject-introspection-devel cairo-gobject-devel
+sudo dnf install libappindicator-gtk3 python3-psutil cairo-devel python3-devel gobject-introspection-devel cairo-gobject-devel python-xcffib
 sudo pip3 install safeeyes
 sudo gtk-update-icon-cache /usr/share/icons/hicolor
 ```
@@ -85,7 +85,7 @@ Ensure to meet the following dependencies:
 - gir1.2-notify-0.7
 - libappindicator-gtk3
 - python3-psutil
-- xprintidle (optional)
+- python3-xcffib
 
 **To install Safe Eyes:**
 
@@ -113,7 +113,7 @@ Some Linux systems like Cent OS do not have matching dependencies available in t
 1. Install the necessary dependencies
 
     ```
-    sudo yum install dbus dbus-devel cairo cairo-devel cairomm-devel libjpeg-turbo-devel pango pango-devel pangomm pangomm-devel
+    sudo yum install dbus dbus-devel cairo cairo-devel cairomm-devel libjpeg-turbo-devel pango pango-devel pangomm pangomm-devel libxcb-devel
     ```
 
 2. Create a virtual environment in your home folder

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Homepage: https://github.com/slgobinath/SafeEyes/
 
 Package: safeeyes
 Architecture: all
-Depends: ${misc:Depends}, ${python3:Depends}, gir1.2-appindicator3-0.1, python3 (>= 3.4.0), python3-xlib, python3-dbus, gir1.2-notify-0.7, python3-babel, x11-utils, xprintidle, alsa-utils, python3-psutil
+Depends: ${misc:Depends}, ${python3:Depends}, gir1.2-appindicator3-0.1, python3 (>= 3.4.0), python3-xlib, python3-dbus, gir1.2-notify-0.7, python3-babel, x11-utils, python3-xcffib, alsa-utils, python3-psutil
 Description: Safe Eyes
  Safe Eyes is a simple tool to remind you to take periodic breaks for your eyes. This is essential for anyone spending more time on the computer to avoid eye strain and other physical problems.
  .

--- a/safeeyes/plugins/smartpause/dependency_checker.py
+++ b/safeeyes/plugins/smartpause/dependency_checker.py
@@ -20,12 +20,9 @@ from safeeyes import Utility
 
 
 def validate(plugin_config):
-    command = None
     if Utility.DESKTOP_ENVIRONMENT == "gnome" and Utility.IS_WAYLAND:
         command = "dbus-send"
-    else:
-        command = "xprintidle"
-    if not Utility.command_exist(command):
-        return _("Please install the command-line tool '%s'") % command
-    else:
-        return None
+        if not Utility.command_exist(command):
+            return _("Please install the command-line tool '%s'") % command
+
+    return None

--- a/safeeyes/plugins/smartpause/interface.py
+++ b/safeeyes/plugins/smartpause/interface.py
@@ -1,0 +1,25 @@
+from abc import ABC, abstractmethod
+from numbers import Integral
+
+
+class IdleTimeInterface(ABC):
+    """Tells how long the user has been idle."""
+    # This could be a typing.Protocol in Python 3.8.
+
+    @classmethod
+    @abstractmethod
+    def is_applicable(cls, context) -> bool:
+        """Is this implementation usable in this context?"""
+        pass
+
+    @abstractmethod
+    def idle_seconds(self) -> Integral:
+        """Time since last user input, in seconds.
+
+        Returns 0 on failure."""
+        pass
+
+    @abstractmethod
+    def destroy(self) -> None:
+        """Destroy this checker (clean up any resources)."""
+        pass

--- a/safeeyes/plugins/smartpause/plugin.py
+++ b/safeeyes/plugins/smartpause/plugin.py
@@ -52,8 +52,8 @@ break_interval = 0
 waiting_time = 2
 interpret_idle_as_break = False
 postpone_if_active = False
-timer: Optional[int] = None
 idle_checker: Optional[IdleTimeInterface] = None
+_timer_event_id: Optional[int] = None
 
 
 class GnomeWaylandIdleTime(IdleTimeInterface):
@@ -210,7 +210,7 @@ def on_start():
     Begin polling to check user idle time.
     """
     global idle_checker
-    global timer
+    global _timer_event_id
 
     if __is_active():
         # If SmartPause is already started, do not start it again
@@ -222,7 +222,7 @@ def on_start():
     __set_active(True)
 
     # FIXME: need to make sure that this gets updated if the waiting_time config changes
-    timer = GLib.timeout_add_seconds(waiting_time, __idle_monitor)
+    _timer_event_id = GLib.timeout_add_seconds(waiting_time, __idle_monitor)
 
 
 def on_stop():
@@ -230,7 +230,7 @@ def on_stop():
     Stop polling to check user idle time.
     """
     global smart_pause_activated
-    global timer
+    global _timer_event_id
     global idle_checker
 
     if smart_pause_activated:
@@ -239,8 +239,8 @@ def on_stop():
         return
     logging.debug('Stop Smart Pause plugin')
     __set_active(False)
-    GLib.source_remove(timer)
-    timer = None
+    GLib.source_remove(_timer_event_id)
+    _timer_event_id = None
     if idle_checker is not None:
         idle_checker.destroy()
         idle_checker = None

--- a/safeeyes/plugins/smartpause/plugin.py
+++ b/safeeyes/plugins/smartpause/plugin.py
@@ -15,6 +15,9 @@
 
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Safe Eyes smart pause plugin
+"""
 
 import datetime
 import logging
@@ -32,9 +35,6 @@ import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import GLib
 
-"""
-Safe Eyes smart pause plugin
-"""
 
 context: Optional[dict] = None
 active = False

--- a/safeeyes/plugins/smartpause/plugin.py
+++ b/safeeyes/plugins/smartpause/plugin.py
@@ -52,7 +52,6 @@ break_interval = 0
 waiting_time = 2
 interpret_idle_as_break = False
 postpone_if_active = False
-is_wayland_and_gnome = False
 timer: Optional[int] = None
 xcb_connection: Optional[xcffib.Connection] = None
 idle_checker: Optional[IdleTimeInterface] = None
@@ -155,7 +154,6 @@ def init(ctx, safeeyes_config, plugin_config):
     global waiting_time
     global interpret_idle_as_break
     global postpone_if_active
-    global is_wayland_and_gnome
     logging.debug('Initialize Smart Pause plugin')
     context = ctx
     enable_safe_eyes = context['api']['enable_safeeyes']
@@ -167,7 +165,6 @@ def init(ctx, safeeyes_config, plugin_config):
     break_interval = safeeyes_config.get(
         'short_break_interval') * 60  # Convert to seconds
     waiting_time = min(2, idle_time)  # If idle time is 1 sec, wait only 1 sec
-    is_wayland_and_gnome = context['desktop'] == 'gnome' and context['is_wayland']
 
 
 def __idle_monitor():

--- a/safeeyes/plugins/smartpause/plugin.py
+++ b/safeeyes/plugins/smartpause/plugin.py
@@ -121,10 +121,17 @@ _idle_checkers = [
 ]
 
 
-def idle_checker_for_platform():
+def idle_checker_for_platform(ctx) -> Optional[IdleTimeInterface]:
+    """
+    Create the appropriate idle checker for this context.
+    """
     for cls in _idle_checkers:
-        if cls.is_applicable(context):
-            return cls()
+        if cls.is_applicable(ctx):
+            checker = cls()
+            logging.debug("Using idle checker %s", checker)
+            return checker
+
+    logging.warning("Could not find any appropriate idle checker.")
     return None
 
 
@@ -217,7 +224,7 @@ def on_start():
         return
 
     logging.debug('Start Smart Pause plugin')
-    idle_checker = idle_checker_for_platform()
+    idle_checker = idle_checker_for_platform(context)
 
     __set_active(True)
 

--- a/safeeyes/plugins/smartpause/plugin.py
+++ b/safeeyes/plugins/smartpause/plugin.py
@@ -22,7 +22,7 @@ import subprocess
 import threading
 import re
 import os
-from typing import Optional
+from typing import Optional, Callable
 
 import xcffib
 import xcffib.xproto
@@ -35,16 +35,16 @@ from safeeyes.model import State
 Safe Eyes smart pause plugin
 """
 
-context = None
 idle_condition = threading.Condition()
 lock = threading.Lock()
+context: Optional[dict] = None
 active = False
 idle_time = 0
-enable_safe_eyes = None
-disable_safe_eyes = None
+enable_safe_eyes: Optional[Callable[[Optional[int]], None]] = None
+disable_safe_eyes: Optional[Callable[[Optional[str]], None]] = None
 smart_pause_activated = False
-idle_start_time = None
-next_break_time = None
+idle_start_time: Optional[datetime.datetime] = None
+next_break_time: Optional[datetime.datetime] = None
 next_break_duration = 0
 break_interval = 0
 waiting_time = 2

--- a/safeeyes/plugins/smartpause/plugin.py
+++ b/safeeyes/plugins/smartpause/plugin.py
@@ -68,6 +68,11 @@ def __gnome_wayland_idle_time():
         return 0
 
 
+def __x11_idle_time():
+    # Convert to seconds
+    return int(subprocess.check_output(['xprintidle']).decode('utf-8')) / 1000
+
+
 def __system_idle_time():
     """
     Get system idle time in minutes.
@@ -76,8 +81,8 @@ def __system_idle_time():
     try:
         if is_wayland_and_gnome:
             return __gnome_wayland_idle_time()
-        # Convert to seconds
-        return int(subprocess.check_output(['xprintidle']).decode('utf-8')) / 1000
+        else:
+            return __x11_idle_time()
     except BaseException:
         return 0
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ requires = [
     'babel',
     'psutil',
     'PyGObject',
-    'python-xlib'
+    'python-xlib',
+    'xcffib'
 ]
 
 _ROOT = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
The `xprintidle` utility is a command-line wrapper around an X11 API call. SafeEyes can make the same call itself.

This likely reduces resource usage by avoiding spawning a new subprocess every few seconds, and potentially simplifies installation dependencies.