### PR TITLE
Wayland: fix keyboard locking

### DIFF
--- a/safeeyes/ui/break_screen.py
+++ b/safeeyes/ui/break_screen.py
@@ -157,9 +157,6 @@ class BreakScreen:
         # Lock the keyboard
         if not self.context['is_wayland']:
             utility.start_thread(self.__lock_keyboard_x11)
-        else:
-            # TODO: Wayland keyboard locking
-            logging.warning("Keyboard locking not yet implemented for Wayland.")
 
         display = Gdk.Display.get_default()
         monitors = display.get_monitors()
@@ -231,6 +228,10 @@ class BreakScreen:
 
             window.fullscreen_on_monitor(monitor)
             window.present()
+
+            if self.context['is_wayland']:
+                # this may or may not be granted by the window system
+                window.get_surface().inhibit_system_shortcuts(None)
 
             i = i + 1
 


### PR DESCRIPTION
## Description

Based on #561, only the last two commits are new.

This PR moves the X11-specific keyboard locking to X11-only environments, as that can fail in certain Wayland environments (eg. no XWayland).
It additionally adds a wayland-compatible way of inhibiting system shortcuts.