### PR TITLE
Add support for DWM's rules

### DIFF
--- a/safeeyes/ui/break_screen.py
+++ b/safeeyes/ui/break_screen.py
@@ -165,7 +165,7 @@ class BreakScreen:
             builder.connect_signals(self)
 
             window = builder.get_object("window_main")
-            window.set_title("SafeEyes-" + str(monitor));
+            window.set_title("SafeEyes-" + str(monitor))
             lbl_message = builder.get_object("lbl_message")
             lbl_count = builder.get_object("lbl_count")
             lbl_widget = builder.get_object("lbl_widget")

--- a/safeeyes/ui/break_screen.py
+++ b/safeeyes/ui/break_screen.py
@@ -165,6 +165,7 @@ class BreakScreen:
             builder.connect_signals(self)
 
             window = builder.get_object("window_main")
+            window.set_title("SafeEyes-" + str(monitor));
             lbl_message = builder.get_object("lbl_message")
             lbl_count = builder.get_object("lbl_count")
             lbl_widget = builder.get_object("lbl_widget")


### PR DESCRIPTION
Resolves issue #387, since we can create custom rules for each monitor like that:
![image](https://user-images.githubusercontent.com/77573150/104840147-7e8a7b00-58bd-11eb-83ad-5d27189f1fe5.png)
