### PR TITLE
release.yml: Stop tagging releases as "vv<version>" with double "v"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Create Tag
         uses: mathieudutour/github-tag-action@v6.1
         with:
-          custom_tag: "v${{steps.get_current_version.outputs.project_version}}"
+          custom_tag: "${{steps.get_current_version.outputs.project_version}}"
           github_token: ${{ secrets.GH_API_SECRET }}
 
       - name: Build Changelog


### PR DESCRIPTION
After #530 and https://github.com/slgobinath/SafeEyes/issues/552#issuecomment-2156178439 I had a closer look now and found the cause in action at https://github.com/slgobinath/SafeEyes/actions/runs/9431239436/job/25979687508#step:7:17 …

![tag_ci_issue_Screenshot_20240608_231614](https://github.com/slgobinath/SafeEyes/assets/1577132/dbb66fea-1ec4-4143-a1bf-c67d5abb2c93)

Default config "tag_prefix: v" already adds prefix "v" for us.

CC @slgobinath 



