### PR TITLE
donotdisturb: fix changing interruptible fullscreen windows to normal mode

### DIFF
--- a/safeeyes/plugins/donotdisturb/plugin.py
+++ b/safeeyes/plugins/donotdisturb/plugin.py
@@ -194,9 +194,9 @@ def on_start_break(break_obj):
         if utility.DESKTOP_ENVIRONMENT == 'gnome':
             skip_break = is_idle_inhibited_gnome()
         else:
-            skip_break = is_active_window_skipped_wayland(True)
+            skip_break = is_active_window_skipped_wayland(False)
     else:
-        skip_break = is_active_window_skipped_xorg(True)
+        skip_break = is_active_window_skipped_xorg(False)
     if dnd_while_on_battery and not skip_break:
         skip_break = is_on_battery()
     return skip_break


### PR DESCRIPTION
Fixes #653 

This appears to have been a typo in 6e07de7c2258a98dcb31c6c33ce31cab2a9edecb (#427),
after which the `pre_break` param always was `False`.

Restore the previous behaviour for XOrg.

