### PR TITLE
Fix broken startup symlinks

### DIFF
--- a/safeeyes/model.py
+++ b/safeeyes/model.py
@@ -303,8 +303,8 @@ class Config:
         # self.__force_upgrade = ['long_breaks', 'short_breaks']
 
         if init:
-            # create_startup_entry will verify if a working symlink is in place before creating it
-            utility.create_startup_entry()
+            # if create_startup_entry finds a broken autostart symlink, it will repair it
+            utility.create_startup_entry(force=False)
             if self.__user_config is None:
                 utility.initialize_safeeyes()
                 self.__user_config = self.__system_config

--- a/safeeyes/model.py
+++ b/safeeyes/model.py
@@ -303,6 +303,8 @@ class Config:
         # self.__force_upgrade = ['long_breaks', 'short_breaks']
 
         if init:
+            # create_startup_entry will verify if a working symlink is in place before creating it
+            utility.create_startup_entry()
             if self.__user_config is None:
                 utility.initialize_safeeyes()
                 self.__user_config = self.__system_config

--- a/safeeyes/utility.py
+++ b/safeeyes/utility.py
@@ -400,18 +400,22 @@ def create_startup_entry():
     """
     startup_dir_path = os.path.join(HOME_DIRECTORY, '.config/autostart')
     startup_entry = os.path.join(startup_dir_path, 'io.github.slgobinath.SafeEyes.desktop')
-
-    # Create the folder if not exist
-    mkdir(startup_dir_path)
-
-    # Remove existing files
-    delete(startup_entry)
-
-    # Create the new startup entry
+    
+    # a FileNotFoundError will get thrown if the startup symlink is missing or is broken
     try:
-        os.symlink(SYSTEM_DESKTOP_FILE, startup_entry)
-    except OSError:
-        logging.error("Failed to create startup entry at %s" % startup_entry)
+        os.stat(startup_entry)
+    except FileNotFoundError:
+        # Create the folder if not exist
+        mkdir(startup_dir_path)
+
+        # Remove existing files
+        delete(startup_entry)
+
+        # Create the new startup entry
+        try:
+            os.symlink(SYSTEM_DESKTOP_FILE, startup_entry)
+        except OSError:
+            logging.error("Failed to create startup entry at %s" % startup_entry)
 
 
 def initialize_platform():

--- a/safeeyes/utility.py
+++ b/safeeyes/utility.py
@@ -391,7 +391,7 @@ def initialize_safeeyes():
         shutil.copy2(SYSTEM_STYLE_SHEET_PATH, STYLE_SHEET_PATH)
         os.chmod(STYLE_SHEET_PATH, 0o777)
 
-    # initialize_safeeyes gets called when the configuration file is not present, which happens just after installation or reset. In these cases, we want to force the creation of a startup entry
+    # initialize_safeeyes gets called when the configuration file is not present, which happens just after installation or manual deletion of .config/safeeyes/safeeyes.json file. In these cases, we want to force the creation of a startup entry
     create_startup_entry(force=True)
 
 def create_startup_entry(force=False):

--- a/safeeyes/utility.py
+++ b/safeeyes/utility.py
@@ -391,8 +391,6 @@ def initialize_safeeyes():
         shutil.copy2(SYSTEM_STYLE_SHEET_PATH, STYLE_SHEET_PATH)
         os.chmod(STYLE_SHEET_PATH, 0o777)
 
-    create_startup_entry()
-
 
 def create_startup_entry():
     """


### PR DESCRIPTION
Fix #474 

I can squash the commits if you prefer.

If it is the first time SafeEyes gets installed, create the autostart file (unchanged behaviour).

If it is not the first installation (i.e. the config file already exists), a check is performed:

- if a broken autostart symlink is detected, as the one reported in #474, fix it
- if no autostart symlink is detected, do nothing (we'll suppose that the user deleted it, either manually or via some helper like Gnome Tweaks)

As an unrelated comment: it is weird that there is no on/off switch for the autostart in the graphical settings interface.