### PR TITLE
SmartPause: Increase default idle time to pause SafeEyes

### DIFF
--- a/safeeyes/plugins/smartpause/config.json
+++ b/safeeyes/plugins/smartpause/config.json
@@ -16,7 +16,7 @@
             "id": "idle_time",
             "label": "Minimum idle time to pause Safe Eyes (in seconds)",
             "type": "INT",
-            "default": 5,
+            "default": 150,
             "max": 3600,
             "min": 5
         },


### PR DESCRIPTION
5 seconds is too low value – SafeEyes break practically always will to postponed. Thus we need to increase default value