### PR TITLE
Add dbus-python to required dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Some Linux systems like Cent OS do not have matching dependencies available in t
     pip3 install virtualenv --user
     virtualenv --no-site-packages venv
     source venv/bin/activate
-    pip3 install dbus-python safeeyes
+    pip3 install safeeyes
     ```
 
 3. Start Safe Eyes from terminal

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ requires = [
     'babel',
     'psutil',
     'croniter',
+    'dbus-python',
     'PyGObject',
     'python-xlib'
 ]


### PR DESCRIPTION
SafeEyes does not start without dbus-python and therefore it is added to required dependencies in setup.py.