### PR TITLE
New version with python 3.12 support

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+safeeyes (2.1.7) noble; urgency=medium
+
+  * Support Python 3.12
+
+ -- Archisman Panigrahi <apandada1@gmail.com>  Mon, 29 Apr 2024 02:09:48 -0400
+
 safeeyes (2.1.6-0) lunar; urgency=high
   * Support Python 3.11
 

--- a/safeeyes/glade/about_dialog.glade
+++ b/safeeyes/glade/about_dialog.glade
@@ -71,7 +71,7 @@ along with this program.  If not, see &lt;https://www.gnu.org/licenses/&gt;.</pr
                 <property name="valign">center</property>
                 <property name="margin_top">10</property>
                 <property name="margin_bottom">10</property>
-                <property name="label" translatable="yes">Safe Eyes 2.1.5</property>
+                <property name="label" translatable="yes">Safe Eyes 2.1.7</property>
                 <property name="justify">center</property>
                 <attributes>
                   <attribute name="style" value="normal"/>

--- a/safeeyes/platform/io.github.slgobinath.SafeEyes.metainfo.xml
+++ b/safeeyes/platform/io.github.slgobinath.SafeEyes.metainfo.xml
@@ -47,7 +47,7 @@
     <url type="homepage">https://slgobinath.github.io/SafeEyes/</url>
 
     <releases>
-        <release version="2.1.6" date="2023-06-04" />
+        <release version="2.1.7" date="2023-06-04" />
     </releases>
 
     <content_rating type="oars-1.1" />

--- a/safeeyes/safeeyes.py
+++ b/safeeyes/safeeyes.py
@@ -40,7 +40,7 @@ from safeeyes.ui.settings_dialog import SettingsDialog
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 
-SAFE_EYES_VERSION = "2.1.6"
+SAFE_EYES_VERSION = "2.1.7"
 
 
 class SafeEyes:

--- a/setup.py
+++ b/setup.py
@@ -78,14 +78,14 @@ def __package_data():
 
 setuptools.setup(
     name="safeeyes",
-    version="2.1.6",
+    version="2.1.7",
     description="Protect your eyes from eye strain using this continuous breaks reminder.",
     long_description=long_description,
     long_description_content_type="text/markdown",
     author="Gobinath Loganathan",
     author_email="slgobinath@gmail.com",
     url="https://github.com/slgobinath/SafeEyes",
-    download_url="https://github.com/slgobinath/SafeEyes/archive/v2.1.6.tar.gz",
+    download_url="https://github.com/slgobinath/SafeEyes/archive/v2.1.7.tar.gz",
     packages=setuptools.find_packages(),
     package_data={'safeeyes': __package_data()},
     data_files=__data_files(),


### PR DESCRIPTION
I followed 1-5 in https://github.com/slgobinath/SafeEyes?tab=readme-ov-file#how-to-release

After merging this, please Create a pull-request from `master` to `release`, and Merge the PR to release with merge commit, as described in [How to release](https://github.com/slgobinath/SafeEyes?tab=readme-ov-file#how-to-release).

We desperately need a new version because safeeyes is broken in latest version of Ubuntu, Fedora and Arch, all of which now use python 3.12