### PR TITLE
Add smartpause support for swaywm

### DIFF
--- a/safeeyes/plugins/smartpause/dependency_checker.py
+++ b/safeeyes/plugins/smartpause/dependency_checker.py
@@ -23,6 +23,8 @@ def validate(plugin_config, plugin_settings):
     command = None
     if utility.DESKTOP_ENVIRONMENT == "gnome" and utility.IS_WAYLAND:
         command = "dbus-send"
+    elif utility.DESKTOP_ENVIRONMENT == "sway":
+        command = "swayidle"
     else:
         command = "xprintidle"
     if not utility.command_exist(command):

--- a/safeeyes/utility.py
+++ b/safeeyes/utility.py
@@ -290,6 +290,9 @@ def desktop_environment():
             env = 'gnome'
         elif desktop_session.startswith('ubuntu'):
             env = 'unity'
+    elif current_desktop is not None:
+        if current_desktop.startswith('sway'):
+            env = 'sway'
     DESKTOP_ENVIRONMENT = env
     return env
 


### PR DESCRIPTION
If the current desktop environment is sway, the smartpause plugin will spawn a swayidle process that outputs the current time on idle and resume. Using that info, we can determine:

1. Whether the system is currently idle (idle timestamp > active timestamp)
2. How many seconds the system has been idle (current timestamp - idle timestamp)

Since swayidle uses the KDE idle protocol, it might be possible to extend this to Wayland KDE as well.