### PR TITLE
Enabled limiting consecutive skips enabled by default

### DIFF
--- a/safeeyes/config/safeeyes.json
+++ b/safeeyes/config/safeeyes.json
@@ -128,6 +128,14 @@
             "id": "mediacontrol",
             "enabled": true,
             "version": "0.0.1"
+        },
+        {
+            "id": "limitconsecutiveskipping",
+            "enabled": true,
+            "version": "0.0.1",
+            "settings": {
+                "number_of_allowed_skips_in_a_row": 2
+            }
         }
     ]
 }


### PR DESCRIPTION
It looks like this is the way of making a plugin enabled by default.

One note is that I am not sure whether it is a good idea to enable this plugin by default, because it eventually makes it impossible to skip a break, which may catch an uninitiated user by surprise and disturb their work. I don't think it is a big deal for most people in most cases, and a PC is not a phone (which are essential in critical situations), but still, it is something to be wary of.