### PR TITLE
Use HTTPS where users potentially open the URL in a browser

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -645,7 +645,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -664,11 +664,11 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
+<https://www.gnu.org/licenses/>.
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+<https://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Protect your eyes from eye strain using this simple and beautiful, yet extensible break reminder.
 
-Visit the official site: http://slgobinath.github.io/SafeEyes/ for more details.
+Visit the official site: https://slgobinath.github.io/SafeEyes/ for more details.
 
 ## Safe Eyes command-line arguments
 

--- a/safeeyes/glade/about_dialog.glade
+++ b/safeeyes/glade/about_dialog.glade
@@ -33,7 +33,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.</property>
+along with this program.  If not, see &lt;https://www.gnu.org/licenses/&gt;.</property>
   </object>
   <object class="GtkWindow" id="window_about">
     <property name="can_focus">False</property>
@@ -135,14 +135,14 @@ along with this program.  If not, see &lt;http://www.gnu.org/licenses/&gt;.</pro
             </child>
             <child>
               <object class="GtkLinkButton" id="btn_url">
-                <property name="label" translatable="yes">http://slgobinath.github.io/SafeEyes</property>
+                <property name="label" translatable="yes">https://slgobinath.github.io/SafeEyes</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="focus_on_click">False</property>
                 <property name="receives_default">True</property>
                 <property name="halign">center</property>
                 <property name="relief">none</property>
-                <property name="uri">http://slgobinath.github.io/SafeEyes</property>
+                <property name="uri">https://slgobinath.github.io/SafeEyes</property>
               </object>
               <packing>
                 <property name="expand">False</property>


### PR DESCRIPTION
.github.io pages no longer redirect to HTTPS and it's a good idea in general to use HTTPS because it's supported everywhere.

It's not necessary in `LICENSE`, I can changed that if you want. It doesn't hurt imo.