### PR TITLE
add list of contributors to about dialog

### DIFF
--- a/safeeyes/config/locale/ar/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/ar/LC_MESSAGES/safeeyes.po
@@ -107,6 +107,10 @@ msgstr "الوصف"
 msgid "License"
 msgstr "الرخصة"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "تجاوز"

--- a/safeeyes/config/locale/bg/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/bg/LC_MESSAGES/safeeyes.po
@@ -106,6 +106,10 @@ msgstr ""
 msgid "License"
 msgstr "Лиценз"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "Пропускане"

--- a/safeeyes/config/locale/ca/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/ca/LC_MESSAGES/safeeyes.po
@@ -109,6 +109,10 @@ msgstr ""
 msgid "License"
 msgstr "Llicència"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "Omet"

--- a/safeeyes/config/locale/cs/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/cs/LC_MESSAGES/safeeyes.po
@@ -110,6 +110,10 @@ msgstr ""
 msgid "License"
 msgstr "Licence"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "Přeskočit"

--- a/safeeyes/config/locale/da/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/da/LC_MESSAGES/safeeyes.po
@@ -108,6 +108,10 @@ msgstr "beskrivelse"
 msgid "License"
 msgstr "Licens"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "Spring over"

--- a/safeeyes/config/locale/de/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/de/LC_MESSAGES/safeeyes.po
@@ -111,6 +111,10 @@ msgstr ""
 msgid "License"
 msgstr "Lizenz"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "Überspringen"

--- a/safeeyes/config/locale/en_US/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/en_US/LC_MESSAGES/safeeyes.po
@@ -111,6 +111,10 @@ msgstr ""
 msgid "License"
 msgstr "License"
 
+# About dialog
+msgid "List of Contributors"
+msgstr "List of Contributors"
+
 # Break screen
 msgid "Skip"
 msgstr "Skip"

--- a/safeeyes/config/locale/eo/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/eo/LC_MESSAGES/safeeyes.po
@@ -109,6 +109,10 @@ msgstr "Priskribo"
 msgid "License"
 msgstr "Licenco"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "Preterpasi"

--- a/safeeyes/config/locale/es/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/es/LC_MESSAGES/safeeyes.po
@@ -110,6 +110,10 @@ msgstr ""
 msgid "License"
 msgstr "Licencia"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "Saltar"

--- a/safeeyes/config/locale/et/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/et/LC_MESSAGES/safeeyes.po
@@ -110,6 +110,10 @@ msgstr ""
 msgid "License"
 msgstr "Litsents"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "Jäta vahele"

--- a/safeeyes/config/locale/eu/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/eu/LC_MESSAGES/safeeyes.po
@@ -110,6 +110,10 @@ msgstr ""
 msgid "License"
 msgstr "Lizentzia"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "Saltatu"

--- a/safeeyes/config/locale/fa/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/fa/LC_MESSAGES/safeeyes.po
@@ -110,6 +110,10 @@ msgstr ""
 msgid "License"
 msgstr "پروانه"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "پرش"

--- a/safeeyes/config/locale/fr/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/fr/LC_MESSAGES/safeeyes.po
@@ -111,6 +111,10 @@ msgstr ""
 msgid "License"
 msgstr "Licence"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "Ignorer"

--- a/safeeyes/config/locale/he/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/he/LC_MESSAGES/safeeyes.po
@@ -108,6 +108,10 @@ msgstr "תיאור"
 msgid "License"
 msgstr "רישיון"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "מסך הפסקה"

--- a/safeeyes/config/locale/hi/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/hi/LC_MESSAGES/safeeyes.po
@@ -106,6 +106,10 @@ msgstr "विवरण"
 msgid "License"
 msgstr "लाइसेंस"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "छोड़ें"

--- a/safeeyes/config/locale/hu/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/hu/LC_MESSAGES/safeeyes.po
@@ -106,6 +106,10 @@ msgstr "leírás"
 msgid "License"
 msgstr "Licensz"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "Kihagyás"

--- a/safeeyes/config/locale/id/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/id/LC_MESSAGES/safeeyes.po
@@ -108,6 +108,10 @@ msgstr "Deskripsi"
 msgid "License"
 msgstr "Lisensi"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "Lewati"

--- a/safeeyes/config/locale/it/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/it/LC_MESSAGES/safeeyes.po
@@ -110,6 +110,10 @@ msgstr ""
 msgid "License"
 msgstr "Licenza"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "Salta"

--- a/safeeyes/config/locale/kn/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/kn/LC_MESSAGES/safeeyes.po
@@ -108,6 +108,10 @@ msgstr "ವಿವರಣೆ"
 msgid "License"
 msgstr "ಪರವಾನಿಗೆ"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr ""

--- a/safeeyes/config/locale/ko/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/ko/LC_MESSAGES/safeeyes.po
@@ -108,6 +108,10 @@ msgstr "설명"
 msgid "License"
 msgstr "라이선스"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "넘기기"

--- a/safeeyes/config/locale/lt/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/lt/LC_MESSAGES/safeeyes.po
@@ -111,6 +111,10 @@ msgstr ""
 msgid "License"
 msgstr "Licencija"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "Praleisti"

--- a/safeeyes/config/locale/lv/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/lv/LC_MESSAGES/safeeyes.po
@@ -89,6 +89,10 @@ msgstr ""
 msgid "License"
 msgstr "Licence"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 msgid "Skip"
 msgstr "Izlaist"
 

--- a/safeeyes/config/locale/mk/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/mk/LC_MESSAGES/safeeyes.po
@@ -108,6 +108,10 @@ msgstr ""
 msgid "License"
 msgstr ""
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr ""

--- a/safeeyes/config/locale/mr/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/mr/LC_MESSAGES/safeeyes.po
@@ -107,6 +107,10 @@ msgstr ""
 msgid "License"
 msgstr ""
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr ""

--- a/safeeyes/config/locale/nb/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/nb/LC_MESSAGES/safeeyes.po
@@ -109,6 +109,10 @@ msgstr "Øyetrygg beskytter øyene dine fra belastning"
 msgid "License"
 msgstr "Lisens"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "Hopp over"

--- a/safeeyes/config/locale/nl/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/nl/LC_MESSAGES/safeeyes.po
@@ -111,6 +111,10 @@ msgstr ""
 msgid "License"
 msgstr "Licentie"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "Overslaan"

--- a/safeeyes/config/locale/pl/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/pl/LC_MESSAGES/safeeyes.po
@@ -111,6 +111,10 @@ msgstr ""
 msgid "License"
 msgstr "Licencja"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "Pomiń"

--- a/safeeyes/config/locale/pt/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/pt/LC_MESSAGES/safeeyes.po
@@ -111,6 +111,10 @@ msgstr ""
 msgid "License"
 msgstr "Licença"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "Ignorar"

--- a/safeeyes/config/locale/pt_BR/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/pt_BR/LC_MESSAGES/safeeyes.po
@@ -110,6 +110,10 @@ msgstr ""
 msgid "License"
 msgstr "Licença"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "Pular"

--- a/safeeyes/config/locale/ru/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/ru/LC_MESSAGES/safeeyes.po
@@ -111,6 +111,10 @@ msgstr ""
 msgid "License"
 msgstr "Лицензия"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "Пропустить"

--- a/safeeyes/config/locale/safeeyes.pot
+++ b/safeeyes/config/locale/safeeyes.pot
@@ -90,6 +90,10 @@ msgstr ""
 msgid "License"
 msgstr ""
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr ""
@@ -503,3 +507,4 @@ msgstr ""
 # plugin/limitconsecutiveskipping
 msgid "Skipped or postponed %d/%d breaks in a row"
 msgstr ""
+

--- a/safeeyes/config/locale/sk/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/sk/LC_MESSAGES/safeeyes.po
@@ -111,6 +111,10 @@ msgstr ""
 msgid "License"
 msgstr "Licencia"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "Preskočiť"

--- a/safeeyes/config/locale/sr/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/sr/LC_MESSAGES/safeeyes.po
@@ -111,6 +111,10 @@ msgstr ""
 msgid "License"
 msgstr "Лиценца"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "Прескочите"

--- a/safeeyes/config/locale/sv/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/sv/LC_MESSAGES/safeeyes.po
@@ -108,6 +108,10 @@ msgstr "beskrivning"
 msgid "License"
 msgstr "Licens"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "Hoppa över"

--- a/safeeyes/config/locale/ta/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/ta/LC_MESSAGES/safeeyes.po
@@ -111,6 +111,10 @@ msgstr ""
 msgid "License"
 msgstr "மென்பொருள் உரிமம்"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "தவிர்"

--- a/safeeyes/config/locale/tr/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/tr/LC_MESSAGES/safeeyes.po
@@ -111,6 +111,10 @@ msgstr ""
 msgid "License"
 msgstr "Lisans"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "Geç"

--- a/safeeyes/config/locale/ug/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/ug/LC_MESSAGES/safeeyes.po
@@ -105,6 +105,10 @@ msgstr ""
 msgid "License"
 msgstr ""
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr ""

--- a/safeeyes/config/locale/uk/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/uk/LC_MESSAGES/safeeyes.po
@@ -109,6 +109,10 @@ msgstr "Опис"
 msgid "License"
 msgstr "Ліцензія"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "Пропустити"

--- a/safeeyes/config/locale/uz_Latn/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/uz_Latn/LC_MESSAGES/safeeyes.po
@@ -105,6 +105,10 @@ msgstr ""
 msgid "License"
 msgstr ""
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr ""

--- a/safeeyes/config/locale/vi/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/vi/LC_MESSAGES/safeeyes.po
@@ -110,6 +110,10 @@ msgstr ""
 msgid "License"
 msgstr "Giấy phép"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "Bỏ qua"

--- a/safeeyes/config/locale/zh_CN/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/zh_CN/LC_MESSAGES/safeeyes.po
@@ -109,6 +109,10 @@ msgstr ""
 msgid "License"
 msgstr "许可"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "跳过"

--- a/safeeyes/config/locale/zh_TW/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/zh_TW/LC_MESSAGES/safeeyes.po
@@ -106,6 +106,10 @@ msgstr "描述"
 msgid "License"
 msgstr "授權"
 
+# About dialog
+msgid "List of Contributors"
+msgstr ""
+
 # Break screen
 msgid "Skip"
 msgstr "跳過"

--- a/safeeyes/glade/about_dialog.glade
+++ b/safeeyes/glade/about_dialog.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.40.0 -->
 <!--
 ~ Safe Eyes is a utility to remind you to take break frequently
 ~ to protect your eyes from eye strain.
@@ -20,7 +20,7 @@
 ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <interface>
-  <requires lib="gtk+" version="3.12"/>
+  <requires lib="gtk+" version="3.20"/>
   <object class="GtkTextBuffer" id="text_buffer_license">
     <property name="text" translatable="yes">This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -36,41 +36,41 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see &lt;https://www.gnu.org/licenses/&gt;.</property>
   </object>
   <object class="GtkWindow" id="window_about">
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="title" translatable="yes">Safe Eyes</property>
     <property name="resizable">False</property>
-    <property name="window_position">center-always</property>
-    <property name="icon_name">safeeyes</property>
-    <property name="type_hint">dialog</property>
+    <property name="window-position">center-always</property>
+    <property name="icon-name">safeeyes</property>
+    <property name="type-hint">dialog</property>
     <property name="gravity">center</property>
     <signal name="delete-event" handler="on_window_delete" swapped="no"/>
     <child>
       <object class="GtkBox" id="layout_box">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="margin_left">5</property>
-        <property name="margin_right">5</property>
-        <property name="margin_top">5</property>
-        <property name="margin_bottom">5</property>
+        <property name="can-focus">False</property>
+        <property name="margin-left">5</property>
+        <property name="margin-right">5</property>
+        <property name="margin-top">5</property>
+        <property name="margin-bottom">5</property>
         <property name="hexpand">True</property>
         <property name="vexpand">True</property>
         <property name="orientation">vertical</property>
-        <property name="baseline_position">top</property>
+        <property name="baseline-position">top</property>
         <child>
           <object class="GtkBox" id="box1">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="valign">start</property>
             <property name="hexpand">True</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkLabel" id="lbl_app_name">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="halign">center</property>
                 <property name="valign">center</property>
-                <property name="margin_top">10</property>
-                <property name="margin_bottom">10</property>
+                <property name="margin-top">10</property>
+                <property name="margin-bottom">10</property>
                 <property name="label" translatable="yes">Safe Eyes 2.2.0</property>
                 <property name="justify">center</property>
                 <attributes>
@@ -87,13 +87,13 @@ along with this program.  If not, see &lt;https://www.gnu.org/licenses/&gt;.</pr
             <child>
               <object class="GtkLabel" id="lbl_decription">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_top">4</property>
+                <property name="can-focus">False</property>
+                <property name="margin-top">4</property>
                 <property name="label" translatable="yes">Safe Eyes protects your eyes from eye strain (asthenopia) by reminding you to take breaks while you're working long hours at the computer</property>
                 <property name="justify">fill</property>
                 <property name="wrap">True</property>
-                <property name="width_chars">60</property>
-                <property name="max_width_chars">60</property>
+                <property name="width-chars">60</property>
+                <property name="max-width-chars">60</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -104,10 +104,10 @@ along with this program.  If not, see &lt;https://www.gnu.org/licenses/&gt;.</pr
             <child>
               <object class="GtkLabel" id="lbl_license">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="halign">start</property>
                 <property name="valign">center</property>
-                <property name="margin_top">10</property>
+                <property name="margin-top">10</property>
                 <property name="label" translatable="yes">License:</property>
               </object>
               <packing>
@@ -119,13 +119,13 @@ along with this program.  If not, see &lt;https://www.gnu.org/licenses/&gt;.</pr
             <child>
               <object class="GtkTextView" id="txt_license">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="can-focus">True</property>
                 <property name="hexpand">True</property>
                 <property name="vexpand">True</property>
                 <property name="editable">False</property>
-                <property name="wrap_mode">word</property>
+                <property name="wrap-mode">word</property>
                 <property name="buffer">text_buffer_license</property>
-                <property name="accepts_tab">False</property>
+                <property name="accepts-tab">False</property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -137,9 +137,9 @@ along with this program.  If not, see &lt;https://www.gnu.org/licenses/&gt;.</pr
               <object class="GtkLinkButton" id="btn_url">
                 <property name="label" translatable="yes">https://slgobinath.github.io/SafeEyes</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="focus_on_click">False</property>
-                <property name="receives_default">True</property>
+                <property name="can-focus">True</property>
+                <property name="focus-on-click">False</property>
+                <property name="receives-default">True</property>
                 <property name="halign">center</property>
                 <property name="relief">none</property>
                 <property name="uri">https://slgobinath.github.io/SafeEyes</property>
@@ -160,9 +160,9 @@ along with this program.  If not, see &lt;https://www.gnu.org/licenses/&gt;.</pr
         <child>
           <object class="GtkSeparator" id="separator">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="margin_top">5</property>
-            <property name="margin_bottom">5</property>
+            <property name="can-focus">False</property>
+            <property name="margin-top">5</property>
+            <property name="margin-bottom">5</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -173,16 +173,32 @@ along with this program.  If not, see &lt;https://www.gnu.org/licenses/&gt;.</pr
         <child>
           <object class="GtkButtonBox" id="buttonbox">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="valign">start</property>
-            <property name="margin_right">5</property>
-            <property name="layout_style">end</property>
+            <property name="margin-right">5</property>
+            <child>
+              <object class="GtkLinkButton" id="btn_url1">
+                <property name="label" translatable="yes">List of Contributors</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="focus-on-click">False</property>
+                <property name="receives-default">True</property>
+                <property name="halign">center</property>
+                <property name="relief">none</property>
+                <property name="uri">https://github.com/slgobinath/SafeEyes/graphs/contributors?type=a</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
             <child>
               <object class="GtkButton" id="btn_close">
                 <property name="label" translatable="yes">Close</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
                 <signal name="clicked" handler="on_close_clicked" swapped="no"/>
               </object>
               <packing>


### PR DESCRIPTION
Added the [list of contributors](https://github.com/slgobinath/SafeEyes/graphs/contributors?type=a) to About Dialog.

In future, maybe after we port to GTK4, we can perhaps use an inbuilt Credits menu like some other apps.