### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build
-          pip install wheel
+          pip install build wheel
 
       - name: Get Current Version
         run: |
@@ -50,7 +49,7 @@ jobs:
           token: ${{ secrets.GH_API_SECRET }}
 
       - name: Build Python Package
-        run: rm -Rf build *.egg-info/ && python3 setup.py sdist bdist_wheel
+        run: rm -rf build *.egg-info/ && python3 -m build
 
       - name: Publish to PyPi
         uses: pypa/gh-action-pypi-publish@v1.6.4


### PR DESCRIPTION
Changes:
* Use recommended build package for building as the use of setup.py as a command line to tool is deprecated
* Install multiple packages with one command which theoretically saves some time