### PR TITLE
Add UnboundLocalError check in smartpause plugin

### DIFF
--- a/safeeyes/plugins/smartpause/plugin.py
+++ b/safeeyes/plugins/smartpause/plugin.py
@@ -159,13 +159,19 @@ def __start_idle_monitor():
                     # User is idle for break duration and wants to consider it as a break
                     enable_safe_eyes()
                 elif idle_seconds < break_interval:
-                    # Credit back the idle time
-                    if next_break is not None:
-                        # This method runs in a thread since the start.
-                        # It may run before next_break is initialized in the update_next_break method
-                        next_break = next_break_time + idle_period
-                        enable_safe_eyes(next_break.timestamp())
-                    else:
+                    try:
+                        # Credit back the idle time
+                        if next_break is not None:
+                            # This method runs in a thread since the start.
+                            # It may run before next_break is initialized in the update_next_break method
+                            next_break = next_break_time + idle_period
+                            enable_safe_eyes(next_break.timestamp())
+                        else:
+                            enable_safe_eyes()
+
+                    except (NameError,UnboundLocalError):
+                        # If next_break is not defined the above code block
+                        # will fail with either a NameError or an UnboundLocalError
                         enable_safe_eyes()
                 else:
                     # User is idle for more than the time between two breaks

--- a/safeeyes/plugins/smartpause/plugin.py
+++ b/safeeyes/plugins/smartpause/plugin.py
@@ -135,6 +135,8 @@ def __start_idle_monitor():
     """
     global smart_pause_activated
     global idle_start_time
+    next_break = None
+
     while __is_active():
         # Wait for waiting_time seconds
         idle_condition.acquire()
@@ -159,19 +161,13 @@ def __start_idle_monitor():
                     # User is idle for break duration and wants to consider it as a break
                     enable_safe_eyes()
                 elif idle_seconds < break_interval:
-                    try:
-                        # Credit back the idle time
-                        if next_break is not None:
-                            # This method runs in a thread since the start.
-                            # It may run before next_break is initialized in the update_next_break method
-                            next_break = next_break_time + idle_period
-                            enable_safe_eyes(next_break.timestamp())
-                        else:
-                            enable_safe_eyes()
-
-                    except (NameError,UnboundLocalError):
-                        # If next_break is not defined the above code block
-                        # will fail with either a NameError or an UnboundLocalError
+                    # Credit back the idle time
+                    if next_break is not None:
+                        # This method runs in a thread since the start.
+                        # It may run before next_break is initialized in the update_next_break method
+                        next_break = next_break_time + idle_period
+                        enable_safe_eyes(next_break.timestamp())
+                    else:
                         enable_safe_eyes()
                 else:
                     # User is idle for more than the time between two breaks


### PR DESCRIPTION
Running this package for the first time locally, I see the following error in my gnome logs:

```
Sep 28 10:31:53 x1carbon safeeyes.desktop[13687]: Exception in thread WorkThread:
Sep 28 10:31:53 x1carbon safeeyes.desktop[13687]: Traceback (most recent call last):
Sep 28 10:31:53 x1carbon safeeyes.desktop[13687]:   File "/usr/lib64/python3.8/threading.py", line 932, in _bootstrap_inner
Sep 28 10:31:53 x1carbon safeeyes.desktop[13687]:     self.run()
Sep 28 10:31:53 x1carbon safeeyes.desktop[13687]:   File "/usr/lib64/python3.8/threading.py", line 870, in run
Sep 28 10:31:53 x1carbon safeeyes.desktop[13687]:     self._target(*self._args, **self._kwargs)
Sep 28 10:31:53 x1carbon safeeyes.desktop[13687]:   File "/usr/lib/python3.8/site-packages/safeeyes/plugins/smartpause/plugin.py", line 163, in __start_idle_monitor
Sep 28 10:31:53 x1carbon safeeyes.desktop[13687]:     if next_break is not None:
Sep 28 10:31:53 x1carbon safeeyes.desktop[13687]: UnboundLocalError: local variable next_break referenced before assignment
```

This is a quick fix to solve that error