### PR TITLE
fix: fail safely if unable to get player status (Media Control)

### DIFF
--- a/safeeyes/plugins/mediacontrol/plugin.py
+++ b/safeeyes/plugins/mediacontrol/plugin.py
@@ -59,10 +59,16 @@ def __active_players():
                 cancellable=None,
             )
 
-            status = player.get_cached_property('PlaybackStatus').unpack().lower()
+            playbackstatus = player.get_cached_property("PlaybackStatus")
 
-            if status == "playing":
-                players.append(player)
+            if playbackstatus is not None:
+                status = playbackstatus.unpack().lower()
+
+                if status == "playing":
+                    players.append(player)
+            else:
+                logging.warning(f"Failed to get PlaybackStatus for {service}")
+
     return players
 
 


### PR DESCRIPTION
## Description

In come cases where there exists a registered MPRIS player that
doesn't have support for playerstatus, safeeyes errors and doesnt
launch a break when the Media Control plugin is enabled.

This patch adds a check to the mediacontrol plugin that checks
if "PlaybackStatus" cached_property is not None, and only then attempts
to get media playing status.

Steps to reproduce:

1. Install playerctl
2. Launch playerctld
3. Do not play any media (close all media playing apps)
4. Try to launch a break using safeeyes

Error:

```
  File "/usr/lib/python3.13/site-packages/safeeyes/utility.py", line 106, in <lambda>
    GLib.idle_add(lambda: target_function(*args, **kwargs))
                          ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/safeeyes/core.py", line 277, in __fire_start_break
    self.start_break.fire(break_obj)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/safeeyes/model.py", line 293, in fire
    if not handler(*args, **keywargs):
           ~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/safeeyes/safeeyes.py", line 356, in start_break
    actions = self.plugins_manager.get_break_screen_tray_actions(break_obj)
  File "/usr/lib/python3.13/site-packages/safeeyes/plugin_manager.py", line 209, in get_break_screen_tray_actions
    action = plugin['module'].get_tray_action(break_obj)
  File "/usr/lib/python3.13/site-packages/safeeyes/plugins/mediacontrol/plugin.py", line 89, in get_tray_action
    players = __active_players()
  File "/usr/lib/python3.13/site-packages/safeeyes/plugins/mediacontrol/plugin.py", line 62, in __active_players
    status = player.get_cached_property('PlaybackStatus').unpack().lower()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'unpack'
```

Expected Behaviour:

Doesn't crash
