### PR TITLE
port to gtk4

### DIFF
--- a/safeeyes/glade/about_dialog.glade
+++ b/safeeyes/glade/about_dialog.glade
@@ -20,7 +20,7 @@
 ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <interface>
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk" version="4.0"/>
   <object class="GtkTextBuffer" id="text_buffer_license">
     <property name="text">This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -36,176 +36,121 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see &lt;https://www.gnu.org/licenses/&gt;.</property>
   </object>
   <object class="GtkWindow" id="window_about">
-    <property name="can-focus">False</property>
     <property name="title">Safe Eyes</property>
-    <property name="resizable">False</property>
-    <property name="window-position">center-always</property>
+    <property name="resizable">0</property>
     <property name="icon-name">safeeyes</property>
-    <property name="type-hint">dialog</property>
-    <property name="gravity">center</property>
-    <signal name="delete-event" handler="on_window_delete" swapped="no"/>
     <child>
       <object class="GtkBox" id="layout_box">
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <property name="margin-left">5</property>
-        <property name="margin-right">5</property>
+        <property name="visible">1</property>
+        <property name="margin-start">5</property>
+        <property name="margin-end">5</property>
         <property name="margin-top">5</property>
         <property name="margin-bottom">5</property>
-        <property name="hexpand">True</property>
-        <property name="vexpand">True</property>
+        <property name="hexpand">1</property>
+        <property name="vexpand">1</property>
         <property name="orientation">vertical</property>
         <property name="baseline-position">top</property>
         <child>
           <object class="GtkBox" id="box1">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
+            <property name="visible">1</property>
             <property name="valign">start</property>
-            <property name="hexpand">True</property>
+            <property name="hexpand">1</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkLabel" id="lbl_app_name">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="visible">1</property>
                 <property name="halign">center</property>
                 <property name="valign">center</property>
                 <property name="margin-top">10</property>
                 <property name="margin-bottom">10</property>
                 <property name="label">Safe Eyes 2.2.3</property>
                 <property name="justify">center</property>
+                <property name="hexpand">1</property>
+                <property name="vexpand">1</property>
                 <attributes>
                   <attribute name="style" value="normal"/>
                   <attribute name="weight" value="bold"/>
                 </attributes>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
             </child>
             <child>
               <object class="GtkLabel" id="lbl_decription">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="visible">1</property>
                 <property name="margin-top">4</property>
-                <property name="label" translatable="yes">Safe Eyes protects your eyes from eye strain (asthenopia) by reminding you to take breaks while you're working long hours at the computer</property>
+                <property name="label" translatable="yes">Safe Eyes protects your eyes from eye strain (asthenopia) by reminding you to take breaks while you&apos;re working long hours at the computer</property>
                 <property name="justify">fill</property>
-                <property name="wrap">True</property>
+                <property name="wrap">1</property>
                 <property name="width-chars">60</property>
                 <property name="max-width-chars">60</property>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
             </child>
             <child>
               <object class="GtkLabel" id="lbl_license">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="visible">1</property>
                 <property name="halign">start</property>
                 <property name="valign">center</property>
                 <property name="margin-top">10</property>
                 <property name="label" translatable="yes">License:</property>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
             </child>
             <child>
               <object class="GtkTextView" id="txt_license">
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="hexpand">True</property>
-                <property name="vexpand">True</property>
-                <property name="editable">False</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="hexpand">1</property>
+                <property name="vexpand">1</property>
+                <property name="editable">0</property>
                 <property name="wrap-mode">word</property>
                 <property name="buffer">text_buffer_license</property>
-                <property name="accepts-tab">False</property>
+                <property name="accepts-tab">0</property>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">3</property>
-              </packing>
             </child>
             <child>
               <object class="GtkLinkButton" id="btn_url">
                 <property name="label">https://slgobinath.github.io/SafeEyes</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="focus-on-click">False</property>
-                <property name="receives-default">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="focus-on-click">0</property>
+                <property name="receives-default">1</property>
                 <property name="halign">center</property>
-                <property name="relief">none</property>
+                <property name="has-frame">0</property>
                 <property name="uri">https://slgobinath.github.io/SafeEyes</property>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">4</property>
-              </packing>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
         </child>
         <child>
           <object class="GtkSeparator" id="separator">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
+            <property name="visible">1</property>
             <property name="margin-top">5</property>
             <property name="margin-bottom">5</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
         </child>
         <child>
-          <object class="GtkButtonBox" id="buttonbox">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
+          <object class="GtkBox" id="buttonbox">
+            <property name="visible">1</property>
             <property name="valign">start</property>
-            <property name="margin-right">5</property>
+            <property name="margin-end">5</property>
             <child>
               <object class="GtkLinkButton" id="btn_url1">
                 <property name="label" translatable="yes">List of Contributors</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="focus-on-click">False</property>
-                <property name="receives-default">True</property>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="focus-on-click">0</property>
+                <property name="receives-default">1</property>
                 <property name="halign">center</property>
-                <property name="relief">none</property>
                 <property name="uri">https://github.com/slgobinath/SafeEyes/graphs/contributors?type=a</property>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
             </child>
             <child>
               <object class="GtkButton" id="btn_close">
                 <property name="label" translatable="yes">Close</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
-                <signal name="clicked" handler="on_close_clicked" swapped="no"/>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="receives-default">1</property>
+                <property name="hexpand">1</property>
+                <property name="vexpand">1</property>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
             </child>
             <child>
               <object class="GtkLinkButton" id="btn_url2">
@@ -225,11 +170,6 @@ along with this program.  If not, see &lt;https://www.gnu.org/licenses/&gt;.</pr
               </packing>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
-          </packing>
         </child>
       </object>
     </child>

--- a/safeeyes/glade/about_dialog.glade
+++ b/safeeyes/glade/about_dialog.glade
@@ -160,14 +160,9 @@ along with this program.  If not, see &lt;https://www.gnu.org/licenses/&gt;.</pr
                 <property name="focus-on-click">False</property>
                 <property name="receives-default">True</property>
                 <property name="halign">center</property>
-                <property name="relief">none</property>
+                <property name="has-frame">0</property>
                 <property name="uri">https://github.com/slgobinath/SafeEyes?tab=readme-ov-file#how-you-can-help-improving-translation-of-safe-eyes</property>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
             </child>
           </object>
         </child>

--- a/safeeyes/glade/break_screen.glade
+++ b/safeeyes/glade/break_screen.glade
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
 <!--
 ~ Safe Eyes is a utility to remind you to take break frequently
 ~ to protect your eyes from eye strain.
@@ -20,115 +19,84 @@
 ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <interface>
-  <requires lib="gtk+" version="3.12"/>
+  <requires lib="gtk" version="4.0"/>
   <object class="GtkWindow" id="window_main">
-    <property name="can_focus">False</property>
-    <property name="window_position">center</property>
-    <property name="hide_titlebar_when_maximized">True</property>
     <property name="icon_name">safeeyes</property>
-    <property name="skip_taskbar_hint">True</property>
-    <property name="urgency_hint">True</property>
-    <property name="focus_on_map">False</property>
-    <property name="decorated">False</property>
-    <property name="deletable">False</property>
-    <property name="gravity">center</property>
-    <signal name="delete-event" handler="on_window_delete" swapped="no"/>
+    <property name="decorated">0</property>
+    <property name="deletable">0</property>
     <child>
       <placeholder/>
     </child>
-    <child>
+    <property name="child">
       <object class="GtkGrid" id="grid1">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="row_homogeneous">True</property>
-        <property name="column_homogeneous">True</property>
+        <property name="row_homogeneous">1</property>
+        <property name="column_homogeneous">1</property>
         <child>
           <object class="GtkBox" id="box_center_parent">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <property name="spacing">10</property>
             <child>
               <object class="GtkGrid" id="grid_central">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
                 <property name="halign">center</property>
                 <property name="valign">center</property>
                 <property name="row_spacing">10</property>
                 <child>
                   <object class="GtkImage" id="img_break">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <layout>
+                      <property name="column">0</property>
+                      <property name="row">0</property>
+                    </layout>
                   </object>
-                  <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">0</property>
-                  </packing>
                 </child>
                 <child>
                   <object class="GtkGrid" id="grid_parent">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
                     <property name="halign">center</property>
                     <property name="valign">center</property>
-                    <property name="hexpand">True</property>
+                    <property name="hexpand">1</property>
                     <property name="row_spacing">15</property>
                     <child>
                       <object class="GtkLabel" id="lbl_message">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
                         <property name="label">Hello World</property>
                         <property name="justify">center</property>
                         <style>
                           <class name="lbl_message"/>
                         </style>
+                        <layout>
+                          <property name="column">0</property>
+                          <property name="row">0</property>
+                          <property name="column-span">3</property>
+                        </layout>
                       </object>
-                      <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">0</property>
-                        <property name="width">3</property>
-                      </packing>
                     </child>
                     <child>
-                      <object class="GtkAlignment" id="alignment_button">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                      <object class="GtkLabel" id="lbl_count">
                         <property name="halign">center</property>
-                        <property name="yscale">0.20000000298023224</property>
-                        <child>
-                          <object class="GtkLabel" id="lbl_count">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label">00</property>
-                            <style>
-                              <class name="lbl_count"/>
-                            </style>
-                          </object>
-                        </child>
+                        <property name="label">00</property>
+                        <style>
+                          <class name="lbl_count"/>
+                        </style>
+                        <layout>
+                          <property name="column">1</property>
+                          <property name="row">2</property>
+                        </layout>
                       </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">1</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkBox" id="box_buttons">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
                         <property name="halign">center</property>
                         <property name="spacing">50</property>
-                        <property name="homogeneous">True</property>
+                        <property name="homogeneous">1</property>
                         <child>
                           <placeholder/>
                         </child>
                         <child>
                           <placeholder/>
                         </child>
+                        <layout>
+                          <property name="column">1</property>
+                          <property name="row">3</property>
+                        </layout>
                       </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">3</property>
-                      </packing>
                     </child>
                     <child>
                       <placeholder/>
@@ -151,89 +119,62 @@
                     <child>
                       <placeholder/>
                     </child>
+                    <layout>
+                      <property name="column">0</property>
+                      <property name="row">1</property>
+                      <property name="row-span">3</property>
+                    </layout>
                   </object>
-                  <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">1</property>
-                    <property name="height">3</property>
-                  </packing>
                 </child>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
             </child>
             <child>
               <object class="GtkLabel" id="lbl_widget">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="vexpand">1</property>
                 <property name="label">Widget</property>
                 <property name="yalign">0.25</property>
                 <style>
                   <class name="lbl_widget"/>
                 </style>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="pack_type">end</property>
-                <property name="position">1</property>
-              </packing>
             </child>
+            <layout>
+              <property name="column">0</property>
+              <property name="row">1</property>
+              <property name="row-span">2</property>
+            </layout>
           </object>
-          <packing>
-            <property name="left_attach">0</property>
-            <property name="top_attach">1</property>
-            <property name="height">2</property>
-          </packing>
         </child>
         <child>
           <object class="GtkBox" id="box_top_panel">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <child>
-              <object class="GtkToolbar" id="toolbar">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+              <object class="GtkBox" id="toolbar">
+                <property name="css-classes">toolbar</property>
+                <property name="can_focus">0</property>
                 <property name="halign">end</property>
                 <property name="valign">start</property>
-                <property name="toolbar_style">icons</property>
-                <property name="icon_size">2</property>
                 <style>
                   <class name="toolbar"/>
                 </style>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
             </child>
             <child>
               <object class="GtkLabel" id="lbl_top">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="vexpand">1</property>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
             </child>
             <style>
               <class name="box_top_panel"/>
             </style>
+            <layout>
+              <property name="column">0</property>
+              <property name="row">0</property>
+            </layout>
           </object>
-          <packing>
-            <property name="left_attach">0</property>
-            <property name="top_attach">0</property>
-          </packing>
         </child>
       </object>
-    </child>
+    </property>
     <style>
       <class name="window_main"/>
     </style>

--- a/safeeyes/glade/item_bool.glade
+++ b/safeeyes/glade/item_bool.glade
@@ -20,42 +20,31 @@
 ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <interface>
-  <requires lib="gtk+" version="3.12"/>
+  <requires lib="gtk" version="4.0"/>
   <object class="GtkBox" id="box">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="margin_left">5</property>
-    <property name="margin_right">5</property>
-    <property name="margin_top">5</property>
-    <property name="margin_bottom">5</property>
+    <property name="visible">1</property>
+    <property name="margin-start">5</property>
+    <property name="margin-end">5</property>
+    <property name="margin-top">5</property>
+    <property name="margin-bottom">5</property>
     <property name="spacing">10</property>
+    <property name="homogeneous">1</property>
     <child>
       <object class="GtkLabel" id="lbl_name">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="visible">1</property>
         <property name="valign">center</property>
+        <property name="halign">start</property>
         <property name="label">label</property>
         <property name="xalign">0</property>
       </object>
-      <packing>
-        <property name="expand">True</property>
-        <property name="fill">True</property>
-        <property name="position">0</property>
-      </packing>
     </child>
     <child>
       <object class="GtkSwitch" id="switch_value">
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
+        <property name="visible">1</property>
+        <property name="can-focus">1</property>
         <property name="halign">end</property>
         <property name="valign">center</property>
       </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">False</property>
-        <property name="pack_type">end</property>
-        <property name="position">1</property>
-      </packing>
     </child>
   </object>
 </interface>

--- a/safeeyes/glade/item_break.glade
+++ b/safeeyes/glade/item_break.glade
@@ -20,76 +20,49 @@
 ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <interface>
-  <requires lib="gtk+" version="3.12"/>
-  <object class="GtkImage" id="img_properties">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-properties</property>
-  </object>
-  <object class="GtkImage" id="img_delete">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-delete</property>
-  </object>
+  <requires lib="gtk" version="4.0"/>
   <object class="GtkBox" id="box">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="margin_left">5</property>
-    <property name="margin_right">5</property>
-    <property name="margin_top">5</property>
-    <property name="margin_bottom">5</property>
+    <property name="visible">1</property>
+    <property name="margin-start">5</property>
+    <property name="margin-end">5</property>
+    <property name="margin-top">5</property>
+    <property name="margin-bottom">5</property>
     <property name="spacing">3</property>
+    <property name="vexpand">0</property>
     <child>
       <object class="GtkLabel" id="lbl_name">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="visible">1</property>
         <property name="valign">center</property>
         <property name="label">label</property>
         <property name="xalign">0</property>
+        <property name="hexpand">1</property>
+        <property name="vexpand">1</property>
       </object>
-      <packing>
-        <property name="expand">True</property>
-        <property name="fill">True</property>
-        <property name="position">0</property>
-      </packing>
     </child>
     <child>
       <object class="GtkButton" id="btn_properties">
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">True</property>
+        <property name="visible">1</property>
+        <property name="can-focus">1</property>
+        <property name="receives-default">1</property>
         <property name="halign">center</property>
         <property name="valign">center</property>
-        <property name="image">img_properties</property>
-        <property name="always_show_image">True</property>
+        <property name="icon-name">gtk-properties</property>
         <style>
           <class name="btn_circle"/>
         </style>
       </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">1</property>
-      </packing>
     </child>
     <child>
       <object class="GtkButton" id="btn_delete">
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">False</property>
+        <property name="visible">1</property>
+        <property name="can-focus">1</property>
         <property name="halign">center</property>
         <property name="valign">center</property>
-        <property name="image">img_delete</property>
-        <property name="always_show_image">True</property>
+        <property name="icon-name">edit-delete</property>
         <style>
           <class name="btn_circle"/>
         </style>
       </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">2</property>
-      </packing>
     </child>
   </object>
 </interface>

--- a/safeeyes/glade/item_int.glade
+++ b/safeeyes/glade/item_int.glade
@@ -20,47 +20,37 @@
 ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <interface>
-  <requires lib="gtk+" version="3.12"/>
+  <requires lib="gtk" version="4.0"/>
   <object class="GtkAdjustment" id="adjustment_value">
     <property name="upper">100</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkBox" id="box">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="margin_left">5</property>
-    <property name="margin_right">5</property>
-    <property name="margin_top">5</property>
-    <property name="margin_bottom">5</property>
+    <property name="visible">1</property>
+    <property name="margin-start">5</property>
+    <property name="margin-end">5</property>
+    <property name="margin-top">5</property>
+    <property name="margin-bottom">5</property>
     <property name="spacing">10</property>
+    <property name="homogeneous">1</property>
     <child>
       <object class="GtkLabel" id="lbl_name">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="halign">start</property>
+        <property name="visible">1</property>
         <property name="valign">center</property>
         <property name="label">label</property>
         <property name="xalign">0</property>
       </object>
-      <packing>
-        <property name="expand">True</property>
-        <property name="fill">True</property>
-        <property name="position">0</property>
-      </packing>
     </child>
     <child>
       <object class="GtkSpinButton" id="spin_value">
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
+        <property name="visible">1</property>
+        <property name="can-focus">1</property>
         <property name="halign">end</property>
         <property name="valign">center</property>
         <property name="adjustment">adjustment_value</property>
       </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">1</property>
-      </packing>
     </child>
   </object>
 </interface>

--- a/safeeyes/glade/item_plugin.glade
+++ b/safeeyes/glade/item_plugin.glade
@@ -20,81 +20,58 @@
 ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <interface>
-  <requires lib="gtk+" version="3.12"/>
-  <object class="GtkImage" id="img_properties">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-properties</property>
-  </object>
-  <object class="GtkImage" id="img_disable">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon-name">_Cancel</property>
-  </object>
+  <requires lib="gtk" version="4.0"/>
   <object class="GtkBox" id="box">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="margin_left">5</property>
-    <property name="margin_right">5</property>
-    <property name="margin_top">5</property>
-    <property name="margin_bottom">5</property>
+    <property name="visible">1</property>
+    <property name="margin-start">5</property>
+    <property name="margin-end">5</property>
+    <property name="margin-top">5</property>
+    <property name="margin-bottom">5</property>
+    <property name="vexpand">0</property>
     <child>
       <object class="GtkImage" id="img_plugin_icon">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="visible">1</property>
         <property name="halign">center</property>
         <property name="valign">center</property>
-        <property name="stock">gtk-about</property>
+        <property name="icon-name">gtk-about</property>
       </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">0</property>
-      </packing>
     </child>
     <child>
       <object class="GtkBox" id="box2">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="margin_left">5</property>
+        <property name="visible">1</property>
+        <property name="margin-start">5</property>
         <property name="orientation">vertical</property>
+        <property name="hexpand">1</property>
+        <property name="vexpand">1</property>
         <child>
           <object class="GtkLabel" id="lbl_plugin_name">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <property name="halign">start</property>
             <property name="valign">end</property>
             <property name="label">Plugin Name</property>
             <property name="xalign">0.05000000074505806</property>
             <property name="yalign">1</property>
+            <property name="hexpand">1</property>
+            <property name="vexpand">1</property>
             <style>
               <class name="lbl_plugin_name"/>
             </style>
           </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
         </child>
         <child>
           <object class="GtkLabel" id="lbl_plugin_description">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="visible">1</property>
             <property name="halign">start</property>
             <property name="valign">start</property>
             <property name="label">Plugin Description</property>
             <property name="xalign">0.05000000074505806</property>
             <property name="yalign">0</property>
+            <property name="hexpand">1</property>
+            <property name="vexpand">1</property>
             <style>
               <class name="lbl_plugin_description"/>
             </style>
           </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
         </child>
         <child>
           <object class="GtkLinkButton" id="btn_plugin_extra_link">
@@ -111,21 +88,15 @@
           </object>
         </child>
       </object>
-      <packing>
-        <property name="expand">True</property>
-        <property name="fill">True</property>
-        <property name="position">1</property>
-      </packing>
     </child>
     <child>
       <object class="GtkBox" id="box3">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="visible">1</property>
         <property name="spacing">5</property>
         <child>
           <object class="GtkSwitch" id="switch_enable">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
             <property name="halign">end</property>
             <property name="valign">center</property>
           </object>
@@ -135,9 +106,8 @@
             <property name="visible">False</property>
             <property name="halign">center</property>
             <property name="valign">center</property>
-            <property name="image">img_disable</property>
+            <property name="icon-name">gtk-cancel</property>
             <property name="tooltip-text" translatable="yes">Disable permanently</property>
-            <property name="always_show_image">True</property>
             <style>
               <class name="btn_circle"/>
             </style>
@@ -145,24 +115,18 @@
         </child>
         <child>
           <object class="GtkButton" id="btn_properties">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="receives-default">1</property>
             <property name="halign">center</property>
             <property name="valign">center</property>
-            <property name="image">img_properties</property>
-            <property name="always_show_image">True</property>
+            <property name="icon-name">gtk-properties</property>
             <style>
               <class name="btn_circle"/>
             </style>
           </object>
         </child>
       </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">2</property>
-      </packing>
     </child>
   </object>
 </interface>

--- a/safeeyes/glade/item_text.glade
+++ b/safeeyes/glade/item_text.glade
@@ -20,41 +20,31 @@
 ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <interface>
-  <requires lib="gtk+" version="3.12"/>
+  <requires lib="gtk" version="4.0"/>
   <object class="GtkBox" id="box">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="margin_left">5</property>
-    <property name="margin_right">5</property>
-    <property name="margin_top">5</property>
-    <property name="margin_bottom">5</property>
+    <property name="visible">1</property>
+    <property name="margin-start">5</property>
+    <property name="margin-end">5</property>
+    <property name="margin-top">5</property>
+    <property name="margin-bottom">5</property>
     <property name="spacing">10</property>
+    <property name="homogeneous">1</property>
     <child>
       <object class="GtkLabel" id="lbl_name">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="visible">1</property>
         <property name="valign">center</property>
+        <property name="halign">start</property>
         <property name="label">label</property>
         <property name="xalign">0</property>
       </object>
-      <packing>
-        <property name="expand">True</property>
-        <property name="fill">True</property>
-        <property name="position">0</property>
-      </packing>
     </child>
     <child>
       <object class="GtkEntry" id="txt_value">
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
+        <property name="visible">1</property>
+        <property name="can-focus">1</property>
         <property name="halign">end</property>
         <property name="valign">center</property>
       </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">1</property>
-      </packing>
     </child>
   </object>
 </interface>

--- a/safeeyes/glade/new_break.glade
+++ b/safeeyes/glade/new_break.glade
@@ -20,11 +20,11 @@
 ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <interface>
-  <requires lib="gtk+" version="3.12"/>
+  <requires lib="gtk" version="4.0"/>
   <object class="GtkAdjustment" id="adjustment_duration">
     <property name="upper">100</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkListStore" id="lst_break_types">
     <columns>
@@ -41,110 +41,69 @@
     </data>
   </object>
   <object class="GtkWindow" id="dialog_new_break">
-    <property name="can_focus">False</property>
     <property name="title" translatable="yes">New Break</property>
-    <property name="resizable">False</property>
-    <property name="modal">True</property>
-    <property name="window_position">center-on-parent</property>
-    <property name="default_width">500</property>
-    <property name="default_height">50</property>
-    <property name="destroy_with_parent">True</property>
-    <property name="icon_name">safeeyes</property>
-    <property name="type_hint">dialog</property>
-    <property name="skip_taskbar_hint">True</property>
-    <property name="gravity">center</property>
-    <signal name="delete-event" handler="on_window_delete" swapped="no"/>
+    <property name="resizable">0</property>
+    <property name="modal">1</property>
+    <property name="default-width">500</property>
+    <property name="default-height">50</property>
+    <property name="destroy-with-parent">1</property>
+    <property name="icon-name">safeeyes</property>
     <child>
       <object class="GtkBox" id="box_settings">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="margin_left">10</property>
-        <property name="margin_right">10</property>
-        <property name="margin_top">10</property>
-        <property name="margin_bottom">10</property>
+        <property name="visible">1</property>
+        <property name="margin-start">10</property>
+        <property name="margin-end">10</property>
+        <property name="margin-top">10</property>
+        <property name="margin-bottom">10</property>
         <property name="orientation">vertical</property>
         <property name="spacing">5</property>
         <child>
           <object class="GtkFrame" id="frame2">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="label_xalign">0</property>
+            <property name="visible">1</property>
             <child>
-              <object class="GtkAlignment" id="alignment2">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="left_padding">12</property>
+              <object class="GtkBox" id="box6">
+                <property name="visible">1</property>
+                <property name="margin-start">12</property>
+                <property name="margin-end">10</property>
+                <property name="margin-top">5</property>
+                <property name="margin-bottom">10</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">3</property>
                 <child>
-                  <object class="GtkBox" id="box6">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_right">10</property>
-                    <property name="margin_top">5</property>
-                    <property name="margin_bottom">10</property>
-                    <property name="orientation">vertical</property>
-                    <property name="spacing">3</property>
+                  <object class="GtkEntry" id="txt_break">
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="valign">center</property>
+                    <property name="width-chars">64</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox" id="box7">
+                    <property name="visible">1</property>
+                    <property name="spacing">10</property>
+                    <property name="homogeneous">1</property>
                     <child>
-                      <object class="GtkEntry" id="txt_break">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                      <object class="GtkLabel" id="lbl_duration3">
+                        <property name="visible">1</property>
+                        <property name="halign">start</property>
                         <property name="valign">center</property>
-                        <property name="width_chars">64</property>
+                        <property name="label" translatable="yes">Type</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" id="box7">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="spacing">10</property>
+                      <object class="GtkComboBox" id="cmb_type">
+                        <property name="halign">end</property>
+                        <property name="visible">1</property>
+                        <property name="model">lst_break_types</property>
+                        <property name="active">0</property>
+                        <property name="id-column">0</property>
                         <child>
-                          <object class="GtkLabel" id="lbl_duration3">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="halign">start</property>
-                            <property name="valign">center</property>
-                            <property name="label" translatable="yes">Type</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkComboBox" id="cmb_type">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="model">lst_break_types</property>
-                            <property name="active">0</property>
-                            <property name="id_column">0</property>
-                            <child>
-                              <object class="GtkCellRendererText" id="cellrenderertext1"/>
-                              <attributes>
-                                <attribute name="text">0</attribute>
-                              </attributes>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="pack_type">end</property>
-                            <property name="position">1</property>
-                          </packing>
+                          <object class="GtkCellRendererText" id="cellrenderertext1"/>
+                          <attributes>
+                            <attribute name="text">0</attribute>
+                          </attributes>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <placeholder/>
                     </child>
                   </object>
                 </child>
@@ -152,61 +111,36 @@
             </child>
             <child type="label">
               <object class="GtkLabel" id="label2">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
                 <property name="label" translatable="yes">Break</property>
               </object>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">0</property>
-          </packing>
         </child>
         <child>
-          <object class="GtkButtonBox" id="buttonbox1">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+          <object class="GtkBox" id="buttonbox1">
+            <property name="visible">1</property>
             <property name="spacing">10</property>
-            <property name="homogeneous">True</property>
-            <property name="baseline_position">top</property>
-            <property name="layout_style">end</property>
+            <property name="homogeneous">1</property>
+            <property name="baseline-position">top</property>
+            <property name="halign">end</property>
             <child>
               <object class="GtkButton" id="btn_discard">
                 <property name="label">Discard</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <signal name="clicked" handler="discard" swapped="no"/>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="receives-default">1</property>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
             </child>
             <child>
               <object class="GtkButton" id="btn_save">
                 <property name="label" translatable="yes">Save</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="has_focus">True</property>
-                <property name="receives_default">True</property>
-                <signal name="clicked" handler="save" swapped="no"/>
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="receives-default">1</property>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">3</property>
-          </packing>
         </child>
       </object>
     </child>

--- a/safeeyes/glade/required_plugin_dialog.glade
+++ b/safeeyes/glade/required_plugin_dialog.glade
@@ -20,7 +20,7 @@
 ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <interface>
-  <requires lib="gtk+" version="3.12"/>
+  <requires lib="gtk" version="4.0"/>
   <object class="GtkWindow" id="window_required_plugin">
     <property name="title" translatable="1">Safe Eyes - Error</property>
     <property name="resizable">0</property>
@@ -71,7 +71,10 @@
             </child>
             <child>
               <object class="GtkLabel" id="lbl_main">
-                <property name="margin">5</property>
+                <property name="margin-top">5</property>
+                <property name="margin-bottom">5</property>
+                <property name="margin-start">5</property>
+                <property name="margin-end">5</property>
                 <property name="wrap">1</property>
                 <property name="justify">center</property>
                 <property name="max-width-chars">60</property>

--- a/safeeyes/glade/settings_break.glade
+++ b/safeeyes/glade/settings_break.glade
@@ -20,23 +20,18 @@
 ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <interface>
-  <requires lib="gtk+" version="3.12"/>
+  <requires lib="gtk" version="4.0"/>
   <object class="GtkAdjustment" id="adjustment_duration">
     <property name="lower">1</property>
     <property name="upper">3600</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment_interval">
     <property name="lower">1</property>
     <property name="upper">120</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
-  </object>
-  <object class="GtkImage" id="img_break">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-missing-image</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkListStore" id="lst_break_types">
     <columns>
@@ -53,152 +48,93 @@
     </data>
   </object>
   <object class="GtkWindow" id="dialog_settings_break">
-    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Break Settings</property>
-    <property name="resizable">False</property>
-    <property name="modal">True</property>
-    <property name="window_position">center-on-parent</property>
-    <property name="default_width">500</property>
-    <property name="default_height">50</property>
-    <property name="destroy_with_parent">True</property>
-    <property name="icon_name">safeeyes</property>
-    <property name="type_hint">dialog</property>
-    <property name="skip_taskbar_hint">True</property>
-    <property name="gravity">center</property>
-    <signal name="delete-event" handler="on_window_delete" swapped="no"/>
-    <child>
-      <placeholder/>
-    </child>
+    <property name="resizable">0</property>
+    <property name="modal">1</property>
+    <property name="default-width">500</property>
+    <property name="default-height">50</property>
+    <property name="destroy-with-parent">1</property>
+    <property name="icon-name">safeeyes</property>
     <child>
       <object class="GtkBox" id="box_settings">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="margin_left">10</property>
-        <property name="margin_right">10</property>
-        <property name="margin_top">10</property>
-        <property name="margin_bottom">10</property>
+        <property name="visible">1</property>
+        <property name="margin-start">10</property>
+        <property name="margin-end">10</property>
+        <property name="margin-top">10</property>
+        <property name="margin-bottom">10</property>
         <property name="orientation">vertical</property>
         <property name="spacing">5</property>
         <child>
           <object class="GtkFrame" id="frame2">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="label_xalign">0</property>
+            <property name="visible">1</property>
             <child>
-              <object class="GtkAlignment" id="alignment2">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="left_padding">12</property>
+              <object class="GtkBox" id="box6">
+                <property name="visible">1</property>
+                <property name="margin-start">12</property>
+                <property name="margin-end">10</property>
+                <property name="margin-top">5</property>
+                <property name="margin-bottom">10</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">3</property>
                 <child>
-                  <object class="GtkBox" id="box6">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_right">10</property>
-                    <property name="margin_top">5</property>
-                    <property name="margin_bottom">10</property>
-                    <property name="orientation">vertical</property>
-                    <property name="spacing">3</property>
+                  <object class="GtkEntry" id="txt_break">
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="valign">center</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox" id="box7">
+                    <property name="visible">1</property>
+                    <property name="spacing">10</property>
+                    <property name="homogeneous">1</property>
                     <child>
-                      <object class="GtkEntry" id="txt_break">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                      <object class="GtkLabel" id="lbl_duration3">
+                        <property name="visible">1</property>
+                        <property name="halign">start</property>
                         <property name="valign">center</property>
+                        <property name="label" translatable="yes">Type</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" id="box7">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="spacing">10</property>
+                      <object class="GtkComboBox" id="cmb_type">
+                        <property name="visible">1</property>
+                        <property name="model">lst_break_types</property>
+                        <property name="active">0</property>
+                        <property name="id-column">0</property>
+                        <property name="halign">end</property>
                         <child>
-                          <object class="GtkLabel" id="lbl_duration3">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="halign">start</property>
-                            <property name="valign">center</property>
-                            <property name="label" translatable="yes">Type</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkComboBox" id="cmb_type">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="model">lst_break_types</property>
-                            <property name="active">0</property>
-                            <property name="id_column">0</property>
-                            <child>
-                              <object class="GtkCellRendererText" id="cellrenderertext1"/>
-                              <attributes>
-                                <attribute name="text">0</attribute>
-                              </attributes>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="pack_type">end</property>
-                            <property name="position">1</property>
-                          </packing>
+                          <object class="GtkCellRendererText" id="cellrenderertext1"/>
+                          <attributes>
+                            <attribute name="text">0</attribute>
+                          </attributes>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox" id="box8">
+                    <property name="visible">1</property>
+                    <property name="spacing">10</property>
+                    <property name="homogeneous">1</property>
+                    <child>
+                      <object class="GtkLabel" id="lbl_duration4">
+                        <property name="visible">1</property>
+                        <property name="halign">start</property>
+                        <property name="valign">center</property>
+                        <property name="label" translatable="yes">Image</property>
+                      </object>
                     </child>
                     <child>
-                      <object class="GtkBox" id="box8">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="spacing">10</property>
-                        <child>
-                          <object class="GtkLabel" id="lbl_duration4">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="halign">start</property>
-                            <property name="valign">center</property>
-                            <property name="label" translatable="yes">Image</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkButton" id="btn_image">
-                            <property name="label" translatable="yes">Select</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">True</property>
-                            <property name="image">img_break</property>
-                            <property name="always_show_image">True</property>
-                            <signal name="clicked" handler="select_image" swapped="no"/>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="pack_type">end</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
+                      <object class="GtkButton" id="btn_image">
+                        <property name="halign">end</property>
+                        <property name="label" translatable="yes">Select</property>
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
+                        <property name="receives-default">1</property>
+                        <property name="icon-name">gtk-missing-image</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">2</property>
-                      </packing>
                     </child>
                   </object>
                 </child>
@@ -206,377 +142,208 @@
             </child>
             <child type="label">
               <object class="GtkLabel" id="label2">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
                 <property name="label" translatable="yes">Break</property>
               </object>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">0</property>
-          </packing>
         </child>
         <child>
           <object class="GtkFrame" id="frame4">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="label_xalign">0</property>
+            <property name="visible">1</property>
             <child>
-              <object class="GtkAlignment" id="alignment4">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="left_padding">12</property>
-                <child>
                   <object class="GtkBox" id="box9">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_right">10</property>
-                    <property name="margin_top">5</property>
-                    <property name="margin_bottom">10</property>
+                    <property name="visible">1</property>
+                    <property name="margin-start">12</property>
+                    <property name="margin-end">10</property>
+                    <property name="margin-top">5</property>
+                    <property name="margin-bottom">10</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">3</property>
                     <child>
                       <object class="GtkBox" id="box10">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="spacing">10</property>
+                        <property name="homogeneous">1</property>
                         <child>
                           <object class="GtkLabel" id="lbl_duration5">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="visible">1</property>
                             <property name="halign">start</property>
                             <property name="valign">center</property>
                             <property name="label" translatable="yes">Override</property>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
                         </child>
                         <child>
                           <object class="GtkSwitch" id="switch_override_interval">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
+                            <property name="visible">1</property>
+                            <property name="can-focus">1</property>
                             <property name="halign">end</property>
                             <property name="valign">center</property>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="pack_type">end</property>
-                            <property name="position">1</property>
-                          </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkBox" id="box11">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="spacing">100</property>
+                        <property name="homogeneous">1</property>
                         <child>
                           <object class="GtkLabel" id="lbl_duration6">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="visible">1</property>
                             <property name="halign">start</property>
                             <property name="valign">center</property>
                             <property name="label" translatable="yes">Time (in minutes)</property>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
                         </child>
                         <child>
                           <object class="GtkSpinButton" id="spin_interval">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
+                            <property name="visible">1</property>
+                            <property name="can-focus">1</property>
                             <property name="halign">end</property>
                             <property name="valign">center</property>
                             <property name="text">0</property>
                             <property name="adjustment">adjustment_interval</property>
-                            <property name="numeric">True</property>
+                            <property name="numeric">1</property>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="pack_type">end</property>
-                            <property name="position">1</property>
-                          </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                   </object>
-                </child>
-              </object>
             </child>
             <child type="label">
               <object class="GtkLabel" id="label4">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
                 <property name="label" translatable="yes">Time to wait</property>
               </object>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">1</property>
-          </packing>
         </child>
         <child>
           <object class="GtkFrame" id="frame1">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="label_xalign">0</property>
+            <property name="visible">1</property>
             <child>
-              <object class="GtkAlignment" id="alignment1">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="left_padding">12</property>
-                <child>
                   <object class="GtkBox" id="box2">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_right">10</property>
-                    <property name="margin_top">5</property>
-                    <property name="margin_bottom">10</property>
+                    <property name="visible">1</property>
+                    <property name="margin-start">12</property>
+                    <property name="margin-end">10</property>
+                    <property name="margin-top">5</property>
+                    <property name="margin-bottom">10</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">3</property>
                     <child>
                       <object class="GtkBox" id="box4">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="spacing">10</property>
+                        <property name="homogeneous">1</property>
                         <child>
                           <object class="GtkLabel" id="lbl_duration1">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="visible">1</property>
                             <property name="halign">start</property>
                             <property name="valign">center</property>
                             <property name="label" translatable="yes">Override</property>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
                         </child>
                         <child>
                           <object class="GtkSwitch" id="switch_override_duration">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
+                            <property name="visible">1</property>
+                            <property name="can-focus">1</property>
                             <property name="halign">end</property>
                             <property name="valign">center</property>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="pack_type">end</property>
-                            <property name="position">1</property>
-                          </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkBox" id="box3">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="visible">1</property>
                         <property name="spacing">100</property>
+                        <property name="homogeneous">1</property>
                         <child>
                           <object class="GtkLabel" id="lbl_duration">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="visible">1</property>
                             <property name="halign">start</property>
                             <property name="valign">center</property>
                             <property name="label" translatable="yes">Time (in seconds)</property>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
                         </child>
                         <child>
                           <object class="GtkSpinButton" id="spin_duration">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
+                            <property name="visible">1</property>
+                            <property name="can-focus">1</property>
                             <property name="halign">end</property>
                             <property name="valign">center</property>
                             <property name="adjustment">adjustment_duration</property>
-                            <property name="numeric">True</property>
+                            <property name="numeric">1</property>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="pack_type">end</property>
-                            <property name="position">1</property>
-                          </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                   </object>
-                </child>
-              </object>
             </child>
             <child type="label">
               <object class="GtkLabel" id="label1">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
                 <property name="label" translatable="yes">Duration</property>
               </object>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">2</property>
-          </packing>
         </child>
         <child>
           <object class="GtkFrame" id="frame3">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="label_xalign">0</property>
+            <property name="visible">1</property>
             <child>
-              <object class="GtkAlignment" id="alignment3">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="left_padding">12</property>
-                <child>
                   <object class="GtkBox" id="box1">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_top">5</property>
-                    <property name="margin_bottom">10</property>
+                    <property name="visible">1</property>
+                    <property name="margin-start">12</property>
+                    <property name="margin-top">5</property>
+                    <property name="margin-bottom">10</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">3</property>
                     <child>
                       <object class="GtkBox" id="box5">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_right">10</property>
-                        <property name="margin_top">5</property>
-                        <property name="margin_bottom">10</property>
+                        <property name="visible">1</property>
+                        <property name="margin-end">10</property>
+                        <property name="margin-top">5</property>
+                        <property name="margin-bottom">10</property>
                         <property name="spacing">10</property>
+                        <property name="homogeneous">1</property>
                         <child>
                           <object class="GtkLabel" id="lbl_duration2">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="visible">1</property>
                             <property name="halign">start</property>
                             <property name="valign">center</property>
                             <property name="label" translatable="yes">Override</property>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
                         </child>
                         <child>
                           <object class="GtkSwitch" id="switch_override_plugins">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
+                            <property name="visible">1</property>
+                            <property name="can-focus">1</property>
                             <property name="halign">end</property>
                             <property name="valign">center</property>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="pack_type">end</property>
-                            <property name="position">1</property>
-                          </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkGrid" id="grid_plugins">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_right">10</property>
-                        <property name="margin_bottom">10</property>
-                        <property name="row_homogeneous">True</property>
-                        <property name="column_homogeneous">True</property>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
+                        <property name="visible">1</property>
+                        <property name="margin-end">10</property>
+                        <property name="margin-bottom">10</property>
+                        <property name="row-homogeneous">1</property>
+                        <property name="column-homogeneous">1</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                   </object>
-                </child>
-              </object>
             </child>
             <child type="label">
               <object class="GtkLabel" id="label3">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="visible">1</property>
                 <property name="label" translatable="yes">Plugins</property>
               </object>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">3</property>
-          </packing>
         </child>
       </object>
     </child>

--- a/safeeyes/glade/settings_dialog.glade
+++ b/safeeyes/glade/settings_dialog.glade
@@ -20,7 +20,7 @@
 ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <interface>
-  <requires lib="gtk+" version="3.12"/>
+  <requires lib="gtk" version="4.0"/>
   <object class="GtkAdjustment" id="adjust_disable_keyboard_shortcut_duration">
     <property name="upper">15</property>
     <property name="step-increment">1</property>
@@ -61,1103 +61,666 @@
     <property name="step-increment">1</property>
     <property name="page-increment">5</property>
   </object>
-  <object class="GtkImage" id="img_add">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="stock">gtk-add</property>
-  </object>
   <object class="GtkPopover" id="popover">
-    <property name="can-focus">False</property>
     <child>
       <object class="GtkBox">
         <property name="width-request">128</property>
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
+        <property name="visible">1</property>
         <property name="orientation">vertical</property>
         <property name="spacing">5</property>
-        <property name="homogeneous">True</property>
+        <property name="homogeneous">1</property>
         <child>
-          <object class="GtkButton">
+          <object class="GtkButton" id="reset_menu">
             <property name="label" translatable="yes">Reset</property>
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">True</property>
-            <signal name="clicked" handler="on_reset_menu_clicked" swapped="no"/>
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="receives-default">1</property>
+            <property name="hexpand">1</property>
+            <property name="vexpand">1</property>
             <style>
               <class name="btn_menu"/>
             </style>
           </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
         </child>
       </object>
     </child>
   </object>
   <object class="GtkApplicationWindow" id="window_settings">
-    <property name="can-focus">False</property>
     <property name="title">Safe Eyes</property>
-    <property name="window-position">center</property>
     <property name="default-width">450</property>
     <property name="default-height">650</property>
     <property name="icon-name">io.github.slgobinath.SafeEyes</property>
-    <property name="gravity">center</property>
-    <signal name="delete-event" handler="on_window_delete" swapped="no"/>
     <child>
       <object class="GtkStack" id="stack">
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <property name="interpolate-size">True</property>
+        <property name="visible">1</property>
+        <property name="interpolate-size">1</property>
         <child>
-          <object class="GtkScrolledWindow" id="scrolledwindow_settings">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="hscrollbar-policy">never</property>
-            <property name="shadow-type">in</property>
-            <child>
-              <object class="GtkViewport" id="viewport_settings">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="shadow-type">none</property>
+          <object class="GtkStackPage">
+            <property name="name">Settings</property>
+            <property name="title" translatable="yes">Settings</property>
+            <property name="child">
+              <object class="GtkScrolledWindow" id="scrolledwindow_settings">
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="hscrollbar-policy">never</property>
+                <property name="has-frame">1</property>
                 <child>
-                  <object class="GtkBox" id="box_settings">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="margin-left">5</property>
-                    <property name="margin-right">5</property>
-                    <property name="orientation">vertical</property>
-                    <property name="spacing">15</property>
+                  <object class="GtkViewport" id="viewport_settings">
+                    <property name="visible">1</property>
                     <child>
-                      <object class="GtkFrame" id="frame_short_breaks">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="label-xalign">0</property>
-                        <property name="shadow-type">in</property>
+                      <object class="GtkBox" id="box_settings">
+                        <property name="visible">1</property>
+                        <property name="margin-start">5</property>
+                        <property name="margin-end">5</property>
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">15</property>
                         <child>
-                          <object class="GtkAlignment" id="alignment2">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="left-padding">12</property>
+                          <object class="GtkFrame" id="frame_short_breaks">
+                            <property name="visible">1</property>
                             <child>
                               <object class="GtkBox" id="box13">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="margin-right">10</property>
+                                <property name="visible">1</property>
+                                <property name="margin-start">12</property>
+                                <property name="margin-end">10</property>
                                 <property name="margin-top">10</property>
                                 <property name="margin-bottom">10</property>
                                 <property name="orientation">vertical</property>
                                 <property name="spacing">15</property>
-                                <property name="homogeneous">True</property>
+                                <property name="homogeneous">1</property>
                                 <child>
                                   <object class="GtkBox" id="box7">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="spacing">5</property>
+                                    <property name="homogeneous">1</property>
                                     <child>
                                       <object class="GtkLabel" id="lbl_interval_between_breaks">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="visible">1</property>
                                         <property name="label" translatable="yes">Interval between two breaks (in minutes)</property>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">0</property>
-                                      </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSpinButton" id="spin_short_break_interval">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
+                                        <property name="visible">1</property>
+                                        <property name="can-focus">1</property>
                                         <property name="halign">end</property>
                                         <property name="valign">center</property>
                                         <property name="text">1</property>
-                                        <property name="input-purpose">number</property>
                                         <property name="adjustment">adjust_short_break_interval</property>
                                         <property name="climb-rate">1</property>
-                                        <property name="numeric">True</property>
+                                        <property name="numeric">1</property>
                                         <property name="update-policy">if-valid</property>
                                         <property name="value">1</property>
-                                        <signal name="value-changed" handler="on_spin_short_break_interval_change" swapped="no"/>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="pack-type">end</property>
-                                        <property name="position">1</property>
-                                      </packing>
                                     </child>
                                   </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
                                 </child>
                                 <child>
                                   <object class="GtkBox" id="box2">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="spacing">5</property>
+                                    <property name="homogeneous">1</property>
                                     <child>
                                       <object class="GtkLabel" id="lbl_short_break_duration">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="visible">1</property>
                                         <property name="label" translatable="yes">Break duration (in seconds)</property>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">0</property>
-                                      </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSpinButton" id="spin_short_break_duration">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
+                                        <property name="visible">1</property>
+                                        <property name="can-focus">1</property>
                                         <property name="halign">end</property>
                                         <property name="valign">center</property>
                                         <property name="text">1</property>
-                                        <property name="input-purpose">number</property>
                                         <property name="adjustment">adjust_short_break_duration</property>
                                         <property name="climb-rate">1</property>
-                                        <property name="numeric">True</property>
+                                        <property name="numeric">1</property>
                                         <property name="update-policy">if-valid</property>
                                         <property name="value">1</property>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="pack-type">end</property>
-                                        <property name="position">1</property>
-                                      </packing>
                                     </child>
                                   </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
                                 </child>
+                              </object>
+                            </child>
+                            <child type="label">
+                              <object class="GtkLabel" id="lbl_frames">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Short Breaks</property>
                               </object>
                             </child>
                           </object>
                         </child>
-                        <child type="label">
-                          <object class="GtkLabel" id="lbl_frames">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">Short Breaks</property>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkFrame" id="frame_long_breaks">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="label-xalign">0</property>
-                        <property name="shadow-type">in</property>
                         <child>
-                          <object class="GtkAlignment" id="alignment3">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="left-padding">12</property>
+                          <object class="GtkFrame" id="frame_long_breaks">
+                            <property name="visible">1</property>
                             <child>
                               <object class="GtkBox" id="box14">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="margin-right">10</property>
+                                <property name="visible">1</property>
+                                <property name="margin-start">12</property>
+                                <property name="margin-end">10</property>
                                 <property name="margin-top">10</property>
                                 <property name="margin-bottom">10</property>
                                 <property name="orientation">vertical</property>
                                 <property name="spacing">15</property>
-                                <property name="homogeneous">True</property>
+                                <property name="homogeneous">1</property>
                                 <child>
                                   <object class="GtkInfoBar" id="info_bar_long_break">
-                                    <property name="app-paintable">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="no-show-all">True</property>
-                                    <property name="show-close-button">True</property>
-                                    <signal name="close" handler="on_info_bar_long_break_close" swapped="no"/>
-                                    <signal name="response" handler="on_info_bar_long_break_close" swapped="no"/>
-                                    <child internal-child="action_area">
-                                      <object class="GtkButtonBox">
-                                        <property name="can-focus">False</property>
-                                        <property name="spacing">6</property>
-                                        <property name="layout-style">start</property>
-                                        <child>
-                                          <placeholder/>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
-                                    <child internal-child="content_area">
+                                    <property name="visible">0</property>
+                                    <property name="show-close-button">1</property>
+                                    <property name="hexpand">1</property>
+                                    <property name="vexpand">1</property>
+                                    <child>
                                       <object class="GtkBox">
-                                        <property name="can-focus">False</property>
                                         <property name="spacing">16</property>
                                         <child>
                                           <object class="GtkImage" id="image1">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="stock">gtk-info</property>
+                                            <property name="visible">1</property>
+                                            <property name="icon-name">dialog-information</property>
                                           </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
                                         </child>
                                         <child>
                                           <object class="GtkLabel" id="label2">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="visible">1</property>
                                             <property name="label" translatable="yes">Long break interval must be a multiple of short break interval</property>
                                             <property name="xalign">0</property>
                                           </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
                                         </child>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <placeholder/>
                                     </child>
                                     <style>
                                       <class name="info_bar_long_break"/>
                                     </style>
                                   </object>
-                                  <packing>
-                                    <property name="expand">True</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
                                 </child>
                                 <child>
                                   <object class="GtkBox" id="box8">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="spacing">5</property>
+                                    <property name="homogeneous">1</property>
                                     <child>
                                       <object class="GtkLabel" id="lbl_short_per_long">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="visible">1</property>
                                         <property name="label" translatable="yes">Interval between two breaks (in minutes)</property>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">0</property>
-                                      </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSpinButton" id="spin_long_break_interval">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
+                                        <property name="visible">1</property>
+                                        <property name="can-focus">1</property>
                                         <property name="halign">end</property>
                                         <property name="valign">center</property>
                                         <property name="text">1</property>
-                                        <property name="input-purpose">number</property>
                                         <property name="adjustment">adjust_long_break_interval</property>
                                         <property name="climb-rate">1</property>
-                                        <property name="snap-to-ticks">True</property>
-                                        <property name="numeric">True</property>
-                                        <property name="wrap">True</property>
+                                        <property name="snap-to-ticks">1</property>
+                                        <property name="numeric">1</property>
+                                        <property name="wrap">1</property>
                                         <property name="update-policy">if-valid</property>
                                         <property name="value">1</property>
-                                        <signal name="value-changed" handler="on_spin_long_break_interval_change" swapped="no"/>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="pack-type">end</property>
-                                        <property name="position">1</property>
-                                      </packing>
                                     </child>
                                   </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
                                 </child>
                                 <child>
                                   <object class="GtkBox" id="box3">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="spacing">5</property>
+                                    <property name="homogeneous">1</property>
                                     <child>
                                       <object class="GtkLabel" id="lbl_long_break_duration">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="visible">1</property>
+                                        <property name="halign">start</property>
                                         <property name="label" translatable="yes">Break duration (in seconds)</property>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">0</property>
-                                      </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSpinButton" id="spin_long_break_duration">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
+                                        <property name="visible">1</property>
+                                        <property name="can-focus">1</property>
                                         <property name="halign">end</property>
                                         <property name="valign">center</property>
                                         <property name="text">1</property>
-                                        <property name="input-purpose">number</property>
                                         <property name="adjustment">adjust_long_break_duration</property>
                                         <property name="climb-rate">1</property>
-                                        <property name="numeric">True</property>
+                                        <property name="numeric">1</property>
                                         <property name="update-policy">if-valid</property>
                                         <property name="value">1</property>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="pack-type">end</property>
-                                        <property name="position">1</property>
-                                      </packing>
                                     </child>
                                   </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">2</property>
-                                  </packing>
                                 </child>
+                              </object>
+                            </child>
+                            <child type="label">
+                              <object class="GtkLabel" id="lbl_lon_breaks">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Long Breaks</property>
                               </object>
                             </child>
                           </object>
                         </child>
-                        <child type="label">
-                          <object class="GtkLabel" id="lbl_lon_breaks">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">Long Breaks</property>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkFrame" id="frame_options">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="label-xalign">0</property>
-                        <property name="shadow-type">in</property>
                         <child>
-                          <object class="GtkAlignment" id="alignment1">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="left-padding">12</property>
+                          <object class="GtkFrame" id="frame_options">
+                            <property name="visible">1</property>
                             <child>
                               <object class="GtkBox" id="box12">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="margin-right">10</property>
+                                <property name="visible">1</property>
+                                <property name="margin-start">12</property>
+                                <property name="margin-end">10</property>
                                 <property name="margin-top">10</property>
                                 <property name="margin-bottom">10</property>
                                 <property name="orientation">vertical</property>
                                 <property name="spacing">15</property>
-                                <property name="homogeneous">True</property>
+                                <property name="homogeneous">1</property>
                                 <child>
                                   <object class="GtkBox" id="box6">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="spacing">5</property>
+                                    <property name="homogeneous">1</property>
                                     <child>
                                       <object class="GtkLabel" id="lbl_time_to_prepare">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="visible">1</property>
+                                        <property name="halign">start</property>
                                         <property name="label" translatable="yes">Time to prepare for a break (in seconds)</property>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">0</property>
-                                      </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSpinButton" id="spin_time_to_prepare">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
+                                        <property name="visible">1</property>
+                                        <property name="can-focus">1</property>
                                         <property name="halign">end</property>
                                         <property name="valign">center</property>
                                         <property name="text">1</property>
-                                        <property name="input-purpose">number</property>
                                         <property name="adjustment">adjust_time_to_prepare</property>
                                         <property name="climb-rate">1</property>
-                                        <property name="numeric">True</property>
+                                        <property name="numeric">1</property>
                                         <property name="update-policy">if-valid</property>
                                         <property name="value">1</property>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="pack-type">end</property>
-                                        <property name="position">1</property>
-                                      </packing>
                                     </child>
                                   </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
                                 </child>
                                 <child>
                                   <object class="GtkBox" id="box16_random_order">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="spacing">5</property>
+                                    <property name="homogeneous">1</property>
                                     <child>
                                       <object class="GtkLabel" id="lbl_random_order">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="visible">1</property>
+                                        <property name="halign">start</property>
                                         <property name="label" translatable="yes">Show breaks in random order</property>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">0</property>
-                                      </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSwitch" id="switch_random_order">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
+                                        <property name="visible">1</property>
+                                        <property name="can-focus">1</property>
                                         <property name="halign">end</property>
                                         <property name="valign">center</property>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="pack-type">end</property>
-                                        <property name="position">1</property>
-                                      </packing>
                                     </child>
                                   </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
                                 </child>
                                 <child>
                                   <object class="GtkBox" id="box9">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="spacing">5</property>
+                                    <property name="homogeneous">1</property>
                                     <child>
                                       <object class="GtkLabel" id="lbl_strict_break">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="visible">1</property>
+                                        <property name="halign">start</property>
                                         <property name="label" translatable="yes">Strict break (No way to skip breaks)</property>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">0</property>
-                                      </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSwitch" id="switch_strict_break">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
+                                        <property name="visible">1</property>
+                                        <property name="can-focus">1</property>
                                         <property name="halign">end</property>
                                         <property name="valign">center</property>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="pack-type">end</property>
-                                        <property name="position">1</property>
-                                      </packing>
                                     </child>
                                   </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">2</property>
-                                  </packing>
                                 </child>
                                 <child>
                                   <object class="GtkBox" id="box11">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="spacing">5</property>
+                                    <property name="homogeneous">1</property>
                                     <child>
                                       <object class="GtkLabel" id="lbl_allow_postpone">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="visible">1</property>
+                                        <property name="halign">start</property>
                                         <property name="label" translatable="yes">Allow postponing breaks</property>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">0</property>
-                                      </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSwitch" id="switch_postpone">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
+                                        <property name="visible">1</property>
+                                        <property name="can-focus">1</property>
                                         <property name="halign">end</property>
                                         <property name="valign">center</property>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="pack-type">end</property>
-                                        <property name="position">1</property>
-                                      </packing>
                                     </child>
                                   </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">3</property>
-                                  </packing>
                                 </child>
                                 <child>
                                   <object class="GtkBox" id="box10">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="spacing">5</property>
+                                    <property name="homogeneous">1</property>
                                     <child>
                                       <object class="GtkLabel" id="lbl_postpone_duration">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="visible">1</property>
+                                        <property name="halign">start</property>
                                         <property name="label" translatable="yes">Postponement duration (in minutes)</property>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">0</property>
-                                      </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSpinButton" id="spin_postpone_duration">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
+                                        <property name="visible">1</property>
+                                        <property name="can-focus">1</property>
                                         <property name="halign">end</property>
                                         <property name="valign">center</property>
                                         <property name="text">1</property>
-                                        <property name="input-purpose">number</property>
                                         <property name="adjustment">adjust_postpone_duration</property>
                                         <property name="climb-rate">1</property>
-                                        <property name="numeric">True</property>
+                                        <property name="numeric">1</property>
                                         <property name="update-policy">if-valid</property>
                                         <property name="value">1</property>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="pack-type">end</property>
-                                        <property name="position">1</property>
-                                      </packing>
                                     </child>
                                   </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">4</property>
-                                  </packing>
                                 </child>
                                 <child>
                                   <object class="GtkBox" id="box5">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="spacing">5</property>
+                                    <property name="homogeneous">1</property>
                                     <child>
                                       <object class="GtkLabel" id="lbl_shortcuts">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="visible">1</property>
+                                        <property name="halign">start</property>
                                         <property name="label" translatable="yes">Keyboard shortcuts disabled period (in seconds)</property>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">0</property>
-                                      </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSpinButton" id="spin_disable_keyboard_shortcut">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
+                                        <property name="visible">1</property>
+                                        <property name="can-focus">1</property>
                                         <property name="halign">end</property>
                                         <property name="valign">center</property>
                                         <property name="text">1</property>
-                                        <property name="input-purpose">number</property>
                                         <property name="adjustment">adjust_disable_keyboard_shortcut_duration</property>
                                         <property name="climb-rate">1</property>
-                                        <property name="numeric">True</property>
+                                        <property name="numeric">1</property>
                                         <property name="update-policy">if-valid</property>
                                         <property name="value">1</property>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="pack-type">end</property>
-                                        <property name="position">1</property>
-                                      </packing>
                                     </child>
                                   </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">5</property>
-                                  </packing>
                                 </child>
                                 <child>
                                   <object class="GtkBox" id="box1">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="spacing">5</property>
+                                    <property name="homogeneous">1</property>
                                     <child>
                                       <object class="GtkLabel" id="lbl_persist_state">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="visible">1</property>
+                                        <property name="halign">start</property>
                                         <property name="label" translatable="yes">Persist the internal state</property>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">0</property>
-                                      </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSwitch" id="switch_persist">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
+                                        <property name="visible">1</property>
+                                        <property name="can-focus">1</property>
                                         <property name="halign">end</property>
                                         <property name="valign">center</property>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="pack-type">end</property>
-                                        <property name="position">1</property>
-                                      </packing>
                                     </child>
                                   </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">6</property>
-                                  </packing>
                                 </child>
                                 <child>
                                   <object class="GtkInfoBar" id="warn_bar_rpc_server">
-                                    <property name="app-paintable">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="no-show-all">True</property>
+                                    <property name="visible">0</property>
                                     <property name="message-type">warning</property>
-                                    <property name="show-close-button">True</property>
-                                    <signal name="close" handler="on_warn_bar_rpc_server_close" swapped="no"/>
-                                    <signal name="response" handler="on_warn_bar_rpc_server_close" swapped="no"/>
-                                    <child internal-child="action_area">
-                                      <object class="GtkButtonBox">
-                                        <property name="can-focus">False</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
-                                    <child internal-child="content_area">
-                                      <object class="GtkBox">
-                                        <property name="can-focus">False</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <placeholder/>
-                                    </child>
+                                    <property name="hexpand">1</property>
+                                    <property name="vexpand">1</property>
+                                    <property name="show-close-button">1</property>
                                     <style>
                                       <class name="warn_bar_rpc_server"/>
                                     </style>
                                   </object>
-                                  <packing>
-                                    <property name="expand">True</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">7</property>
-                                  </packing>
                                 </child>
                                 <child>
                                   <object class="GtkBox" id="box15">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
+                                    <property name="visible">1</property>
                                     <property name="spacing">5</property>
+                                    <property name="homogeneous">1</property>
                                     <child>
                                       <object class="GtkLabel" id="lbl_toggle_rpc_server">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="visible">1</property>
+                                        <property name="halign">start</property>
                                         <property name="label" translatable="yes">Use RPC server to receive runtime commands</property>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">0</property>
-                                      </packing>
                                     </child>
                                     <child>
                                       <object class="GtkSwitch" id="switch_rpc_server">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
+                                        <property name="visible">1</property>
+                                        <property name="can-focus">1</property>
                                         <property name="halign">end</property>
                                         <property name="valign">center</property>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="pack-type">end</property>
-                                        <property name="position">1</property>
-                                      </packing>
                                     </child>
                                   </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">8</property>
-                                  </packing>
+                                </child>
+                              </object>
+                            </child>
+                            <child type="label">
+                              <object class="GtkLabel" id="label1">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Options</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkStackPage">
+            <property name="name">page1</property>
+            <property name="title" translatable="yes">Breaks</property>
+            <property name="child">
+              <object class="GtkBox" id="box_break">
+                <property name="visible">1</property>
+                <property name="margin-start">5</property>
+                <property name="margin-end">5</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkScrolledWindow" id="scrolledwindow_breaks">
+                    <property name="visible">1</property>
+                    <property name="hexpand">1</property>
+                    <property name="vexpand">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="hscrollbar-policy">never</property>
+                    <property name="has-frame">1</property>
+                    <child>
+                      <object class="GtkViewport" id="viewport_breaks">
+                        <property name="visible">1</property>
+                        <child>
+                          <object class="GtkBox" id="box_breaks">
+                            <property name="visible">1</property>
+                            <property name="margin-top">10</property>
+                            <property name="margin-bottom">10</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkBox" id="box4">
+                                <property name="visible">1</property>
+                                <property name="orientation">vertical</property>
+                                <property name="hexpand">1</property>
+                                <property name="vexpand">1</property>
+                                <child>
+                                  <object class="GtkExpander" id="expander_short_breaks">
+                                    <property name="visible">1</property>
+                                    <property name="can-focus">1</property>
+                                    <property name="expanded">1</property>
+                                    <child>
+                                      <object class="GtkBox" id="box_short_breaks">
+                                        <property name="visible">1</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="spacing">5</property>
+                                      </object>
+                                    </child>
+                                    <child type="label">
+                                      <object class="GtkLabel" id="lbl_short_breaks">
+                                        <property name="visible">1</property>
+                                        <property name="label" translatable="yes">Short Breaks</property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkSeparator" id="separator_breaks">
+                                    <property name="visible">1</property>
+                                    <property name="margin-top">10</property>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkExpander" id="expander_long_breaks">
+                                    <property name="visible">1</property>
+                                    <property name="can-focus">1</property>
+                                    <child>
+                                      <object class="GtkBox" id="box_long_breaks">
+                                        <property name="visible">1</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="spacing">5</property>
+                                      </object>
+                                    </child>
+                                    <child type="label">
+                                      <object class="GtkLabel" id="lbl_long_breaks">
+                                        <property name="visible">1</property>
+                                        <property name="label" translatable="yes">Long Breaks</property>
+                                      </object>
+                                    </child>
+                                  </object>
                                 </child>
                               </object>
                             </child>
                           </object>
                         </child>
-                        <child type="label">
-                          <object class="GtkLabel" id="label1">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">Options</property>
-                          </object>
-                        </child>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">2</property>
-                      </packing>
                     </child>
                   </object>
                 </child>
+                <child>
+                  <object class="GtkBox" id="buttonbox1">
+                    <property name="visible">1</property>
+                    <property name="margin-top">10</property>
+                    <property name="margin-bottom">10</property>
+                    <property name="halign">end</property>
+                    <property name="valign">end</property>
+                    <child>
+                      <object class="GtkButton" id="btn_add_break">
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
+                        <property name="receives-default">1</property>
+                        <property name="halign">end</property>
+                        <property name="icon-name">gtk-add</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkSeparator" id="separator_butoon">
+                    <property name="visible">1</property>
+                    <property name="margin-top">10</property>
+                  </object>
+                </child>
               </object>
-            </child>
+            </property>
           </object>
-          <packing>
-            <property name="name">Settings</property>
-            <property name="title" translatable="yes">Settings</property>
-          </packing>
         </child>
         <child>
-          <object class="GtkBox" id="box_break">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="margin-left">5</property>
-            <property name="margin-right">5</property>
-            <property name="orientation">vertical</property>
-            <child>
-              <object class="GtkScrolledWindow" id="scrolledwindow_breaks">
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
+          <object class="GtkStackPage">
+            <property name="name">page2</property>
+            <property name="title" translatable="yes">Plugins</property>
+            <property name="child">
+              <object class="GtkScrolledWindow" id="scrolledwindow_plugins">
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
                 <property name="hscrollbar-policy">never</property>
+                <property name="has-frame">1</property>
                 <child>
-                  <object class="GtkViewport" id="viewport_breaks">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="shadow-type">none</property>
+                  <object class="GtkViewport" id="viewport_plugins">
+                    <property name="visible">1</property>
                     <child>
-                      <object class="GtkBox" id="box_breaks">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
+                      <object class="GtkBox" id="box_plugins">
+                        <property name="visible">1</property>
                         <property name="margin-top">10</property>
                         <property name="margin-bottom">10</property>
                         <property name="orientation">vertical</property>
-                        <child>
-                          <object class="GtkBox" id="box4">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="orientation">vertical</property>
-                            <child>
-                              <object class="GtkExpander" id="expander_short_breaks">
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="expanded">True</property>
-                                <child>
-                                  <object class="GtkBox" id="box_short_breaks">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="orientation">vertical</property>
-                                    <property name="spacing">5</property>
-                                    <child>
-                                      <placeholder/>
-                                    </child>
-                                    <child>
-                                      <placeholder/>
-                                    </child>
-                                    <child>
-                                      <placeholder/>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child type="label">
-                                  <object class="GtkLabel" id="lbl_short_breaks">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="label" translatable="yes">Short Breaks</property>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator" id="separator_breaks">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="margin-top">10</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkExpander" id="expander_long_breaks">
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <child>
-                                  <object class="GtkBox" id="box_long_breaks">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="orientation">vertical</property>
-                                    <property name="spacing">5</property>
-                                    <child>
-                                      <placeholder/>
-                                    </child>
-                                    <child>
-                                      <placeholder/>
-                                    </child>
-                                    <child>
-                                      <placeholder/>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child type="label">
-                                  <object class="GtkLabel" id="lbl_long_breaks">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="label" translatable="yes">Long Breaks</property>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
+                        <property name="spacing">5</property>
                       </object>
                     </child>
                   </object>
                 </child>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButtonBox" id="buttonbox1">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-top">10</property>
-                <property name="margin-bottom">10</property>
-                <property name="layout-style">end</property>
-                <child>
-                  <object class="GtkButton" id="btn_add_break">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="receives-default">True</property>
-                    <property name="halign">end</property>
-                    <property name="image">img_add</property>
-                    <signal name="clicked" handler="add_break" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="pack-type">end</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkSeparator" id="separator_butoon">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-top">10</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
+            </property>
           </object>
-          <packing>
-            <property name="name">page1</property>
-            <property name="title" translatable="yes">Breaks</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkScrolledWindow" id="scrolledwindow_plugins">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="hscrollbar-policy">never</property>
-            <property name="shadow-type">in</property>
-            <child>
-              <object class="GtkViewport" id="viewport_plugins">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <child>
-                  <object class="GtkBox" id="box_plugins">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="margin-top">10</property>
-                    <property name="margin-bottom">10</property>
-                    <property name="orientation">vertical</property>
-                    <property name="spacing">5</property>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="name">page2</property>
-            <property name="title" translatable="yes">Plugins</property>
-            <property name="position">2</property>
-          </packing>
         </child>
       </object>
     </child>
     <child type="titlebar">
       <object class="GtkHeaderBar" id="header_bar">
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <property name="title">Safe Eyes</property>
-        <property name="spacing">91</property>
-        <property name="show-close-button">True</property>
+        <property name="visible">1</property>
+        <property name="show-title-buttons">1</property>
         <property name="decoration-layout">menu:close</property>
         <child type="title">
           <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
+            <property name="visible">1</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="visible">1</property>
                 <property name="margin-top">5</property>
                 <property name="label">Safe Eyes</property>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
             </child>
             <child>
               <object class="GtkStackSwitcher">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="visible">1</property>
                 <property name="stack">stack</property>
               </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
             </child>
           </object>
         </child>
         <child>
           <object class="GtkMenuButton">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">True</property>
+            <property name="visible">1</property>
+            <property name="can-focus">1</property>
+            <property name="receives-default">1</property>
             <property name="halign">center</property>
             <property name="valign">center</property>
             <property name="popover">popover</property>
             <child>
               <object class="GtkImage" id="img_icon">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="visible">1</property>
                 <property name="icon-name">io.github.slgobinath.SafeEyes</property>
-                <property name="icon_size">1</property>
+                <property name="icon-size">1</property>
               </object>
             </child>
           </object>

--- a/safeeyes/glade/settings_plugin.glade
+++ b/safeeyes/glade/settings_plugin.glade
@@ -20,39 +20,23 @@
 ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <interface>
-  <requires lib="gtk+" version="3.12"/>
+  <requires lib="gtk" version="4.0"/>
   <object class="GtkWindow" id="dialog_settings_plugin">
-    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Plugin Settings</property>
-    <property name="resizable">False</property>
-    <property name="modal">True</property>
-    <property name="window_position">center-on-parent</property>
-    <property name="default_width">400</property>
-    <property name="default_height">10</property>
-    <property name="destroy_with_parent">True</property>
-    <property name="icon_name">safeeyes</property>
-    <property name="type_hint">dialog</property>
-    <property name="skip_taskbar_hint">True</property>
-    <property name="gravity">center</property>
-    <signal name="delete-event" handler="on_window_delete" swapped="no"/>
+    <property name="resizable">0</property>
+    <property name="modal">1</property>
+    <property name="default-width">400</property>
+    <property name="default-height">10</property>
+    <property name="destroy-with-parent">1</property>
+    <property name="icon-name">safeeyes</property>
     <child>
       <object class="GtkBox" id="box_settings">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="margin_top">10</property>
-        <property name="margin_bottom">10</property>
+        <property name="visible">1</property>
+        <property name="margin-top">10</property>
+        <property name="margin-bottom">10</property>
         <property name="orientation">vertical</property>
         <property name="spacing">15</property>
-        <property name="homogeneous">True</property>
-        <child>
-          <placeholder/>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
+        <property name="homogeneous">1</property>
       </object>
     </child>
   </object>

--- a/safeeyes/model.py
+++ b/safeeyes/model.py
@@ -28,6 +28,10 @@ from typing import Optional, Union
 
 from packaging.version import parse
 
+import gi
+gi.require_version('Gtk', '4.0')
+from gi.repository import Gtk
+
 from safeeyes import utility
 
 
@@ -400,7 +404,8 @@ class TrayAction:
 
     def get_icon(self):
         if self.system_icon:
-            return self.__icon
+            image = Gtk.Image.new_from_icon_name(self.__icon)
+            return image
         else:
             image = utility.load_and_scale_image(self.__icon, 16, 16)
             image.show()

--- a/safeeyes/platform/io.github.slgobinath.SafeEyes.desktop
+++ b/safeeyes/platform/io.github.slgobinath.SafeEyes.desktop
@@ -25,7 +25,7 @@ Comment[tr]=Gözünüzü yorgunluğa karşı koruyun
 Comment[uk]=Захистіть свої очі від втоми
 Comment[vi]=Bảo vệ đôi mắt của bạn khỏi sự mệt mỏi
 GenericName=RSI Prevention
-Exec=env GDK_BACKEND=x11 safeeyes
+Exec=safeeyes
 Icon=io.github.slgobinath.SafeEyes
 Terminal=false
 Type=Application

--- a/safeeyes/plugins/mediacontrol/plugin.py
+++ b/safeeyes/plugins/mediacontrol/plugin.py
@@ -25,7 +25,7 @@ import os
 import re
 import gi
 from safeeyes.model import TrayAction
-gi.require_version('Gtk', '3.0')
+gi.require_version('Gtk', '4.0')
 from gi.repository import Gtk, Gio
 
 tray_icon_path = None

--- a/safeeyes/plugins/mediacontrol/plugin.py
+++ b/safeeyes/plugins/mediacontrol/plugin.py
@@ -96,5 +96,5 @@ def get_tray_action(break_obj):
     if players:
         return TrayAction.build("Pause media",
                                 tray_icon_path,
-                                Gtk.STOCK_MEDIA_PAUSE,
+                                "media-playback-pause",
                                 lambda: __pause_players(players))

--- a/safeeyes/plugins/mediacontrol/plugin.py
+++ b/safeeyes/plugins/mediacontrol/plugin.py
@@ -25,8 +25,8 @@ import os
 import re
 import gi
 from safeeyes.model import TrayAction
-gi.require_version('Gtk', '4.0')
-from gi.repository import Gtk, Gio
+gi.require_version('Gio', '2.0')
+from gi.repository import Gio
 
 tray_icon_path = None
 

--- a/safeeyes/plugins/screensaver/plugin.py
+++ b/safeeyes/plugins/screensaver/plugin.py
@@ -26,7 +26,7 @@ import os
 
 from safeeyes import utility
 from safeeyes.model import TrayAction
-gi.require_version('Gtk', '3.0')
+gi.require_version('Gtk', '4.0')
 from gi.repository import Gtk
 
 context = None

--- a/safeeyes/plugins/screensaver/plugin.py
+++ b/safeeyes/plugins/screensaver/plugin.py
@@ -131,5 +131,5 @@ def on_stop_break():
 def get_tray_action(break_obj):
     return TrayAction.build("Lock screen",
                             tray_icon_path,
-                            Gtk.STOCK_DIALOG_AUTHENTICATION,
+                            "dialog-password",
                             __lock_screen)

--- a/safeeyes/plugins/screensaver/plugin.py
+++ b/safeeyes/plugins/screensaver/plugin.py
@@ -26,8 +26,6 @@ import os
 
 from safeeyes import utility
 from safeeyes.model import TrayAction
-gi.require_version('Gtk', '4.0')
-from gi.repository import Gtk
 
 context = None
 lock_screen = False

--- a/safeeyes/plugins/trayicon/plugin.py
+++ b/safeeyes/plugins/trayicon/plugin.py
@@ -19,7 +19,7 @@
 import datetime
 from safeeyes.model import BreakType
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version('Gtk', '4.0')
 from gi.repository import Gio, GLib
 import logging
 from safeeyes import utility

--- a/safeeyes/safeeyes.py
+++ b/safeeyes/safeeyes.py
@@ -36,7 +36,7 @@ from safeeyes.plugin_manager import PluginManager
 from safeeyes.core import SafeEyesCore
 from safeeyes.ui.settings_dialog import SettingsDialog
 
-gi.require_version('Gtk', '3.0')
+gi.require_version('Gtk', '4.0')
 from gi.repository import Gtk, Gio, GLib
 
 SAFE_EYES_VERSION = "2.2.3"

--- a/safeeyes/ui/about_dialog.py
+++ b/safeeyes/ui/about_dialog.py
@@ -35,8 +35,11 @@ class AboutDialog:
 
     def __init__(self, version):
         builder = utility.create_gtk_builder(ABOUT_DIALOG_GLADE)
-        builder.connect_signals(self)
         self.window = builder.get_object('window_about')
+
+        self.window.connect("close-request", self.on_window_delete)
+        builder.get_object('btn_close').connect('clicked', self.on_close_clicked)
+
         builder.get_object('lbl_decription').set_label(_("Safe Eyes protects your eyes from eye strain (asthenopia) by reminding you to take breaks while you're working long hours at the computer"))
         builder.get_object('lbl_license').set_label(_('License') + ':')
 
@@ -47,7 +50,7 @@ class AboutDialog:
         """
         Show the About dialog.
         """
-        self.window.show_all()
+        self.window.present()
 
     def on_window_delete(self, *args):
         """

--- a/safeeyes/ui/break_screen.py
+++ b/safeeyes/ui/break_screen.py
@@ -27,7 +27,7 @@ from safeeyes import utility
 from Xlib.display import Display
 from Xlib.display import X
 
-gi.require_version('Gtk', '3.0')
+gi.require_version('Gtk', '4.0')
 from gi.repository import Gdk
 from gi.repository import GLib
 from gi.repository import Gtk

--- a/safeeyes/ui/break_screen.py
+++ b/safeeyes/ui/break_screen.py
@@ -62,7 +62,9 @@ class BreakScreen:
         # Initialize the theme
         css_provider = Gtk.CssProvider()
         css_provider.load_from_path(style_sheet_path)
-        Gtk.StyleContext.add_provider_for_screen(Gdk.Screen.get_default(), css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+
+        display = Gdk.Display.get_default()
+        Gtk.StyleContext.add_provider_for_display(display, css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
 
     def initialize(self, config):
         """
@@ -160,25 +162,25 @@ class BreakScreen:
             logging.warning("Keyboard locking not yet implemented for Wayland.")
 
         display = Gdk.Display.get_default()
-        screen = display.get_default_screen()
-        no_of_monitors = display.get_n_monitors()
-        logging.info("Show break screens in %d display(s)", no_of_monitors)
+        monitors = display.get_monitors()
+        logging.info("Show break screens in %d display(s)", len(monitors))
 
         skip_button_disabled = self.context.get('skip_button_disabled', False)
         postpone_button_disabled = self.context.get('postpone_button_disabled', False)
 
-        for monitor_num in range(no_of_monitors):
-            monitor = display.get_monitor(monitor_num)
+        i = 0
+
+        for monitor in monitors:
             monitor_gemoetry = monitor.get_geometry()
             x = monitor_gemoetry.x
             y = monitor_gemoetry.y
 
             builder = Gtk.Builder()
             builder.add_from_file(BREAK_SCREEN_GLADE)
-            builder.connect_signals(self)
 
             window = builder.get_object("window_main")
-            window.set_title("SafeEyes-" + str(monitor_num))
+            window.connect("close-request", self.on_window_delete)
+            window.set_title("SafeEyes-" + str(i))
             lbl_message = builder.get_object("lbl_message")
             lbl_count = builder.get_object("lbl_count")
             lbl_widget = builder.get_object("lbl_widget")
@@ -187,15 +189,14 @@ class BreakScreen:
             toolbar = builder.get_object("toolbar")
 
             for tray_action in tray_actions:
-                toolbar_button = None
-                if tray_action.system_icon:
-                    toolbar_button = Gtk.ToolButton.new_from_stock(tray_action.get_icon())
-                else:
-                    toolbar_button = Gtk.ToolButton.new(tray_action.get_icon(), tray_action.name)
+                # TODO: apparently, this would be better served with an icon theme + Gtk.button.new_from_icon_name
+                icon = tray_action.get_icon()
+                toolbar_button = Gtk.Button()
+                toolbar_button.set_child(icon)
                 tray_action.add_toolbar_button(toolbar_button)
                 toolbar_button.connect("clicked", lambda button, action: self.__tray_action(button, action), tray_action)
                 toolbar_button.set_tooltip_text(_(tray_action.name))
-                toolbar.add(toolbar_button)
+                toolbar.append(toolbar_button)
                 toolbar_button.show()
 
             # Add the buttons
@@ -205,7 +206,7 @@ class BreakScreen:
                 btn_postpone.get_style_context().add_class('btn_postpone')
                 btn_postpone.connect('clicked', self.on_postpone_clicked)
                 btn_postpone.set_visible(True)
-                box_buttons.pack_start(btn_postpone, True, True, 0)
+                box_buttons.append(btn_postpone)
 
             if not self.strict_break and not skip_button_disabled:
                 # Add the skip button
@@ -213,7 +214,7 @@ class BreakScreen:
                 btn_skip.get_style_context().add_class('btn_skip')
                 btn_skip.connect('clicked', self.on_skip_clicked)
                 btn_skip.set_visible(True)
-                box_buttons.pack_start(btn_skip, True, True, 0)
+                box_buttons.append(btn_skip)
 
             # Set values
             if image_path:
@@ -224,23 +225,14 @@ class BreakScreen:
             self.windows.append(window)
             self.count_labels.append(lbl_count)
 
-            # Set visual to apply css theme. It should be called before show method.
-            window.set_visual(window.get_screen().get_rgba_visual())
             if self.context['desktop'] == 'kde':
                 # Fix flickering screen in KDE by setting opacity to 1
                 window.set_opacity(0.9)
 
-            # In Unity, move the window before present
-            window.move(x, y)
-            window.resize(monitor_gemoetry.width, monitor_gemoetry.height)
-            window.stick()
-            window.set_keep_above(True)
-            window.fullscreen_on_monitor(screen, monitor_num)
+            window.fullscreen_on_monitor(monitor)
             window.present()
-            # In other desktop environments, move the window after present
-            window.move(x, y)
-            window.resize(monitor_gemoetry.width, monitor_gemoetry.height)
-            logging.info("Moved break screen to Display[%d, %d]", x, y)
+
+            i = i + 1
 
     def __update_count_down(self, count):
         """

--- a/safeeyes/ui/required_plugin_dialog.py
+++ b/safeeyes/ui/required_plugin_dialog.py
@@ -40,7 +40,7 @@ class RequiredPluginDialog:
         builder = utility.create_gtk_builder(REQUIRED_PLUGIN_DIALOG_GLADE)
         self.window = builder.get_object('window_required_plugin')
 
-        self.window.connect("delete-event", self.on_window_delete)
+        self.window.connect("close-request", self.on_window_delete)
         builder.get_object('btn_close').connect('clicked', self.on_close_clicked)
         builder.get_object('btn_disable_plugin').connect('clicked', self.on_disable_plugin_clicked)
 
@@ -64,7 +64,7 @@ class RequiredPluginDialog:
         """
         Show the dialog.
         """
-        self.window.show_all()
+        self.window.present()
 
     def on_window_delete(self, *args):
         """

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -381,7 +381,6 @@ class PluginSettingsDialog:
         self.property_controls = []
 
         builder = utility.create_gtk_builder(SETTINGS_DIALOG_PLUGIN_GLADE)
-        builder.connect_signals(self)
         self.window = builder.get_object('dialog_settings_plugin')
         box_settings = builder.get_object('box_settings')
         self.window.set_title(_('Plugin Settings'))
@@ -445,7 +444,7 @@ class PluginSettingsDialog:
         """
         Show the Properties dialog.
         """
-        self.window.show_all()
+        self.window.present()
 
 
 class BreakSettingsDialog:
@@ -646,7 +645,6 @@ class NewBreakDialog:
         self.on_add = on_add
 
         builder = utility.create_gtk_builder(SETTINGS_DIALOG_NEW_BREAK_GLADE)
-        builder.connect_signals(self)
         self.window = builder.get_object('dialog_new_break')
         self.txt_break = builder.get_object('txt_break')
         self.cmb_type = builder.get_object('cmb_type')
@@ -654,6 +652,10 @@ class NewBreakDialog:
 
         list_types[0][0] = _(list_types[0][0])
         list_types[1][0] = _(list_types[1][0])
+
+        self.window.connect("close-request", self.on_window_delete)
+        builder.get_object('btn_discard').connect('clicked', self.discard)
+        builder.get_object('btn_save').connect('clicked', self.save)
 
         # Set the values
         self.window.set_title(_('New Break'))
@@ -688,4 +690,4 @@ class NewBreakDialog:
         """
         Show the Properties dialog.
         """
-        self.window.show_all()
+        self.window.present()

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -164,56 +164,57 @@ class SettingsDialog:
 
     def on_reset_menu_clicked(self, button):
         self.popover.hide()
-        def __confirmation_dialog_response(widget, response_id):
-            if response_id == Gtk.ResponseType.OK:
+        def __confirmation_dialog_response(dialog, result):
+            response_id = dialog.choose_finish(result)
+            if response_id == 1:
                 utility.reset_config()
                 self.config = Config()
                 # Remove breaks from the container
-                self.box_short_breaks.foreach(lambda element: self.box_short_breaks.remove(element))
-                self.box_long_breaks.foreach(lambda element: self.box_long_breaks.remove(element))
-                # Remove plugins from the container
-                self.box_plugins.foreach(lambda element: self.box_plugins.remove(element))
+                self.__clear_children(self.box_short_breaks)
+                self.__clear_children(self.box_long_breaks)
+                self.__clear_children(self.box_plugins)
                 # Initialize again
                 self.__initialize(self.config)
-            widget.destroy()
 
-        messagedialog = Gtk.MessageDialog()
+        messagedialog = Gtk.AlertDialog()
         messagedialog.set_modal(True)
-        messagedialog.set_transient_for(self.window)
-        messagedialog.set_property('message_type', Gtk.MessageType.WARNING)
-        messagedialog.set_property('text', _("Are you sure you want to reset all settings to default?"))
-        messagedialog.set_property('secondary-text', _("You can't undo this action."))
-        messagedialog.add_button('_Cancel', Gtk.ResponseType.CANCEL)
-        messagedialog.add_button(_("Reset"), Gtk.ResponseType.OK)
+        messagedialog.set_buttons(['_Cancel', _("Reset")])
+        messagedialog.set_message(_("Are you sure you want to reset all settings to default?"))
+        messagedialog.set_detail(_("You can't undo this action."))
 
-        messagedialog.connect("response", __confirmation_dialog_response)
-        messagedialog.show()
+        messagedialog.set_cancel_button(0)
+        messagedialog.set_default_button(0)
+
+        messagedialog.choose(self.window, None, __confirmation_dialog_response)
+
+    def __clear_children(self, widget):
+        while widget.get_last_child() is not None:
+            widget.remove(widget.get_last_child())
 
     def __delete_break(self, break_config, is_short, on_remove):
         """
         Remove the break after a confirmation.
         """
 
-        def __confirmation_dialog_response(widget, response_id):
-            if response_id == Gtk.ResponseType.OK:
+        def __confirmation_dialog_response(dialog, result):
+            response_id = dialog.choose_finish(result)
+            if response_id == 1:
                 if is_short:
                     self.config.get('short_breaks').remove(break_config)
                 else:
                     self.config.get('long_breaks').remove(break_config)
                 on_remove()
-            widget.destroy()
 
-        messagedialog = Gtk.MessageDialog()
+        messagedialog = Gtk.AlertDialog()
         messagedialog.set_modal(True)
-        messagedialog.set_transient_for(self.window)
-        messagedialog.set_property('message_type', Gtk.MessageType.WARNING)
-        messagedialog.set_property('text', _("Are you sure you want to delete this break?"))
-        messagedialog.set_property('secondary-text', _("You can't undo this action."))
-        messagedialog.add_button('_Cancel', Gtk.ResponseType.CANCEL)
-        messagedialog.add_button(_("Delete"), Gtk.ResponseType.OK)
+        messagedialog.set_buttons(['_Cancel', _("Delete")])
+        messagedialog.set_message(_("Are you sure you want to delete this break?"))
+        messagedialog.set_detail(_("You can't undo this action."))
 
-        messagedialog.connect("response", __confirmation_dialog_response)
-        messagedialog.show()
+        messagedialog.set_cancel_button(0)
+        messagedialog.set_default_button(0)
+
+        messagedialog.choose(self.window, None, __confirmation_dialog_response)
 
     def __create_plugin_item(self, plugin_config):
         """

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -386,11 +386,13 @@ class PluginSettingsDialog:
         self.window.set_title(_('Plugin Settings'))
         for setting in config.get('settings'):
             if setting['type'].upper() == 'INT':
-                box_settings.pack_start(self.__load_int_item(setting['label'], setting['id'], setting['safeeyes_config'], setting.get('min', 0), setting.get('max', 120)), False, False, 0)
+                box_settings.append(self.__load_int_item(setting['label'], setting['id'], setting['safeeyes_config'], setting.get('min', 0), setting.get('max', 120)))
             elif setting['type'].upper() == 'TEXT':
-                box_settings.pack_start(self.__load_text_item(setting['label'], setting['id'], setting['safeeyes_config']), False, False, 0)
+                box_settings.append(self.__load_text_item(setting['label'], setting['id'], setting['safeeyes_config']))
             elif setting['type'].upper() == 'BOOL':
-                box_settings.pack_start(self.__load_bool_item(setting['label'], setting['id'], setting['safeeyes_config']), False, False, 0)
+                box_settings.append(self.__load_bool_item(setting['label'], setting['id'], setting['safeeyes_config']))
+
+        self.window.connect("close-request", self.on_window_delete)
 
     def __load_int_item(self, name, key, settings, min_value, max_value):
         """

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -23,7 +23,7 @@ import gi
 from safeeyes import utility
 from safeeyes.model import Config, PluginDependency
 
-gi.require_version('Gtk', '3.0')
+gi.require_version('Gtk', '4.0')
 from gi.repository import Gtk
 from gi.repository import GdkPixbuf
 

--- a/safeeyes/utility.py
+++ b/safeeyes/utility.py
@@ -38,13 +38,13 @@ from pathlib import Path
 import babel.core
 import babel.dates
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version('Gtk', '4.0')
 from gi.repository import Gtk
 from gi.repository import GLib
 from gi.repository import GdkPixbuf
 from packaging.version import parse
 
-gi.require_version('Gdk', '3.0')
+gi.require_version('Gdk', '4.0')
 
 BIN_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
 HOME_DIRECTORY = os.environ.get('HOME') or os.path.expanduser('~')

--- a/safeeyes/utility.py
+++ b/safeeyes/utility.py
@@ -654,7 +654,7 @@ def create_gtk_builder(glade_file):
     builder.add_from_file(glade_file)
     # Tranlslate all sub components
     for obj in builder.get_objects():
-        if (not isinstance(obj, Gtk.SeparatorMenuItem)) and hasattr(obj, "get_label"):
+        if hasattr(obj, "get_label"):
             label = obj.get_label()
             if label is not None:
                 obj.set_label(_(label))


### PR DESCRIPTION
~Based on https://github.com/slgobinath/SafeEyes/pull/560, will rebase the first two commits away once that is merged.~
~Needs https://github.com/slgobinath/SafeEyes/pull/558 for the trayicon - with the trayicon plugin disabled, this can be tested as-is.~

The changes in the .glade xml files are rather noisy, they were partially done using gtk-builder-tool.
I mostly made sure that things still looked correct visually after running the tool.

Opening this as draft for now, as it relies on the two PRs above. Additionally, this is a rather big PR, and I'd like to split it into things that are backwards compatible with gtk3 (like most changes in the .glade files) and things that are not.
It also likely needs some changes in the configurations/dependencies.

Fixes https://github.com/slgobinath/SafeEyes/issues/367.
Fixes https://github.com/slgobinath/SafeEyes/issues/521.
Fixes https://github.com/slgobinath/SafeEyes/issues/473.