### PR TITLE
smartpause: use swayidle on all non-gnome wayland sessions

### DIFF
--- a/safeeyes/plugins/smartpause/dependency_checker.py
+++ b/safeeyes/plugins/smartpause/dependency_checker.py
@@ -23,7 +23,7 @@ def validate(plugin_config, plugin_settings):
     command = None
     if utility.DESKTOP_ENVIRONMENT == "gnome" and utility.IS_WAYLAND:
         command = "dbus-send"
-    elif utility.DESKTOP_ENVIRONMENT == "sway":
+    elif utility.IS_WAYLAND:
         command = "swayidle"
     else:
         command = "xprintidle"

--- a/safeeyes/plugins/smartpause/plugin.py
+++ b/safeeyes/plugins/smartpause/plugin.py
@@ -174,7 +174,7 @@ def init(ctx, safeeyes_config, plugin_config):
     long_break_duration = safeeyes_config.get('long_break_duration')
     waiting_time = min(2, idle_time)  # If idle time is 1 sec, wait only 1 sec
     is_wayland_and_gnome = context['desktop'] == 'gnome' and context['is_wayland']
-    use_swayidle = context['desktop'] == 'sway'
+    use_swayidle = context['desktop'] != 'gnome' and context['is_wayland']
 
 
 def __start_idle_monitor():


### PR DESCRIPTION
CC https://github.com/slgobinath/SafeEyes/issues/391.

swayidle by default now uses the standardized [ext-idle-notify-v1](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/tree/main/staging/ext-idle-notify) protocol, so in theory this should be supportable by all wayland compositors in the future. Notably, gnome does not support it, so keep using the gnome-specific solution in that case.

Tested on KDE Plasma 5.27 Wayland.
This should possibly still be tested on a non-gnome compositor without ext-idle-notify support, with swayidle installed, as this PR will make that case go from using xprintidle to probably failing not that gracefully. However, xprintidle on wayland compositors was pretty much broken already.
According to [this](https://wayland.app/protocols/ext-idle-notify-v1#compositor-support), this would be something using weston or mir - however, those tend to be pretty niche, and since this un-breaks smartpause on KDE Plasma, this might be more important.