### PR TITLE
Make SafeEyes compatible with Python 3.6 again

### DIFF
--- a/safeeyes/model.py
+++ b/safeeyes/model.py
@@ -24,6 +24,7 @@ import logging
 import random
 from enum import Enum
 from dataclasses import dataclass
+from typing import Optional, Union
 
 from packaging.version import parse
 
@@ -424,11 +425,11 @@ class TrayAction:
 @dataclass
 class PluginDependency:
     message: str
-    link: str|None = None
+    link: Optional[str] = None
     retryable: bool = False
 
 class RequiredPluginException(Exception):
-    def __init__(self, plugin_id, plugin_name: str, message: str|PluginDependency):
+    def __init__(self, plugin_id, plugin_name: str, message: Union[str, PluginDependency]):
         if isinstance(message, PluginDependency):
             msg = message.message
         else:

--- a/safeeyes/plugins/healthstats/plugin.py
+++ b/safeeyes/plugins/healthstats/plugin.py
@@ -55,7 +55,7 @@ def init(ctx, safeeyes_config, plugin_config):
             'total_resets': 0,
         }
 
-        session = context['session']['plugin'].get('healthstats', {}) | defaults
+        session = context['session']['plugin'].get('healthstats', {}) or defaults
         if 'no_of_breaks' in session:
             # Ignore old format session.
             session = defaults

--- a/safeeyes/plugins/healthstats/plugin.py
+++ b/safeeyes/plugins/healthstats/plugin.py
@@ -55,7 +55,8 @@ def init(ctx, safeeyes_config, plugin_config):
             'total_resets': 0,
         }
 
-        session = context['session']['plugin'].get('healthstats', {}) or defaults
+        session = context['session']['plugin'].get('healthstats', {}).copy()
+        session.update(defaults)
         if 'no_of_breaks' in session:
             # Ignore old format session.
             session = defaults


### PR DESCRIPTION
## Description
SafeEyes requires Python 3.10+, but openSUSE Leap 15.* still use Python 3.6. With only little effort, we can make it run again in Python 3.6. This should fix https://github.com/slgobinath/SafeEyes/issues/656
