### PR TITLE
Add 'hyprland' to the list of recognized desktop sessions

### DIFF
--- a/safeeyes/utility.py
+++ b/safeeyes/utility.py
@@ -265,7 +265,7 @@ def desktop_environment():
     env = 'unknown'
     if desktop_session is not None:
         desktop_session = desktop_session.lower()
-        if desktop_session in ['gnome', 'unity', 'budgie-desktop', 'cinnamon', 'mate', 'xfce4', 'lxde', 'pantheon', 'fluxbox', 'blackbox', 'openbox', 'icewm', 'jwm', 'afterstep', 'trinity', 'kde']:
+        if desktop_session in ['gnome', 'unity', 'budgie-desktop', 'cinnamon', 'mate', 'xfce4', 'lxde', 'pantheon', 'fluxbox', 'blackbox', 'openbox', 'icewm', 'jwm', 'afterstep', 'trinity', 'kde', 'hyprland']:
             env = desktop_session
         elif desktop_session.startswith('xubuntu') or (current_desktop is not None and 'xfce' in current_desktop):
             env = 'xfce'


### PR DESCRIPTION
## Description

This commit adds 'hyprland' as a recognized `DESKTOP_SESSION`.

Long story short, I had to populate the `GNOME_DESKTOP_SESSION_ID` env variable to avoid issues with `xdg-open` on Hyprland, but doing so broke SafeEyes because it would think it's running on Gnome. The symptoms were identical to #629 (except that it was installed from the AUR, not as a Flatpack).
Adding hyprland as a desktop session prevents that issue and allows SafeEyes to work once more.