### PR TITLE
feat: check if the running process is of the same user

### DIFF
--- a/safeeyes/__main__.py
+++ b/safeeyes/__main__.py
@@ -40,6 +40,7 @@ gettext.install("safeeyes", utility.LOCALE_PATH)
 def __running():
     """Check if SafeEyes is already running."""
     process_count = 0
+    current_user = psutil.Process().username()
     for proc in psutil.process_iter():
         if not proc.cmdline:
             continue
@@ -54,9 +55,10 @@ def __running():
             if ("python3" in cmd_line[0] or "python" in cmd_line[0]) and (
                 "safeeyes" in cmd_line[1] or "safeeyes" in cmd_line
             ):
-                process_count += 1
-                if process_count > 1:
-                    return True
+                if proc.username() == current_user:
+                    process_count += 1
+                    if process_count > 1:
+                        return True
 
         # Ignore if process does not exist or does not have command line args
         except (IndexError, psutil.NoSuchProcess):


### PR DESCRIPTION
When running SafeEyes in multi-user environments (multiple users running
SafeEyes in the same machine), it refuses to start more than one
instance of SafeEyes because it is already running accoding to ps.

This patch adds a check to the running SafeEyes pid such that the
_running() function returns True only if it is running as the same user.

Please check if the Windows platform works as expected.
