### PR TITLE
Keep merged user config after upgrade

### DIFF
--- a/safeeyes/model.py
+++ b/safeeyes/model.py
@@ -319,7 +319,6 @@ class Config:
                         # Update the user config
                         self.__merge_dictionary(
                             self.__user_config, self.__system_config)
-                        self.__user_config = self.__system_config
                         # Update the style sheet
                         utility.replace_style_sheet()
 


### PR DESCRIPTION
I'm not sure of the reason this line was in here before, was it on purpose? I was running version 6.0.1 with custom config, but on upgrading to 6.0.3 all my config got wiped. I tracked it down to this command that (I think?) replaced the user config entirely after merging it. Let me know what you think? Thanks!

Thanks for your work on this project! I only found it recently but it's fantastic :heart: 