### PR TITLE
donotdisturb: fix for GNOME

### DIFF
--- a/safeeyes/plugins/donotdisturb/dependency_checker.py
+++ b/safeeyes/plugins/donotdisturb/dependency_checker.py
@@ -22,6 +22,8 @@ from safeeyes import utility
 def validate(plugin_config, plugin_settings):
     command = None
     if utility.IS_WAYLAND:
+        if utility.DESKTOP_ENVIRONMENT == "gnome":
+            return None
         command = "wlrctl"
     else:
         command = "xprop"


### PR DESCRIPTION
GNOME Shell (on Wayland) doesn't work with wlrctl, but there is a DBus property that can be read to see if any application has requested that the screensaver not kick in, so let's use that to suppress SafeEyes breaks too—it's not exactly the same as detecting if the active window is fullscreen, but I actually think it's a little better (if a productivity application is fullscreened, we probably want breaks; if a real-time game is running in a window, we probably don't).

I'm using the Gio interface to DBus instead of dbus-python, per the direction proposed in #558.