### PR TITLE
Allow forced disabling even when strict mode is enabled

### DIFF
--- a/safeeyes/config/safeeyes.json
+++ b/safeeyes/config/safeeyes.json
@@ -65,7 +65,7 @@
         {
             "id": "audiblealert",
             "enabled": true,
-            "version": "0.0.3",
+            "version": "0.0.4",
             "settings": {
                 "pre_break_alert": true,
                 "post_break_alert": true
@@ -79,6 +79,7 @@
                 "show_time_in_tray": false,
                 "show_long_time_in_tray": false,
                 "allow_disabling": true,
+                "allow_forced_disabling": false,
                 "disable_options": [{
                         "time": 30,
                         "unit": "minute"

--- a/safeeyes/plugins/trayicon/config.json
+++ b/safeeyes/plugins/trayicon/config.json
@@ -2,7 +2,7 @@
     "meta": {
         "name": "Tray Icon",
         "description": "Show a tray icon in the notification area",
-        "version": "0.0.3"
+        "version": "0.0.4"
     },
     "dependencies": {
         "python_modules": [],
@@ -29,6 +29,12 @@
             "label": "Allow disabling Safe Eyes",
             "type": "BOOL",
             "default": true
+        },
+        {
+            "id": "allow_forced_disabling",
+            "label": "Allow disabling Safe Eyes even when strict mode is enabled",
+            "type": "BOOL",
+            "default": false
         },
         {
             "id": "disable_options",

--- a/safeeyes/plugins/trayicon/plugin.py
+++ b/safeeyes/plugins/trayicon/plugin.py
@@ -65,6 +65,7 @@ class TrayIcon:
         self.idle_condition = threading.Condition()
         self.lock = threading.Lock()
         self.allow_disabling = plugin_config['allow_disabling']
+        self.allow_forced_disabling = plugin_config.get('allow_forced_disabling', False)
         self.animate = False
 
         # Construct the tray icon
@@ -356,14 +357,14 @@ class TrayIcon:
         """
         This method is called by the core to prevent user from disabling Safe Eyes after the notification.
         """
-        if self.active:
+        if self.active and not self.allow_forced_disabling:
             self.menu.set_sensitive(False)
 
     def unlock_menu(self):
         """
         This method is called by the core to activate the menu after the the break.
         """
-        if self.active:
+        if self.active and not self.allow_forced_disabling:
             self.menu.set_sensitive(True)
 
     def disable_ui(self):


### PR DESCRIPTION
I like the strict mode, but there are sometimes cases when I forget to disable the app before a presentation or something. Right now it is not possible to disable the app for 30 minutes after the notification that the screen will be locked within 15 seconds. Enabling this option would allow disabling the app even after the notification.
