### PR TITLE
Update plugin.py to capture time_in_minutes

### DIFF
--- a/safeeyes/plugins/trayicon/plugin.py
+++ b/safeeyes/plugins/trayicon/plugin.py
@@ -514,7 +514,7 @@ class TrayIcon:
                 disable_items.append({
                     'id': disable_option_dynamic_id,
                     'label': label,
-                    'callback': lambda: self.on_disable_clicked(time_in_minutes),
+                    'callback': lambda time_in_minutes=time_in_minutes: self.on_disable_clicked(time_in_minutes),
                 })
 
                 disable_option_dynamic_id += 1


### PR DESCRIPTION
## Description

Python does not capture lambda parameters on creation.
So the last loop value of `time_in_minutes` was used on callback time.
Explicitly capture the variable.

See https://stackoverflow.com/questions/2295290/what-do-lambda-function-closures-capture or https://stackoverflow.com/questions/19837486/lambda-in-a-loop

Fixes: #648 