### PR TITLE
Smartpause: add support for ext-idle-notify-v1 using pywayland

### DIFF
--- a/safeeyes/plugins/smartpause/config.json
+++ b/safeeyes/plugins/smartpause/config.json
@@ -5,7 +5,7 @@
         "version": "0.0.3"
     },
     "dependencies": {
-        "python_modules": [],
+        "python_modules": ["pywayland"],
         "shell_commands": [],
         "operating_systems": [],
         "desktop_environments": [],

--- a/safeeyes/plugins/smartpause/dependency_checker.py
+++ b/safeeyes/plugins/smartpause/dependency_checker.py
@@ -25,6 +25,11 @@ def validate(plugin_config, plugin_settings):
         command = "dbus-send"
     elif utility.DESKTOP_ENVIRONMENT == "sway":
         command = "swayidle"
+    elif utility.IS_WAYLAND:
+        if not utility.module_exist("pywayland"):
+            return _("Please install the Python module '%s'") % "pywayland"
+        # no command needed with pywayland
+        return None
     else:
         command = "xprintidle"
     if not utility.command_exist(command):

--- a/safeeyes/plugins/smartpause/ext_idle_notify.py
+++ b/safeeyes/plugins/smartpause/ext_idle_notify.py
@@ -1,0 +1,93 @@
+# Safe Eyes is a utility to remind you to take break frequently
+# to protect your eyes from eye strain.
+
+# Copyright (C) 2017  Gobinath
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file is heavily inspired by https://github.com/juienpro/easyland/blob/efc26a0b22d7bdbb0f8436183428f7036da4662a/src/easyland/idle.py
+
+import logging
+import threading
+import datetime
+
+from pywayland.client import Display
+from pywayland.protocol.wayland.wl_seat import WlSeat
+from pywayland.protocol.ext_idle_notify_v1 import (
+    ExtIdleNotificationV1,
+    ExtIdleNotifierV1
+)
+
+
+class ExtIdleNotify:
+    _idle_notifier = None
+    _seat = None
+    _notification = None
+    _notifier_set = False
+    _running = True
+    _thread = None
+
+    _idle_since = None
+
+    def __init__(self):
+        self._display = Display()
+        self._display.connect()
+
+    def stop(self):
+        self._running = False
+        self._notification.destroy()
+        self._notification = None
+        self._seat = None
+        self._thread.join()
+
+    def run(self):
+        self._thread = threading.Thread(target=self._run, name="ExtIdleNotify", daemon=False)
+        self._thread.start()
+
+    def _run(self):
+        reg = self._display.get_registry()
+        reg.dispatcher['global'] = self._global_handler
+
+        while self._running:
+            self._display.dispatch(block=True)
+
+        self._display.disconnect()
+
+    def _global_handler(self, reg, id_num, iface_name, version):
+        if iface_name == 'wl_seat':
+            self._seat = reg.bind(id_num, WlSeat, version)
+        if iface_name == "ext_idle_notifier_v1":
+            self._idle_notifier = reg.bind(id_num, ExtIdleNotifierV1, version)
+
+        if self._idle_notifier and self._seat and not self._notifier_set:
+            self._notifier_set = True
+            timeout_sec = 1
+            self._notification = self._idle_notifier.get_idle_notification(timeout_sec * 1000, self._seat)
+            self._notification.dispatcher['idled'] = self._idle_notifier_handler
+            self._notification.dispatcher['resumed'] = self._idle_notifier_resume_handler
+
+    def _idle_notifier_handler(self, notification):
+        self._idle_since = datetime.datetime.now()
+
+    def _idle_notifier_resume_handler(self, notification):
+        self._idle_since = None
+
+    def get_idle_time_seconds(self):
+        if self._idle_since is None:
+            return 0
+
+        result = datetime.datetime.now() - self._idle_since
+        return result.total_seconds()
+
+

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import setuptools
 
 
 requires = [
+    'pywayland',
     'babel',
     'psutil',
     'croniter',


### PR DESCRIPTION
Fixes https://github.com/slgobinath/SafeEyes/issues/391.

This is an alternative to https://github.com/slgobinath/SafeEyes/pull/553. Instead of relying on swayidle, which appears to have issues both on KDE as well as within Flatpaks, this PR uses [pywayland](https://pypi.org/project/pywayland/) to use the ext-idle-notify-v1 wayland protocol directly.

Tested on KDE Plasma 6.0 Wayland.
This still needs to be tested on compositors that do not implement the ext-idle-notify-v1 protocol. According to [this](https://wayland.app/protocols/ext-idle-notify-v1#compositor-support), this would be Weston, Mir or GameScope. (Gnome still has its own solution.) The plugin will not work correctly on these compositors, but we should probably give a better error.