### PR TITLE
trayicon: migrate from libappindicator to org.kde.StatusNotifierItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ sudo apt-get install safeeyes
 ### Fedora
 
 ```bash
-sudo dnf install libappindicator-gtk3 python3-psutil python3-packaging cairo-devel python3-devel gobject-introspection-devel cairo-gobject-devel
+sudo dnf install python3-psutil python3-packaging cairo-devel python3-devel gobject-introspection-devel cairo-gobject-devel
 sudo pip3 install safeeyes
 sudo gtk-update-icon-cache /usr/share/icons/hicolor
 ```
@@ -105,9 +105,7 @@ flatpak install flathub io.github.slgobinath.SafeEyes
 
 Ensure to meet the following dependencies:
 
-- gir1.2-appindicator3-0.1 or gir1.2-ayatanaappindicator3-0.1
 - gir1.2-notify-0.7
-- libappindicator-gtk3
 - python3-psutil
 - xprintidle (optional)
 - wlrctl (wayland optional)

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Homepage: https://github.com/slgobinath/SafeEyes/
 
 Package: safeeyes
 Architecture: all
-Depends: ${misc:Depends}, ${python3:Depends}, gir1.2-ayatanaappindicator3-0.1, python3 (>= 3.10.0), python3-xlib, python3-dbus, gir1.2-notify-0.7, python3-babel, x11-utils, xprintidle, alsa-utils, python3-psutil, python3-croniter, python3-packaging
+Depends: ${misc:Depends}, ${python3:Depends}, gir1.2-ayatanaappindicator3-0.1, python3 (>= 3.10.0), python3-xlib, gir1.2-notify-0.7, python3-babel, x11-utils, xprintidle, alsa-utils, python3-psutil, python3-croniter, python3-packaging
 Description: Safe Eyes
  Safe Eyes is a simple tool to remind you to take periodic breaks for your eyes. This is essential for anyone spending more time on the computer to avoid eye strain and other physical problems.
  .

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Homepage: https://github.com/slgobinath/SafeEyes/
 
 Package: safeeyes
 Architecture: all
-Depends: ${misc:Depends}, ${python3:Depends}, gir1.2-ayatanaappindicator3-0.1, python3 (>= 3.10.0), python3-xlib, gir1.2-notify-0.7, python3-babel, x11-utils, xprintidle, alsa-utils, python3-psutil, python3-croniter, python3-packaging
+Depends: ${misc:Depends}, ${python3:Depends}, python3 (>= 3.10.0), python3-xlib, gir1.2-notify-0.7, python3-babel, x11-utils, xprintidle, alsa-utils, python3-psutil, python3-croniter, python3-packaging
 Description: Safe Eyes
  Safe Eyes is a simple tool to remind you to take periodic breaks for your eyes. This is essential for anyone spending more time on the computer to avoid eye strain and other physical problems.
  .

--- a/safeeyes/config/locale/ar/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/ar/LC_MESSAGES/safeeyes.po
@@ -555,10 +555,18 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""
 
 # plugin/healthstats

--- a/safeeyes/config/locale/ar/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/ar/LC_MESSAGES/safeeyes.po
@@ -542,6 +542,25 @@ msgstr ""
 msgid "RSI Prevention"
 msgstr ""
 
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""
+
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "مهلة تصفير الإعدادات (ساعات)"

--- a/safeeyes/config/locale/bg/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/bg/LC_MESSAGES/safeeyes.po
@@ -527,3 +527,22 @@ msgstr ""
 # safeeyes/platform/io.github.slgobinath.SafeEyes.desktop
 msgid "RSI Prevention"
 msgstr ""
+
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""

--- a/safeeyes/config/locale/bg/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/bg/LC_MESSAGES/safeeyes.po
@@ -541,8 +541,16 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""

--- a/safeeyes/config/locale/ca/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/ca/LC_MESSAGES/safeeyes.po
@@ -545,8 +545,16 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""

--- a/safeeyes/config/locale/ca/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/ca/LC_MESSAGES/safeeyes.po
@@ -531,3 +531,22 @@ msgstr ""
 # safeeyes/platform/io.github.slgobinath.SafeEyes.desktop
 msgid "RSI Prevention"
 msgstr ""
+
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""

--- a/safeeyes/config/locale/cs/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/cs/LC_MESSAGES/safeeyes.po
@@ -538,6 +538,25 @@ msgstr ""
 msgid "RSI Prevention"
 msgstr ""
 
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""
+
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "Interval pro resetování statistik (v hodinách)"

--- a/safeeyes/config/locale/cs/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/cs/LC_MESSAGES/safeeyes.po
@@ -551,10 +551,18 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""
 
 # plugin/healthstats

--- a/safeeyes/config/locale/da/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/da/LC_MESSAGES/safeeyes.po
@@ -531,6 +531,25 @@ msgstr ""
 msgid "RSI Prevention"
 msgstr ""
 
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""
+
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "Interval for nulstilling af statistik (i timer)"

--- a/safeeyes/config/locale/da/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/da/LC_MESSAGES/safeeyes.po
@@ -544,10 +544,18 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""
 
 # plugin/healthstats

--- a/safeeyes/config/locale/de/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/de/LC_MESSAGES/safeeyes.po
@@ -553,11 +553,19 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
 msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
+msgstr "Permanent deaktivieren"
 
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"

--- a/safeeyes/config/locale/de/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/de/LC_MESSAGES/safeeyes.po
@@ -540,6 +540,25 @@ msgstr ""
 msgid "RSI Prevention"
 msgstr ""
 
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""
+
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "Zeit bis die Statistik zurückgesetzt wird (in Stunden)"

--- a/safeeyes/config/locale/en_US/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/en_US/LC_MESSAGES/safeeyes.po
@@ -546,10 +546,18 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""
 
 # plugin/healthstats

--- a/safeeyes/config/locale/en_US/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/en_US/LC_MESSAGES/safeeyes.po
@@ -533,6 +533,25 @@ msgstr "Skipped or postponed %d/%d breaks in a row"
 msgid "RSI Prevention"
 msgstr "RSI Prevention"
 
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""
+
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "Interval to reset statistics (in hours)"

--- a/safeeyes/config/locale/eo/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/eo/LC_MESSAGES/safeeyes.po
@@ -546,10 +546,18 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""
 
 # plugin/healthstats

--- a/safeeyes/config/locale/eo/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/eo/LC_MESSAGES/safeeyes.po
@@ -533,6 +533,25 @@ msgstr ""
 msgid "RSI Prevention"
 msgstr ""
 
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""
+
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "Intertempo por restarigi statistikojn (en horoj)"

--- a/safeeyes/config/locale/es/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/es/LC_MESSAGES/safeeyes.po
@@ -554,10 +554,18 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""
 
 # plugin/healthstats

--- a/safeeyes/config/locale/es/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/es/LC_MESSAGES/safeeyes.po
@@ -541,6 +541,25 @@ msgstr ""
 msgid "RSI Prevention"
 msgstr ""
 
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""
+
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "Intervalo para restablecer estadísticas (en horas)"

--- a/safeeyes/config/locale/et/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/et/LC_MESSAGES/safeeyes.po
@@ -532,6 +532,25 @@ msgstr ""
 msgid "RSI Prevention"
 msgstr ""
 
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""
+
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "Statistika lähtestamise intervall (tundides)"

--- a/safeeyes/config/locale/et/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/et/LC_MESSAGES/safeeyes.po
@@ -545,10 +545,18 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""
 
 # plugin/healthstats

--- a/safeeyes/config/locale/eu/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/eu/LC_MESSAGES/safeeyes.po
@@ -537,3 +537,22 @@ msgstr ""
 # safeeyes/platform/io.github.slgobinath.SafeEyes.desktop
 msgid "RSI Prevention"
 msgstr ""
+
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""

--- a/safeeyes/config/locale/eu/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/eu/LC_MESSAGES/safeeyes.po
@@ -551,8 +551,16 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""

--- a/safeeyes/config/locale/fa/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/fa/LC_MESSAGES/safeeyes.po
@@ -532,6 +532,25 @@ msgstr ""
 msgid "RSI Prevention"
 msgstr ""
 
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""
+
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "فاصله برای تنظیم مجدد آمار (در چند ساعت)"

--- a/safeeyes/config/locale/fa/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/fa/LC_MESSAGES/safeeyes.po
@@ -545,10 +545,18 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""
 
 # plugin/healthstats

--- a/safeeyes/config/locale/fr/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/fr/LC_MESSAGES/safeeyes.po
@@ -558,10 +558,18 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""
 
 # plugin/healthstats

--- a/safeeyes/config/locale/fr/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/fr/LC_MESSAGES/safeeyes.po
@@ -545,6 +545,25 @@ msgstr ""
 msgid "RSI Prevention"
 msgstr ""
 
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""
+
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "Fréquence de réinitialisation (en heures)"

--- a/safeeyes/config/locale/he/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/he/LC_MESSAGES/safeeyes.po
@@ -543,10 +543,18 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""
 
 # plugin/healthstats

--- a/safeeyes/config/locale/he/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/he/LC_MESSAGES/safeeyes.po
@@ -530,6 +530,25 @@ msgstr ""
 msgid "RSI Prevention"
 msgstr ""
 
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""
+
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "הפרש בין איפוסי סטטיסטיקה (בשעות)"

--- a/safeeyes/config/locale/hi/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/hi/LC_MESSAGES/safeeyes.po
@@ -527,3 +527,22 @@ msgstr ""
 # safeeyes/platform/io.github.slgobinath.SafeEyes.desktop
 msgid "RSI Prevention"
 msgstr ""
+
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""

--- a/safeeyes/config/locale/hi/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/hi/LC_MESSAGES/safeeyes.po
@@ -541,8 +541,16 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""

--- a/safeeyes/config/locale/hu/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/hu/LC_MESSAGES/safeeyes.po
@@ -528,3 +528,22 @@ msgstr ""
 # safeeyes/platform/io.github.slgobinath.SafeEyes.desktop
 msgid "RSI Prevention"
 msgstr ""
+
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""

--- a/safeeyes/config/locale/hu/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/hu/LC_MESSAGES/safeeyes.po
@@ -542,8 +542,16 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""

--- a/safeeyes/config/locale/id/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/id/LC_MESSAGES/safeeyes.po
@@ -546,10 +546,18 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""
 
 # plugin/healthstats

--- a/safeeyes/config/locale/id/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/id/LC_MESSAGES/safeeyes.po
@@ -533,6 +533,25 @@ msgstr ""
 msgid "RSI Prevention"
 msgstr ""
 
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""
+
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "Interval untuk mengatur ulang statistik (dalam jam)"

--- a/safeeyes/config/locale/it/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/it/LC_MESSAGES/safeeyes.po
@@ -552,8 +552,16 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""

--- a/safeeyes/config/locale/it/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/it/LC_MESSAGES/safeeyes.po
@@ -538,3 +538,22 @@ msgstr ""
 # safeeyes/platform/io.github.slgobinath.SafeEyes.desktop
 msgid "RSI Prevention"
 msgstr ""
+
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""

--- a/safeeyes/config/locale/kn/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/kn/LC_MESSAGES/safeeyes.po
@@ -526,3 +526,22 @@ msgstr ""
 # safeeyes/platform/io.github.slgobinath.SafeEyes.desktop
 msgid "RSI Prevention"
 msgstr ""
+
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""

--- a/safeeyes/config/locale/kn/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/kn/LC_MESSAGES/safeeyes.po
@@ -540,8 +540,16 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""

--- a/safeeyes/config/locale/ko/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/ko/LC_MESSAGES/safeeyes.po
@@ -540,10 +540,18 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""
 
 # plugin/healthstats

--- a/safeeyes/config/locale/ko/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/ko/LC_MESSAGES/safeeyes.po
@@ -527,6 +527,25 @@ msgstr ""
 msgid "RSI Prevention"
 msgstr ""
 
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""
+
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "통계 초기화 간격 (시)"

--- a/safeeyes/config/locale/lt/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/lt/LC_MESSAGES/safeeyes.po
@@ -553,10 +553,18 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""
 
 # plugin/healthstats

--- a/safeeyes/config/locale/lt/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/lt/LC_MESSAGES/safeeyes.po
@@ -540,6 +540,25 @@ msgstr ""
 msgid "RSI Prevention"
 msgstr ""
 
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""
+
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "Statistikos atstatymo intervalas (valandomis)"

--- a/safeeyes/config/locale/lv/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/lv/LC_MESSAGES/safeeyes.po
@@ -446,5 +446,24 @@ msgstr ""
 msgid "RSI Prevention"
 msgstr ""
 
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""
+
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "Statistikas atstatīšanas intervāls (stundās)"

--- a/safeeyes/config/locale/lv/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/lv/LC_MESSAGES/safeeyes.po
@@ -459,10 +459,18 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""
 
 #~ msgid "Interval to reset statistics (in hours)"

--- a/safeeyes/config/locale/mk/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/mk/LC_MESSAGES/safeeyes.po
@@ -529,3 +529,22 @@ msgstr ""
 # safeeyes/platform/io.github.slgobinath.SafeEyes.desktop
 msgid "RSI Prevention"
 msgstr ""
+
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""

--- a/safeeyes/config/locale/mk/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/mk/LC_MESSAGES/safeeyes.po
@@ -543,8 +543,16 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""

--- a/safeeyes/config/locale/mr/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/mr/LC_MESSAGES/safeeyes.po
@@ -528,3 +528,22 @@ msgstr ""
 # safeeyes/platform/io.github.slgobinath.SafeEyes.desktop
 msgid "RSI Prevention"
 msgstr ""
+
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""

--- a/safeeyes/config/locale/mr/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/mr/LC_MESSAGES/safeeyes.po
@@ -542,8 +542,16 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""

--- a/safeeyes/config/locale/nb/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/nb/LC_MESSAGES/safeeyes.po
@@ -535,6 +535,25 @@ msgstr ""
 msgid "RSI Prevention"
 msgstr ""
 
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""
+
 # plugin/healthstats
 #, fuzzy
 #~ msgid "Interval to reset statistics (in hours)"

--- a/safeeyes/config/locale/nb/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/nb/LC_MESSAGES/safeeyes.po
@@ -548,10 +548,18 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""
 
 # plugin/healthstats

--- a/safeeyes/config/locale/nl/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/nl/LC_MESSAGES/safeeyes.po
@@ -538,6 +538,25 @@ msgstr ""
 msgid "RSI Prevention"
 msgstr ""
 
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""
+
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "Tussenpoos om statistieken te herstellen (in uren)"

--- a/safeeyes/config/locale/nl/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/nl/LC_MESSAGES/safeeyes.po
@@ -551,10 +551,18 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""
 
 # plugin/healthstats

--- a/safeeyes/config/locale/pl/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/pl/LC_MESSAGES/safeeyes.po
@@ -538,6 +538,25 @@ msgstr ""
 msgid "RSI Prevention"
 msgstr ""
 
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""
+
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "Czas do wyzerowania statystyk (w godzinach)"

--- a/safeeyes/config/locale/pl/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/pl/LC_MESSAGES/safeeyes.po
@@ -551,10 +551,18 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""
 
 # plugin/healthstats

--- a/safeeyes/config/locale/pt/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/pt/LC_MESSAGES/safeeyes.po
@@ -549,10 +549,18 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""
 
 # plugin/healthstats

--- a/safeeyes/config/locale/pt/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/pt/LC_MESSAGES/safeeyes.po
@@ -536,6 +536,25 @@ msgstr ""
 msgid "RSI Prevention"
 msgstr ""
 
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""
+
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "Intervalo para reiniciar estatísticas (em horas)"

--- a/safeeyes/config/locale/pt_BR/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/pt_BR/LC_MESSAGES/safeeyes.po
@@ -553,8 +553,16 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""

--- a/safeeyes/config/locale/pt_BR/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/pt_BR/LC_MESSAGES/safeeyes.po
@@ -539,3 +539,22 @@ msgstr ""
 # safeeyes/platform/io.github.slgobinath.SafeEyes.desktop
 msgid "RSI Prevention"
 msgstr ""
+
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""

--- a/safeeyes/config/locale/ru/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/ru/LC_MESSAGES/safeeyes.po
@@ -552,10 +552,18 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""
 
 # plugin/healthstats

--- a/safeeyes/config/locale/ru/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/ru/LC_MESSAGES/safeeyes.po
@@ -539,6 +539,25 @@ msgstr ""
 msgid "RSI Prevention"
 msgstr ""
 
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""
+
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "Интервал для сброса статистики (в часах)"

--- a/safeeyes/config/locale/safeeyes.pot
+++ b/safeeyes/config/locale/safeeyes.pot
@@ -524,8 +524,14 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid "Please install the dependencies or disable the plugin. To hide this message, you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""

--- a/safeeyes/config/locale/safeeyes.pot
+++ b/safeeyes/config/locale/safeeyes.pot
@@ -511,3 +511,21 @@ msgstr ""
 # safeeyes/platform/io.github.slgobinath.SafeEyes.desktop
 msgid "RSI Prevention"
 msgstr ""
+
+msgid "Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""

--- a/safeeyes/config/locale/sk/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/sk/LC_MESSAGES/safeeyes.po
@@ -549,8 +549,16 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""

--- a/safeeyes/config/locale/sk/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/sk/LC_MESSAGES/safeeyes.po
@@ -535,3 +535,22 @@ msgstr ""
 # safeeyes/platform/io.github.slgobinath.SafeEyes.desktop
 msgid "RSI Prevention"
 msgstr ""
+
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""

--- a/safeeyes/config/locale/sr/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/sr/LC_MESSAGES/safeeyes.po
@@ -556,8 +556,16 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""

--- a/safeeyes/config/locale/sr/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/sr/LC_MESSAGES/safeeyes.po
@@ -542,3 +542,22 @@ msgstr ""
 # safeeyes/platform/io.github.slgobinath.SafeEyes.desktop
 msgid "RSI Prevention"
 msgstr ""
+
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""

--- a/safeeyes/config/locale/sv/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/sv/LC_MESSAGES/safeeyes.po
@@ -532,6 +532,25 @@ msgstr ""
 msgid "RSI Prevention"
 msgstr ""
 
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""
+
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "Intervall för att återställa statistik (i timmar)"

--- a/safeeyes/config/locale/sv/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/sv/LC_MESSAGES/safeeyes.po
@@ -545,10 +545,18 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""
 
 # plugin/healthstats

--- a/safeeyes/config/locale/ta/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/ta/LC_MESSAGES/safeeyes.po
@@ -535,6 +535,25 @@ msgstr ""
 msgid "RSI Prevention"
 msgstr ""
 
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""
+
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "திரை நேரத்தை  மீட்டமைப்பதற்கான  இடைவேளை (மணித்தியாலங்களில்)"

--- a/safeeyes/config/locale/ta/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/ta/LC_MESSAGES/safeeyes.po
@@ -548,10 +548,18 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""
 
 # plugin/healthstats

--- a/safeeyes/config/locale/tr/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/tr/LC_MESSAGES/safeeyes.po
@@ -549,10 +549,18 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""
 
 # plugin/healthstats

--- a/safeeyes/config/locale/tr/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/tr/LC_MESSAGES/safeeyes.po
@@ -536,6 +536,25 @@ msgstr ""
 msgid "RSI Prevention"
 msgstr ""
 
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""
+
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "İstatistikleri sıfırlama aralığı (saat olarak)"

--- a/safeeyes/config/locale/ug/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/ug/LC_MESSAGES/safeeyes.po
@@ -523,3 +523,22 @@ msgstr ""
 # safeeyes/platform/io.github.slgobinath.SafeEyes.desktop
 msgid "RSI Prevention"
 msgstr ""
+
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""

--- a/safeeyes/config/locale/ug/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/ug/LC_MESSAGES/safeeyes.po
@@ -537,8 +537,16 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""

--- a/safeeyes/config/locale/uk/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/uk/LC_MESSAGES/safeeyes.po
@@ -539,6 +539,25 @@ msgstr ""
 msgid "RSI Prevention"
 msgstr ""
 
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""
+
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "Інтервал скидання статистики (в годинах)"

--- a/safeeyes/config/locale/uk/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/uk/LC_MESSAGES/safeeyes.po
@@ -552,10 +552,18 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""
 
 # plugin/healthstats

--- a/safeeyes/config/locale/uz_Latn/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/uz_Latn/LC_MESSAGES/safeeyes.po
@@ -523,3 +523,22 @@ msgstr ""
 # safeeyes/platform/io.github.slgobinath.SafeEyes.desktop
 msgid "RSI Prevention"
 msgstr ""
+
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""

--- a/safeeyes/config/locale/uz_Latn/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/uz_Latn/LC_MESSAGES/safeeyes.po
@@ -537,8 +537,16 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""

--- a/safeeyes/config/locale/vi/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/vi/LC_MESSAGES/safeeyes.po
@@ -546,8 +546,16 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""

--- a/safeeyes/config/locale/vi/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/vi/LC_MESSAGES/safeeyes.po
@@ -532,3 +532,22 @@ msgstr ""
 # safeeyes/platform/io.github.slgobinath.SafeEyes.desktop
 msgid "RSI Prevention"
 msgstr ""
+
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""

--- a/safeeyes/config/locale/zh_CN/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/zh_CN/LC_MESSAGES/safeeyes.po
@@ -541,10 +541,18 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""
 
 # plugin/healthstats

--- a/safeeyes/config/locale/zh_CN/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/zh_CN/LC_MESSAGES/safeeyes.po
@@ -528,6 +528,25 @@ msgstr ""
 msgid "RSI Prevention"
 msgstr ""
 
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""
+
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "重置统计间隔（小时）"

--- a/safeeyes/config/locale/zh_TW/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/zh_TW/LC_MESSAGES/safeeyes.po
@@ -538,10 +538,18 @@ msgstr ""
 msgid "The required plugin '%s' is missing dependencies!"
 msgstr ""
 
-msgid "Please install the dependencies or disable the plugin."
+msgid ""
+"Please install the dependencies or disable the plugin. To hide this message, "
+"you can also deactivate the plugin in the settings."
 msgstr ""
 
 msgid "Click here for more information"
+msgstr ""
+
+msgid "Disable plugin temporarily"
+msgstr ""
+
+msgid "Disable permanently"
 msgstr ""
 
 # plugin/healthstats

--- a/safeeyes/config/locale/zh_TW/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/zh_TW/LC_MESSAGES/safeeyes.po
@@ -525,6 +525,25 @@ msgstr ""
 msgid "RSI Prevention"
 msgstr ""
 
+msgid ""
+"Please install service providing tray icons for your desktop environment."
+msgstr ""
+
+msgid "Next long break at %s"
+msgstr ""
+
+msgid "Next breaks at %s/%s"
+msgstr ""
+
+msgid "The required plugin '%s' is missing dependencies!"
+msgstr ""
+
+msgid "Please install the dependencies or disable the plugin."
+msgstr ""
+
+msgid "Click here for more information"
+msgstr ""
+
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "重置數據間隔（時）"

--- a/safeeyes/config/style/safeeyes_style.css
+++ b/safeeyes/config/style/safeeyes_style.css
@@ -90,6 +90,10 @@
     color: #9B9B9B;
 }
 
+.btn_plugin_extra_link {
+    padding-left: 0px;
+}
+
 .info_bar_long_break {
     opacity: 0.9;
     border-radius: 5px;

--- a/safeeyes/glade/item_plugin.glade
+++ b/safeeyes/glade/item_plugin.glade
@@ -91,6 +91,20 @@
             <property name="position">1</property>
           </packing>
         </child>
+        <child>
+          <object class="GtkLinkButton" id="btn_plugin_extra_link">
+            <property name="label" translatable="yes">Click here for more information</property>
+            <property name="uri">https://slgobinath.github.io/SafeEyes</property>
+            <property name="visible">0</property>
+            <property name="margin-start">0</property>
+            <property name="margin-top">5</property>
+            <property name="margin-bottom">5</property>
+            <property name="halign">start</property>
+            <style>
+              <class name="btn_plugin_extra_link"/>
+            </style>
+          </object>
+        </child>
       </object>
       <packing>
         <property name="expand">True</property>

--- a/safeeyes/glade/item_plugin.glade
+++ b/safeeyes/glade/item_plugin.glade
@@ -26,6 +26,11 @@
     <property name="can_focus">False</property>
     <property name="stock">gtk-properties</property>
   </object>
+  <object class="GtkImage" id="img_disable">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon-name">_Cancel</property>
+  </object>
   <object class="GtkBox" id="box">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -124,11 +129,19 @@
             <property name="halign">end</property>
             <property name="valign">center</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="btn_disable_errored">
+            <property name="visible">False</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+            <property name="image">img_disable</property>
+            <property name="tooltip-text" translatable="yes">Disable permanently</property>
+            <property name="always_show_image">True</property>
+            <style>
+              <class name="btn_circle"/>
+            </style>
+          </object>
         </child>
         <child>
           <object class="GtkButton" id="btn_properties">
@@ -143,11 +156,6 @@
               <class name="btn_circle"/>
             </style>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">1</property>
-          </packing>
         </child>
       </object>
       <packing>

--- a/safeeyes/glade/required_plugin_dialog.glade
+++ b/safeeyes/glade/required_plugin_dialog.glade
@@ -67,15 +67,15 @@
                 <property name="label" translatable="yes">Click here for more information</property>
                 <property name="uri">https://slgobinath.github.io/SafeEyes</property>
                 <property name="visible">0</property>
-                <property name="margin-top">5</property>
-                <property name="margin-bottom">5</property>
               </object>
             </child>
             <child>
               <object class="GtkLabel" id="lbl_main">
-                <property name="margin-top">5</property>
-                <property name="margin-bottom">5</property>
-                <property name="label" translatable="1">Please install the dependencies or disable the plugin.</property>
+                <property name="margin">5</property>
+                <property name="wrap">1</property>
+                <property name="justify">center</property>
+                <property name="max-width-chars">60</property>
+                <property name="label" translatable="1">Please install the dependencies or disable the plugin. To hide this message, you can also deactivate the plugin in the settings.</property>
                 <attributes>
                   <attribute name="style" value="normal"></attribute>
                 </attributes>
@@ -106,7 +106,7 @@
             </child>
             <child>
               <object class="GtkButton" id="btn_disable_plugin">
-                <property name="label" translatable="1">Disable plugin</property>
+                <property name="label" translatable="1">Disable plugin temporarily</property>
               </object>
             </child>
           </object>

--- a/safeeyes/glade/required_plugin_dialog.glade
+++ b/safeeyes/glade/required_plugin_dialog.glade
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.18.3 -->
+<!--
+~ Safe Eyes is a utility to remind you to take break frequently
+~ to protect your eyes from eye strain.
+
+~ Copyright (C) 2016  Gobinath
+
+~ This program is free software: you can redistribute it and/or modify
+~ it under the terms of the GNU General Public License as published by
+~ the Free Software Foundation, either version 3 of the License, or
+~ (at your option) any later version.
+
+~ This program is distributed in the hope that it will be useful,
+~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+~ GNU General Public License for more details.
+
+~ You should have received a copy of the GNU General Public License
+~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<interface>
+  <requires lib="gtk+" version="3.12"/>
+  <object class="GtkWindow" id="window_required_plugin">
+    <property name="title" translatable="1">Safe Eyes - Error</property>
+    <property name="resizable">0</property>
+    <property name="icon-name">safeeyes</property>
+    <child>
+      <object class="GtkBox" id="layout_box">
+        <property name="margin-start">5</property>
+        <property name="margin-end">5</property>
+        <property name="margin-top">5</property>
+        <property name="margin-bottom">5</property>
+        <property name="hexpand">1</property>
+        <property name="vexpand">1</property>
+        <property name="orientation">vertical</property>
+        <property name="baseline-position">top</property>
+        <child>
+          <object class="GtkBox" id="box1">
+            <property name="valign">start</property>
+            <property name="hexpand">1</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel" id="lbl_header">
+                <property name="justify">center</property>
+                <property name="margin-top">10</property>
+                <property name="margin-bottom">10</property>
+                <property name="label" translatable="1">A required plugin is missing dependencies!</property>
+                <attributes>
+                  <attribute name="style" value="normal"></attribute>
+                  <attribute name="weight" value="bold"></attribute>
+                </attributes>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="lbl_message">
+                <property name="margin-top">5</property>
+                <property name="margin-bottom">5</property>
+                <property name="label" translatable="1"></property>
+                <attributes>
+                  <attribute name="style" value="normal"></attribute>
+                </attributes>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="lbl_main">
+                <property name="margin-top">5</property>
+                <property name="margin-bottom">5</property>
+                <property name="label" translatable="1">Please install the dependencies or disable the plugin.</property>
+                <attributes>
+                  <attribute name="style" value="normal"></attribute>
+                </attributes>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkSeparator" id="separator">
+            <property name="margin_top">5</property>
+            <property name="margin_bottom">5</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox" id="buttonbox">
+            <property name="valign">start</property>
+            <property name="halign">end</property>
+            <property name="margin-end">5</property>
+            <property name="vexpand">1</property>
+            <property name="homogeneous">1</property>
+            <property name="spacing">5</property>
+            <child>
+              <object class="GtkButton" id="btn_close">
+                <property name="label" translatable="1">Quit</property>
+                <property name="receives-default">1</property>
+                <property name="vexpand">1</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkButton" id="btn_disable_plugin">
+                <property name="label" translatable="1">Disable plugin</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/safeeyes/glade/required_plugin_dialog.glade
+++ b/safeeyes/glade/required_plugin_dialog.glade
@@ -63,6 +63,15 @@
               </object>
             </child>
             <child>
+              <object class="GtkLinkButton" id="btn_extra_link">
+                <property name="label" translatable="yes">Click here for more information</property>
+                <property name="uri">https://slgobinath.github.io/SafeEyes</property>
+                <property name="visible">0</property>
+                <property name="margin-top">5</property>
+                <property name="margin-bottom">5</property>
+              </object>
+            </child>
+            <child>
               <object class="GtkLabel" id="lbl_main">
                 <property name="margin-top">5</property>
                 <property name="margin-bottom">5</property>

--- a/safeeyes/glade/required_plugin_dialog.glade
+++ b/safeeyes/glade/required_plugin_dialog.glade
@@ -24,7 +24,7 @@
   <object class="GtkWindow" id="window_required_plugin">
     <property name="title" translatable="1">Safe Eyes - Error</property>
     <property name="resizable">0</property>
-    <property name="icon-name">safeeyes</property>
+    <property name="icon-name">io.github.slgobinath.SafeEyes</property>
     <child>
       <object class="GtkBox" id="layout_box">
         <property name="margin-start">5</property>

--- a/safeeyes/model.py
+++ b/safeeyes/model.py
@@ -23,6 +23,7 @@ This module contains the entity classes used by Safe Eyes and its plugins.
 import logging
 import random
 from enum import Enum
+from dataclasses import dataclass
 
 from packaging.version import parse
 
@@ -420,9 +421,19 @@ class TrayAction:
         else:
             return TrayAction(name, icon_path, action, False)
 
+@dataclass
+class PluginDependency:
+    message: str
+    link: str|None = None
+
 class RequiredPluginException(Exception):
-    def __init__(self, plugin_id, plugin_name, message):
-        super().__init__(message)
+    def __init__(self, plugin_id, plugin_name: str, message: str|PluginDependency):
+        if isinstance(message, PluginDependency):
+            msg = message.message
+        else:
+            msg = message
+
+        super().__init__(msg)
 
         self.plugin_id = plugin_id
         self.plugin_name = plugin_name

--- a/safeeyes/model.py
+++ b/safeeyes/model.py
@@ -419,3 +419,20 @@ class TrayAction:
             return TrayAction(name, icon_id, action, True)
         else:
             return TrayAction(name, icon_path, action, False)
+
+class RequiredPluginException(Exception):
+    def __init__(self, plugin_id, plugin_name, message):
+        super().__init__(message)
+
+        self.plugin_id = plugin_id
+        self.plugin_name = plugin_name
+        self.message = message
+
+    def get_plugin_id(self):
+        return self.plugin_id
+
+    def get_plugin_name(self):
+        return self.plugin_name
+
+    def get_message(self):
+        return self.message

--- a/safeeyes/plugin_manager.py
+++ b/safeeyes/plugin_manager.py
@@ -303,7 +303,7 @@ class PluginManager:
                 # Check for dependencies
                 message = utility.check_plugin_dependencies(plugin['id'], plugin_config, plugin.get('settings', {}), plugin_path)
                 if message:
-                    if plugin_config['required_plugin']:
+                    if plugin_config.get('required_plugin', False):
                         raise RequiredPluginException(
                             plugin['id'],
                             plugin_config['meta']['name'],

--- a/safeeyes/plugins/mediacontrol/config.json
+++ b/safeeyes/plugins/mediacontrol/config.json
@@ -5,7 +5,7 @@
         "version": "0.0.1"
     },
     "dependencies": {
-        "python_modules": ["dbus"],
+        "python_modules": [],
         "shell_commands": [],
         "operating_systems": [],
         "desktop_environments": [],

--- a/safeeyes/plugins/trayicon/config.json
+++ b/safeeyes/plugins/trayicon/config.json
@@ -11,6 +11,7 @@
         "desktop_environments": [],
         "resources": []
     },
+    "required_plugin": true,
     "settings": [
         {
             "id": "show_time_in_tray",

--- a/safeeyes/plugins/trayicon/dependency_checker.py
+++ b/safeeyes/plugins/trayicon/dependency_checker.py
@@ -1,0 +1,58 @@
+# Safe Eyes is a utility to remind you to take break frequently
+# to protect your eyes from eye strain.
+
+# Copyright (C) 2017  Gobinath
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from safeeyes import utility
+
+import gi
+gi.require_version('Gio', '2.0')
+from gi.repository import Gio
+
+def validate(plugin_config, plugin_settings):
+    dbus_proxy = Gio.DBusProxy.new_for_bus_sync(
+        bus_type=Gio.BusType.SESSION,
+        flags=Gio.DBusProxyFlags.DO_NOT_LOAD_PROPERTIES,
+        info=None,
+        name='org.freedesktop.DBus',
+        object_path='/org/freedesktop/DBus',
+        interface_name='org.freedesktop.DBus',
+        cancellable=None,
+    )
+
+    if dbus_proxy.NameHasOwner('(s)', 'org.kde.StatusNotifierWatcher'):
+        return None
+    else:
+        if utility.DESKTOP_ENVIRONMENT == "gnome":
+            return _("Please install a gnome shell plugin providing tray icons, eg. 'Tray Icons Reloaded'")
+        elif utility.IS_WAYLAND:
+            return _("Please install a plugin providing tray icons for your desktop environment")
+        elif utility.DESKTOP_ENVIRONMENT == "lxde":
+            return _("Please install the 'snixembed' service")
+        else:
+            return _("Please install the 'snixembed' service, or a plugin providing tray icons for your desktop environment")
+
+    command = None
+    if utility.IS_WAYLAND:
+        if utility.DESKTOP_ENVIRONMENT == "gnome":
+            return None
+        command = "wlrctl"
+    else:
+        command = "xprop"
+    if not utility.command_exist(command):
+        return _("Please install the command-line tool '%s'") % command
+    else:
+        return None

--- a/safeeyes/plugins/trayicon/dependency_checker.py
+++ b/safeeyes/plugins/trayicon/dependency_checker.py
@@ -37,13 +37,13 @@ def validate(plugin_config, plugin_settings):
         return None
     else:
         if utility.DESKTOP_ENVIRONMENT == "gnome":
-            return _("Please install a gnome shell plugin providing tray icons, eg. 'Tray Icons Reloaded'")
+            return _("Please install a gnome shell plugin providing tray icons, eg. 'Tray Icons Reloaded'.")
         elif utility.IS_WAYLAND:
-            return _("Please install a plugin providing tray icons for your desktop environment")
+            return _("Please install a service providing tray icons for your desktop environment.")
         elif utility.DESKTOP_ENVIRONMENT == "lxde":
-            return _("Please install the 'snixembed' service")
+            return _("Please install the 'snixembed' service.")
         else:
-            return _("Please install the 'snixembed' service, or a plugin providing tray icons for your desktop environment")
+            return _("Please install the 'snixembed' service, or a service providing tray icons for your desktop environment.")
 
     command = None
     if utility.IS_WAYLAND:

--- a/safeeyes/plugins/trayicon/dependency_checker.py
+++ b/safeeyes/plugins/trayicon/dependency_checker.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from safeeyes import utility
+from safeeyes.model import PluginDependency
 
 import gi
 gi.require_version('Gio', '2.0')
@@ -36,14 +37,10 @@ def validate(plugin_config, plugin_settings):
     if dbus_proxy.NameHasOwner('(s)', 'org.kde.StatusNotifierWatcher'):
         return None
     else:
-        if utility.DESKTOP_ENVIRONMENT == "gnome":
-            return _("Please install a gnome shell plugin providing tray icons, eg. 'Tray Icons Reloaded'.")
-        elif utility.IS_WAYLAND:
-            return _("Please install a service providing tray icons for your desktop environment.")
-        elif utility.DESKTOP_ENVIRONMENT == "lxde":
-            return _("Please install the 'snixembed' service.")
-        else:
-            return _("Please install the 'snixembed' service, or a service providing tray icons for your desktop environment.")
+        return PluginDependency(
+            message=_("Please install service providing tray icons for your desktop environment."),
+            link="https://github.com/slgobinath/SafeEyes/wiki/How-to-install-backend-for-Safe-Eyes-tray-icon"
+        )
 
     command = None
     if utility.IS_WAYLAND:

--- a/safeeyes/plugins/trayicon/plugin.py
+++ b/safeeyes/plugins/trayicon/plugin.py
@@ -341,11 +341,11 @@ class StatusNotifierItemService(DBusService):
 
     Category = 'ApplicationStatus'
     Id = 'io.github.slgobinath.SafeEyes'
-    Title = _('Safe Eyes')
+    Title = 'Safe Eyes'
     Status = 'Active'
     IconName = 'io.github.slgobinath.SafeEyes-enabled'
     IconThemePath = ''
-    ToolTip = ('', [], _('Safe Eyes'), '')
+    ToolTip = ('', [], 'Safe Eyes', '')
     ItemIsMenu = True
     Menu = None
 
@@ -447,7 +447,7 @@ class TrayIcon:
     def get_items(self):
         breaks_found = self.has_breaks()
 
-        info_message = _('No breaks available')
+        info_message = _('No Breaks Available')
 
         if breaks_found:
             if self.active:
@@ -546,17 +546,17 @@ class TrayIcon:
                 'children': [
                     {
                         'id': 9,
-                        'label': _('Any Break'),
+                        'label': _('Any break'),
                         'callback': lambda: self.on_manual_break_clicked(None),
                     },
                     {
                         'id': 10,
-                        'label': _('Short Break'),
+                        'label': _('Short break'),
                         'callback': lambda: self.on_manual_break_clicked(BreakType.SHORT_BREAK),
                     },
                     {
                         'id': 11,
-                        'label': _('Long Break'),
+                        'label': _('Long break'),
                         'callback': lambda: self.on_manual_break_clicked(BreakType.LONG_BREAK),
                     },
                 ]
@@ -597,7 +597,7 @@ class TrayIcon:
         else:
             description = ''
 
-        self.sni_service.set_tooltip(_('Safe Eyes'), description)
+        self.sni_service.set_tooltip('Safe Eyes', description)
 
     def quit_safe_eyes(self):
         """

--- a/safeeyes/plugins/trayicon/plugin.py
+++ b/safeeyes/plugins/trayicon/plugin.py
@@ -337,7 +337,7 @@ class DBusMenuService(DBusService):
         )
 
 class StatusNotifierItemService(DBusService):
-    DBUS_SERVICE_PATH = '/io/github/slgobinath/SafeEyes'
+    DBUS_SERVICE_PATH = '/org/ayatana/NotificationItem/io_github_slgobinath_SafeEyes'
 
     Category = 'ApplicationStatus'
     Id = 'io.github.slgobinath.SafeEyes'

--- a/safeeyes/safeeyes.py
+++ b/safeeyes/safeeyes.py
@@ -156,9 +156,6 @@ class SafeEyes(Gtk.Application):
             settings_dialog.show()
 
     def show_required_plugin_dialog(self, plugin_id, plugin_name, message):
-        """
-        Listen to tray icon About action and send the signal to About dialog.
-        """
         logging.info("Show RequiredPlugin dialog")
         dialog = RequiredPluginDialog(
             plugin_id,
@@ -170,15 +167,14 @@ class SafeEyes(Gtk.Application):
         dialog.show()
 
     def disable_plugin(self, plugin_id):
+        """
+        Temporarily disable plugin, and restart SafeEyes.
+        """
         config = self.config.clone()
 
         for plugin in config.get('plugins'):
             if plugin['id'] == plugin_id:
                 plugin['enabled'] = False
-
-        logging.info("Saving settings to safeeyes.json")
-
-        config.save()
 
         self.required_plugin_dialog_active = False
 

--- a/safeeyes/safeeyes.py
+++ b/safeeyes/safeeyes.py
@@ -29,7 +29,8 @@ import gi
 from safeeyes import utility
 from safeeyes.ui.about_dialog import AboutDialog
 from safeeyes.ui.break_screen import BreakScreen
-from safeeyes.model import State
+from safeeyes.ui.required_plugin_dialog import RequiredPluginDialog
+from safeeyes.model import State, RequiredPluginException
 from safeeyes.rpc import RPCServer
 from safeeyes.plugin_manager import PluginManager
 from safeeyes.core import SafeEyesCore
@@ -45,6 +46,8 @@ class SafeEyes(Gtk.Application):
     """
     This class represents a runnable Safe Eyes instance.
     """
+
+    required_plugin_dialog_active = False
 
     def __init__(self, system_locale, config, cli_args):
         super().__init__(
@@ -100,7 +103,12 @@ class SafeEyes(Gtk.Application):
         self.context['api']['has_breaks'] = self.safe_eyes_core.has_breaks
         self.context['api']['postpone'] = self.safe_eyes_core.postpone
         self.context['api']['get_break_time'] = self.safe_eyes_core.get_break_time
-        self.plugins_manager.init(self.context, self.config)
+
+        try:
+            self.plugins_manager.init(self.context, self.config)
+        except RequiredPluginException as e:
+            self.show_required_plugin_dialog(e.get_plugin_id(), e.get_plugin_name(), e.get_message())
+            self.required_plugin_dialog_active = True
 
         self.hold()
 
@@ -113,7 +121,7 @@ class SafeEyes(Gtk.Application):
         if self.config.get('use_rpc_server', True):
             self.__start_rpc_server()
 
-        if self.safe_eyes_core.has_breaks():
+        if not self.required_plugin_dialog_active and self.safe_eyes_core.has_breaks():
             self.active = True
             self.context['state'] = State.START
             self.plugins_manager.start()		# Call the start method of all plugins
@@ -146,6 +154,35 @@ class SafeEyes(Gtk.Application):
             settings_dialog = SettingsDialog(
                 self.config.clone(), self.save_settings)
             settings_dialog.show()
+
+    def show_required_plugin_dialog(self, plugin_id, plugin_name, message):
+        """
+        Listen to tray icon About action and send the signal to About dialog.
+        """
+        logging.info("Show RequiredPlugin dialog")
+        dialog = RequiredPluginDialog(
+            plugin_id,
+            plugin_name,
+            message,
+            self.quit,
+            lambda: self.disable_plugin(plugin_id)
+        )
+        dialog.show()
+
+    def disable_plugin(self, plugin_id):
+        config = self.config.clone()
+
+        for plugin in config.get('plugins'):
+            if plugin['id'] == plugin_id:
+                plugin['enabled'] = False
+
+        logging.info("Saving settings to safeeyes.json")
+
+        config.save()
+
+        self.required_plugin_dialog_active = False
+
+        self.restart(config, set_active=True)
 
     def show_about(self):
         """
@@ -246,6 +283,9 @@ class SafeEyes(Gtk.Application):
         config.save()
         self.persist_session()
 
+        self.restart(config)
+
+    def restart(self, config, set_active=False):
         logging.info("Initialize SafeEyesCore with modified settings")
 
         if self.rpc_server is None and config.get('use_rpc_server'):
@@ -259,7 +299,17 @@ class SafeEyes(Gtk.Application):
         self.config = config
         self.safe_eyes_core.initialize(config)
         self.break_screen.initialize(config)
-        self.plugins_manager.init(self.context, self.config)
+
+        try:
+            self.plugins_manager.init(self.context, self.config)
+        except RequiredPluginException as e:
+            self.show_required_plugin_dialog(e.get_plugin_id(), e.get_plugin_name(), e.get_message())
+            self.required_plugin_dialog_active = True
+            return
+
+        if set_active:
+            self.active = True
+
         if self.active and self.safe_eyes_core.has_breaks():
             # 1 sec delay is required to give enough time for core to be stopped
             Timer(1.0, self.safe_eyes_core.start).start()
@@ -269,7 +319,7 @@ class SafeEyes(Gtk.Application):
         """
         Listen to tray icon enable action and send the signal to core.
         """
-        if not self.active and self.safe_eyes_core.has_breaks():
+        if not self.required_plugin_dialog_active and not self.active and self.safe_eyes_core.has_breaks():
             self.active = True
             self.safe_eyes_core.start(scheduled_next_break_time, reset_breaks)
             self.plugins_manager.start()

--- a/safeeyes/ui/required_plugin_dialog.py
+++ b/safeeyes/ui/required_plugin_dialog.py
@@ -23,6 +23,7 @@ This module creates the RequiredPluginDialog which shows the error for a require
 import os
 
 from safeeyes import utility
+from safeeyes.model import PluginDependency
 
 REQUIRED_PLUGIN_DIALOG_GLADE = os.path.join(utility.BIN_DIRECTORY, "glade/required_plugin_dialog.glade")
 
@@ -47,7 +48,14 @@ class RequiredPluginDialog:
 
         builder.get_object('lbl_main').set_label(_("Please install the dependencies or disable the plugin."))
 
-        builder.get_object('lbl_message').set_label(message)
+        if isinstance(message, PluginDependency):
+            builder.get_object('lbl_message').set_label(_(message.message))
+            btn_extra_link = builder.get_object('btn_extra_link')
+            btn_extra_link.set_label(_("Click here for more information"))
+            btn_extra_link.set_uri(message.link)
+            btn_extra_link.set_visible(True)
+        else:
+            builder.get_object('lbl_message').set_label(_(message))
 
     def show(self):
         """

--- a/safeeyes/ui/required_plugin_dialog.py
+++ b/safeeyes/ui/required_plugin_dialog.py
@@ -46,7 +46,10 @@ class RequiredPluginDialog:
 
         builder.get_object('lbl_header').set_label(_("The required plugin '%s' is missing dependencies!") % _(plugin_name))
 
-        builder.get_object('lbl_main').set_label(_("Please install the dependencies or disable the plugin."))
+        builder.get_object('lbl_main').set_label(_("Please install the dependencies or disable the plugin. To hide this message, you can also deactivate the plugin in the settings."))
+
+        builder.get_object('btn_close').set_label(_("Quit"))
+        builder.get_object('btn_disable_plugin').set_label(_("Disable plugin temporarily"))
 
         if isinstance(message, PluginDependency):
             builder.get_object('lbl_message').set_label(_(message.message))

--- a/safeeyes/ui/required_plugin_dialog.py
+++ b/safeeyes/ui/required_plugin_dialog.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+# Safe Eyes is a utility to remind you to take break frequently
+# to protect your eyes from eye strain.
+
+# Copyright (C) 2016  Gobinath
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+This module creates the RequiredPluginDialog which shows the error for a required plugin.
+"""
+
+import os
+
+from safeeyes import utility
+
+REQUIRED_PLUGIN_DIALOG_GLADE = os.path.join(utility.BIN_DIRECTORY, "glade/required_plugin_dialog.glade")
+
+
+class RequiredPluginDialog:
+    """
+    RequiredPluginDialog shows an error when a plugin has required dependencies.
+    """
+
+    def __init__(self, plugin_id, plugin_name, message, on_quit, on_disable_plugin):
+        self.on_quit = on_quit
+        self.on_disable_plugin = on_disable_plugin
+
+        builder = utility.create_gtk_builder(REQUIRED_PLUGIN_DIALOG_GLADE)
+        self.window = builder.get_object('window_required_plugin')
+
+        self.window.connect("delete-event", self.on_window_delete)
+        builder.get_object('btn_close').connect('clicked', self.on_close_clicked)
+        builder.get_object('btn_disable_plugin').connect('clicked', self.on_disable_plugin_clicked)
+
+        builder.get_object('lbl_header').set_label(_("The required plugin '%s' is missing dependencies!") % _(plugin_name))
+
+        builder.get_object('lbl_main').set_label(_("Please install the dependencies or disable the plugin."))
+
+        builder.get_object('lbl_message').set_label(message)
+
+    def show(self):
+        """
+        Show the dialog.
+        """
+        self.window.show_all()
+
+    def on_window_delete(self, *args):
+        """
+        Window close event handler.
+        """
+        self.window.destroy()
+        self.on_quit()
+
+    def on_close_clicked(self, *args):
+        self.window.destroy()
+        self.on_quit()
+
+    def on_disable_plugin_clicked(self, *args):
+        self.window.destroy()
+        self.on_disable_plugin()

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -21,7 +21,7 @@ import os
 
 import gi
 from safeeyes import utility
-from safeeyes.model import Config
+from safeeyes.model import Config, PluginDependency
 
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
@@ -220,7 +220,15 @@ class SettingsDialog:
         lbl_plugin_name.set_label(_(plugin_config['meta']['name']))
         switch_enable.set_active(plugin_config['enabled'])
         if plugin_config['error']:
-            lbl_plugin_description.set_label(_(plugin_config['meta']['description']))
+            message = plugin_config['meta']['dependency_description']
+            if isinstance(message, PluginDependency):
+                lbl_plugin_description.set_label(_(message.message))
+                btn_plugin_extra_link = builder.get_object('btn_plugin_extra_link')
+                btn_plugin_extra_link.set_label(_("Click here for more information"))
+                btn_plugin_extra_link.set_uri(message.link)
+                btn_plugin_extra_link.set_visible(True)
+            else:
+                lbl_plugin_description.set_label(_(message))
             lbl_plugin_name.set_sensitive(False)
             lbl_plugin_description.set_sensitive(False)
             switch_enable.set_sensitive(False)
@@ -258,7 +266,7 @@ class SettingsDialog:
         """
         Show the SettingsDialog.
         """
-        self.window.show_all()
+        self.window.show()
 
     def on_switch_postpone_activate(self, switch, state):
         """

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -232,18 +232,24 @@ class SettingsDialog:
             lbl_plugin_name.set_sensitive(False)
             lbl_plugin_description.set_sensitive(False)
             switch_enable.set_sensitive(False)
+            btn_properties.set_sensitive(False)
+            if plugin_config['enabled']:
+                btn_disable_errored = builder.get_object('btn_disable_errored')
+                btn_disable_errored.set_visible(True)
+                btn_disable_errored.connect('clicked', lambda button: self.__disable_errored_plugin(button, plugin_config))
+
         else:
             lbl_plugin_description.set_label(_(plugin_config['meta']['description']))
+            if plugin_config['settings']:
+                btn_properties.set_sensitive(True)
+                btn_properties.connect('clicked', lambda button: self.__show_plugins_properties_dialog(plugin_config))
+            else:
+                btn_properties.set_sensitive(False)
         self.plugin_switches[plugin_config['id']] = switch_enable
         if plugin_config.get('break_override_allowed', False):
             self.plugin_map[plugin_config['id']] = plugin_config['meta']['name']
         if plugin_config['icon']:
             builder.get_object('img_plugin_icon').set_from_file(plugin_config['icon'])
-        if plugin_config['settings']:
-            btn_properties.set_sensitive(True)
-            btn_properties.connect('clicked', lambda button: self.__show_plugins_properties_dialog(plugin_config))
-        else:
-            btn_properties.set_sensitive(False)
         box = builder.get_object('box')
         box.set_visible(True)
         return box
@@ -254,6 +260,13 @@ class SettingsDialog:
         """
         dialog = PluginSettingsDialog(plugin_config)
         dialog.show()
+
+    def __disable_errored_plugin(self, button, plugin_config):
+        """
+        Permanently disable errored plugin
+        """
+        button.set_sensitive(False)
+        self.plugin_switches[plugin_config['id']].set_active(False)
 
     def __show_break_properties_dialog(self, break_config, is_short, parent, on_close, on_add, on_remove):
         """

--- a/safeeyes/utility.py
+++ b/safeeyes/utility.py
@@ -241,7 +241,6 @@ def load_plugins_config(safeeyes_config):
             continue
         dependency_description = check_plugin_dependencies(plugin['id'], config, plugin.get('settings', {}), plugin_path)
         if dependency_description:
-            plugin['enabled'] = False
             config['error'] = True
             config['meta']['dependency_description'] = dependency_description
             icon = get_resource_path('ic_warning.png')

--- a/safeeyes/utility.py
+++ b/safeeyes/utility.py
@@ -243,7 +243,7 @@ def load_plugins_config(safeeyes_config):
         if dependency_description:
             plugin['enabled'] = False
             config['error'] = True
-            config['meta']['description'] = dependency_description
+            config['meta']['dependency_description'] = dependency_description
             icon = get_resource_path('ic_warning.png')
         else:
             config['error'] = False

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ requires = [
     'babel',
     'psutil',
     'croniter',
-    'dbus-python',
     'PyGObject',
     'packaging',
     'python-xlib'


### PR DESCRIPTION
This is necessary for migrating to gtk4, as gtk4 does not support libappindicator (neither the gtk nor ayatana version, see https://github.com/AyatanaIndicators/libayatana-appindicator/issues/22).

The org.kde.StatusNotifierItem is non-standard, however it seems more likely to be a way forward than libappindicator.
See also https://pagure.io/fedora-workstation/issue/246 for a discussion on this.
For example, this should also work on default ubuntu desktop installs, with GNOME using https://github.com/ubuntu/gnome-shell-extension-appindicator.

Unfortunately, since it is not standardized yet, there is no python library for using it, so this PR needs to create its own bespoke implementation of the DBus interactions.
Additionally, this also drops dbus-python in favor of Gio's dbus.

This is tested in KDE Plasma 5.27, Plasma 6, and GNOME 46 with the [extension](https://github.com/ubuntu/gnome-shell-extension-appindicator).