### PR TITLE
migrate from setup.py to pyproject.toml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,15 +24,16 @@ jobs:
           pip install build wheel
 
       - name: Get Current Version
-        run: |
-          project_version=$(python3 setup.py --version)
-          echo "project_version=$project_version" >> $GITHUB_OUTPUT
+        uses: SebRollen/toml-action@v1.2.0
+        with:
+          file: "pyproject.toml"
+          field: project.version
         id: get_current_version
 
       - name: Create Tag
         uses: mathieudutour/github-tag-action@v6.1
         with:
-          custom_tag: "${{steps.get_current_version.outputs.project_version}}"
+          custom_tag: "${{steps.get_current_version.outputs.value}}"
           github_token: ${{ secrets.GH_API_SECRET }}
 
       - name: Build Changelog
@@ -44,7 +45,7 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: 'v${{steps.get_current_version.outputs.project_version}}'
+          tag_name: 'v${{steps.get_current_version.outputs.value}}'
           body: ${{steps.build_changelog.outputs.changelog}}
           token: ${{ secrets.GH_API_SECRET }}
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,6 @@
 include LICENSES/GPL-3.0-or-later.txt
 include README.md
+
+graft safeeyes
+
+global-exclude *.py[cod]

--- a/README.md
+++ b/README.md
@@ -200,8 +200,8 @@ To ensure the new strings are well-formed, you can use `python validate_po.py --
 1. Checkout the latest commits from the `master` branch
 2. Run `python3 -m safeeyes` to make sure nothing is broken
 3. Update the Safe Eyes version in the following places (Open the project in VSCode and search for the current version):
-    - [setup.py](https://github.com/slgobinath/SafeEyes/blob/master/setup.py#L82)
-    - [setup.py](https://github.com/slgobinath/SafeEyes/blob/master/setup.py#L89)
+    - [pyproject.toml](https://github.com/slgobinath/SafeEyes/blob/master/pyproject.toml#L4)
+    - [pyproject.toml](https://github.com/slgobinath/SafeEyes/blob/master/pyproject.toml#L35)
     - [safeeyes.py](https://github.com/slgobinath/SafeEyes/blob/master/safeeyes/safeeyes.py#L42)
     - [io.github.slgobinath.SafeEyes.metainfo.xml](https://github.com/slgobinath/SafeEyes/blob/master/safeeyes/platform/io.github.slgobinath.SafeEyes.metainfo.xml#L56)
     - [about_dialog.glade](https://github.com/slgobinath/SafeEyes/blob/master/safeeyes/glade/about_dialog.glade#L74)

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ To ensure the new strings are well-formed, you can use `python validate_po.py --
 2. Run `python3 -m safeeyes` to make sure nothing is broken
 3. Update the Safe Eyes version in the following places (Open the project in VSCode and search for the current version):
     - [pyproject.toml](https://github.com/slgobinath/SafeEyes/blob/master/pyproject.toml#L4)
-    - [pyproject.toml](https://github.com/slgobinath/SafeEyes/blob/master/pyproject.toml#L36)
+    - [pyproject.toml](https://github.com/slgobinath/SafeEyes/blob/master/pyproject.toml#L35)
     - [io.github.slgobinath.SafeEyes.metainfo.xml](https://github.com/slgobinath/SafeEyes/blob/master/safeeyes/platform/io.github.slgobinath.SafeEyes.metainfo.xml#L56)
     - [about_dialog.glade](https://github.com/slgobinath/SafeEyes/blob/master/safeeyes/glade/about_dialog.glade#L74)
 4. Update the [changelog](https://github.com/slgobinath/SafeEyes/blob/master/debian/changelog) (for Ubuntu PPA release)

--- a/README.md
+++ b/README.md
@@ -201,8 +201,7 @@ To ensure the new strings are well-formed, you can use `python validate_po.py --
 2. Run `python3 -m safeeyes` to make sure nothing is broken
 3. Update the Safe Eyes version in the following places (Open the project in VSCode and search for the current version):
     - [pyproject.toml](https://github.com/slgobinath/SafeEyes/blob/master/pyproject.toml#L4)
-    - [pyproject.toml](https://github.com/slgobinath/SafeEyes/blob/master/pyproject.toml#L35)
-    - [safeeyes.py](https://github.com/slgobinath/SafeEyes/blob/master/safeeyes/safeeyes.py#L42)
+    - [pyproject.toml](https://github.com/slgobinath/SafeEyes/blob/master/pyproject.toml#L36)
     - [io.github.slgobinath.SafeEyes.metainfo.xml](https://github.com/slgobinath/SafeEyes/blob/master/safeeyes/platform/io.github.slgobinath.SafeEyes.metainfo.xml#L56)
     - [about_dialog.glade](https://github.com/slgobinath/SafeEyes/blob/master/safeeyes/glade/about_dialog.glade#L74)
 4. Update the [changelog](https://github.com/slgobinath/SafeEyes/blob/master/debian/changelog) (for Ubuntu PPA release)

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: safeeyes
 Section: utils
 Priority: optional
 Maintainer: Gobinath Loganathan <slgobinath@gmail.com>
-Build-Depends: debhelper (>= 10), dh-python, python3, python3-packaging, python3-setuptools
+Build-Depends: debhelper (>= 10), dh-python, python3, python3-packaging, python3-setuptools, pybuild-plugin-pyproject
 Standards-Version: 3.9.6
 X-Python3-Version: >= 3.10
 Homepage: https://github.com/slgobinath/SafeEyes/

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: safeeyes
 Section: utils
 Priority: optional
 Maintainer: Gobinath Loganathan <slgobinath@gmail.com>
-Build-Depends: debhelper (>= 10), dh-python, python3, python3-packaging, python3-setuptools, pybuild-plugin-pyproject
+Build-Depends: debhelper (>= 10), dh-python, python3, python3-packaging, python3-setuptools
 Standards-Version: 3.9.6
 X-Python3-Version: >= 3.10
 Homepage: https://github.com/slgobinath/SafeEyes/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,3 @@
-
 [project]
 name = "safeeyes"
 version = "2.2.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,50 @@
+
+[project]
+name = "safeeyes"
+version = "2.2.3"
+description = "Protect your eyes from eye strain using this continuous breaks reminder."
+keywords = ["linux utility health eye-strain safe-eyes"]
+readme = "README.md"
+authors = [
+    {name = "Gobinath Loganathan", email = "slgobinath@gmail.com"},
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: X11 Applications :: GTK",
+    "Environment :: Other Environment",
+    "Intended Audience :: End Users/Desktop",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Utilities",
+]
+dependencies = [
+    "pywayland",
+    "PyGObject",
+    "babel",
+    "psutil",
+    "packaging",
+    "python-xlib",
+]
+requires-python = ">=3.10"
+
+[project.urls]
+Homepage = "https://github.com/slgobinath/SafeEyes"
+Downloads = "https://github.com/slgobinath/SafeEyes/archive/v2.2.3.tar.gz"
+
+[project.scripts]
+safeeyes = "safeeyes.__main__:main"
+
+[project.optional-dependencies]
+healthstats = ["croniter"]
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages=["safeeyes"]
+include-package-data = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,5 @@ healthstats = ["croniter"]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages=["safeeyes"]
-include-package-data = true
+[tool.setuptools.packages.find]
+include=["safeeyes*"]

--- a/safeeyes/safeeyes.py
+++ b/safeeyes/safeeyes.py
@@ -24,6 +24,7 @@ import atexit
 import logging
 import os
 from threading import Timer
+from importlib import metadata
 
 import gi
 from safeeyes import utility
@@ -39,7 +40,7 @@ from safeeyes.ui.settings_dialog import SettingsDialog
 gi.require_version('Gtk', '4.0')
 from gi.repository import Gtk, Gio, GLib
 
-SAFE_EYES_VERSION = "2.2.3"
+SAFE_EYES_VERSION = metadata.version("safeeyes")
 
 
 class SafeEyes(Gtk.Application):

--- a/setup.py
+++ b/setup.py
@@ -38,24 +38,22 @@ class BuildMoSubCommand(Command):
 
         files = {}
 
-        localedir = 'safeeyes/config/locale'
-        po_dirs = [localedir + '/' + l + '/LC_MESSAGES/'
-                   for l in next(os.walk(localedir))[1]]
+        localedir = Path('safeeyes/config/locale')
+        po_dirs = [l.joinpath('LC_MESSAGES') for l in localedir.iterdir() if l.is_dir()]
         for po_dir in po_dirs:
             po_files = [f
-                        for f in next(os.walk(po_dir))[2]
-                        if os.path.splitext(f)[1] == '.po']
+                        for f in po_dir.iterdir()
+                        if f.is_file() and f.suffix == '.po']
             for po_file in po_files:
-                filename, _ = os.path.splitext(po_file)
-                mo_file = filename + '.mo'
+                mo_file = po_file.with_suffix(".mo")
 
-                source_file = po_dir + po_file
+                source_file = po_file
+                build_file = mo_file
 
-                build_file = po_dir + mo_file
                 if not self.editable_mode:
-                    build_file = os.path.join(self.build_lib, build_file)
+                    build_file = Path(self.build_lib).joinpath(build_file)
 
-                files[build_file] = source_file
+                files[str(build_file)] = str(source_file)
 
         self.files = files
         return files

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,13 @@ import os
 
 from pathlib import Path
 from setuptools import Command, setup
-from setuptools.command.build import build as orig_build
+from setuptools.command.build import build as OriginalBuildCommand
 
-class build(orig_build):
-    sub_commands = [('build_mo', None), *orig_build.sub_commands]
+class BuildCommand(OriginalBuildCommand):
+    sub_commands = [('build_mo', None), *OriginalBuildCommand.sub_commands]
 
 
-class build_mo(Command):
+class BuildMoSubCommand(Command):
     description = 'Compile .po files into .mo files'
 
     files = None
@@ -22,7 +22,6 @@ class build_mo(Command):
 
     def finalize_options(self):
         self.set_undefined_options("build_py", ("build_lib", "build_lib"))
-        pass
 
     def run(self):
         files = self._get_files()
@@ -72,5 +71,5 @@ class build_mo(Command):
 
 
 setup(
-    cmdclass={'build': build, 'build_mo': build_mo}
+    cmdclass={'build': BuildCommand, 'build_mo': BuildMoSubCommand}
 )


### PR DESCRIPTION
## Description

This PR switches configuration from setup.py to pyproject.toml.

This is somewhat of a prerequisite in the plan discussed in https://github.com/slgobinath/SafeEyes/discussions/589.
Most of the tools there (type checkers, `nox`/`tox`, `ruff`) expect to be configured with a `pyproject.toml` file.
[This documentation](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/#is-pyproject-toml-mandatory) also "strongly recommends" using a `pyproject.toml` file in some form.

In theory, it would be enough to just use the `[build-backend]` table, and keep the `setup.py` mostly as-is.
However, when a `pyproject.toml` file is detected, it also enables [build isolation](https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/#build-isolation) automatically.

Build isolation means that the way `.mo` files were generated needs to be changed (it is now a [custom build step](https://setuptools.pypa.io/en/latest/userguide/extension.html)), and the `data_files` key is [deprecated](https://github.com/pypa/setuptools/discussions/2648), so I decided to properly migrate everything to `pyproject.toml`.

The only thing this should have an impact on is building the release. I have tested locally, and using `python -m build` properly builds the `.whl` and `.tar.gz` as before, with identical contents apart from some metadata differences.
