### PR TITLE
fix gtk startup order

### DIFF
--- a/safeeyes/safeeyes.py
+++ b/safeeyes/safeeyes.py
@@ -51,7 +51,7 @@ class SafeEyes(Gtk.Application):
     def __init__(self, system_locale, config, cli_args):
         super().__init__(
             application_id="io.github.slgobinath.SafeEyes",
-            flags=Gio.ApplicationFlags.IS_SERVICE
+            flags=Gio.ApplicationFlags.DEFAULT_FLAGS
         )
         self.active = False
         self.break_screen = None
@@ -63,12 +63,24 @@ class SafeEyes(Gtk.Application):
         self.rpc_server = None
         self._status = ''
         self.cli_args = cli_args
+        self.system_locale = system_locale
+
+    def start(self):
+        """
+        Start Safe Eyes
+        """
+        self.run()
+
+    def do_startup(self):
+        Gtk.Application.do_startup(self)
+
+        logging.info('Starting up Application')
 
         # Initialize the Safe Eyes Context
         self.context['version'] = SAFE_EYES_VERSION
         self.context['desktop'] = utility.desktop_environment()
         self.context['is_wayland'] = utility.is_wayland()
-        self.context['locale'] = system_locale
+        self.context['locale'] = self.system_locale
         self.context['api'] = {}
         self.context['api']['show_settings'] = lambda: utility.execute_main_thread(
             self.show_settings)
@@ -108,10 +120,6 @@ class SafeEyes(Gtk.Application):
 
         atexit.register(self.persist_session)
 
-    def start(self):
-        """
-        Start Safe Eyes
-        """
         if self.config.get('use_rpc_server', True):
             self.__start_rpc_server()
 
@@ -122,10 +130,8 @@ class SafeEyes(Gtk.Application):
             self.safe_eyes_core.start()
             self.handle_system_suspend()
 
-        self.run()
-
-    def do_startup(self):
-        Gtk.Application.do_startup(self)
+    def do_activate(self):
+        logging.info('Application activated')
 
         if self.cli_args.about:
             self.show_about()


### PR DESCRIPTION
Ensure that the Gtk.Application is fully started up before other Gtk/Gdk
methods are called.

Should hopefully address https://github.com/slgobinath/SafeEyes/issues/467.