### PR TITLE
trayicon: set XAyatanaLabel attribute for "Show next break time in tray icon"

### DIFF
--- a/safeeyes/plugins/trayicon/plugin.py
+++ b/safeeyes/plugins/trayicon/plugin.py
@@ -49,6 +49,12 @@ SNI_NODE_INFO = Gio.DBusNodeInfo.new_for_xml("""
         <property name="Status" type="s" access="read"/>
         <signal name="NewIcon"/>
         <signal name="NewTooltip"/>
+
+        <property name="XAyatanaLabel" type="s" access="read"/>
+        <signal name="XAyatanaNewLabel">
+            <arg type="s" name="label" direction="out" />
+            <arg type="s" name="guide" direction="out" />
+        </signal>
     </interface>
 </node>""").interfaces[0]
 
@@ -346,6 +352,7 @@ class StatusNotifierItemService(DBusService):
     IconName = 'io.github.slgobinath.SafeEyes-enabled'
     IconThemePath = ''
     ToolTip = ('', [], 'Safe Eyes', '')
+    XAyatanaLabel = ""
     ItemIsMenu = True
     Menu = None
 
@@ -396,6 +403,14 @@ class StatusNotifierItemService(DBusService):
 
         self.emit_signal(
             'NewTooltip'
+        )
+
+    def set_xayatanalabel(self, label):
+        self.XAyatanaLabel = label
+
+        self.emit_signal(
+            "XAyatanaNewLabel",
+            (label, "")
         )
 
 class TrayIcon:
@@ -611,6 +626,7 @@ class TrayIcon:
             description = ''
 
         self.sni_service.set_tooltip('Safe Eyes', description)
+        self.sni_service.set_xayatanalabel(description)
 
     def quit_safe_eyes(self):
         """


### PR DESCRIPTION
Fixes https://github.com/slgobinath/SafeEyes/issues/643

This a non-standard attribute that is not supported by many desktops, e.g. KDE and snixembed.
However, this also did not work with libappindicator on KDE before.

This should fix the regression in #643 for all desktops that support both StatusNotifierItem and the non-standard XAyatanaLabel property, notably GNOME with the [AppIndicator and KStatusNotifierItem Support](https://extensions.gnome.org/extension/615/appindicator-support/) extension.