### PR TITLE
Correctly detect GNOME in screensaver plugin and in utility.py

### DIFF
--- a/safeeyes/plugins/screensaver/plugin.py
+++ b/safeeyes/plugins/screensaver/plugin.py
@@ -64,7 +64,7 @@ def __lock_screen_command():
             return ['mate-screensaver-command', '--lock']
         elif desktop_session == 'kde' or 'plasma' in desktop_session or desktop_session.startswith('kubuntu') or os.environ.get('KDE_FULL_SESSION') == 'true':
             return ['qdbus', 'org.freedesktop.ScreenSaver', '/ScreenSaver', 'Lock']
-        elif desktop_session in ['gnome', 'unity', 'budgie-desktop'] or desktop_session.startswith('ubuntu'):
+        elif desktop_session in ['gnome', 'unity', 'budgie-desktop'] or desktop_session.startswith('ubuntu') or desktop_session.startswith('gnome'):
             if utility.command_exist('gnome-screensaver-command'):
                 return ['gnome-screensaver-command', '--lock']
             # From Gnome 3.8 no gnome-screensaver-command

--- a/safeeyes/utility.py
+++ b/safeeyes/utility.py
@@ -287,7 +287,7 @@ def desktop_environment():
             env = 'lxde'
         elif 'plasma' in desktop_session or desktop_session.startswith('kubuntu') or os.environ.get('KDE_FULL_SESSION') == 'true':
             env = 'kde'
-        elif os.environ.get('GNOME_DESKTOP_SESSION_ID'):
+        elif os.environ.get('GNOME_DESKTOP_SESSION_ID') or desktop_session.startswith('gnome'):
             env = 'gnome'
         elif desktop_session.startswith('ubuntu'):
             env = 'unity'


### PR DESCRIPTION
I'm using Manjaro with GNOME 44 and 45  on my computers.

GNOME can be represented also as `gnome-xorg` and not only as `gnome`.

Currently GNOME isn't properly recognized, thus the locking screen feature is broken.

I added `desktop_session.startswith('gnome')` to detect possible GNOME sessions in `utility.py` and in the screensaver plugin.