### PR TITLE
Remove use of distutils

### DIFF
--- a/safeeyes/model.py
+++ b/safeeyes/model.py
@@ -22,8 +22,9 @@ This module contains the entity classes used by Safe Eyes and its plugins.
 
 import logging
 import random
-from distutils.version import LooseVersion
 from enum import Enum
+
+from packaging.version import parse
 
 from safeeyes import utility
 
@@ -323,7 +324,7 @@ class Config:
                 else:
                     user_config_version = str(
                         meta_obj.get('config_version', '0.0.0'))
-                    if LooseVersion(user_config_version) != LooseVersion(system_config_version):
+                    if parse(user_config_version) != parse(system_config_version):
                         # Update the user config
                         self.__merge_dictionary(
                             self.__user_config, self.__system_config)

--- a/safeeyes/utility.py
+++ b/safeeyes/utility.py
@@ -32,7 +32,6 @@ import sys
 import shutil
 import subprocess
 import threading
-from distutils.version import LooseVersion
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
@@ -43,6 +42,7 @@ gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 from gi.repository import GLib
 from gi.repository import GdkPixbuf
+from packaging.version import parse
 
 gi.require_version('Gdk', '3.0')
 
@@ -559,7 +559,7 @@ def __update_plugin_config(plugin, plugin_config, config):
     if plugin_config is None:
         config['plugins'].remove(plugin)
     else:
-        if LooseVersion(plugin.get('version', '0.0.0')) != LooseVersion(plugin_config['meta']['version']):
+        if parse(plugin.get('version', '0.0.0')) != parse(plugin_config['meta']['version']):
             # Update the configuration
             plugin['version'] = plugin_config['meta']['version']
             setting_ids = []

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ requires = [
     'psutil',
     'croniter',
     'PyGObject',
+    'packaging',
     'python-xlib'
 ]
 


### PR DESCRIPTION
As of Python 3.12 setuptools is no longer installed by default and if setuptools is not installed distutils is not found and SafeEyes fails to start.

Furthermore distutils is deprecated and should thus not be used anymore. The packaging module provides a replacement for LooseVersion and it is added in this commit.