### PR TITLE
Remove build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-rm -rf build/ dist/ safeeyes.egg-info/ .eggs/
-
-python3 setup.py sdist bdist_wheel
-twine upload --repository pypitest dist/safeeyes*.tar.gz
-clear >$(tty)
-twine upload --repository pypitest dist/safeeyes*.whl


### PR DESCRIPTION
The use of setup.py as a command line tool is deprecated. build.sh is updated to use the recommended building command.