### PR TITLE
donotdisturb: fix fullscreen window detection on Cinnamon

### DIFF
--- a/safeeyes/plugins/donotdisturb/plugin.py
+++ b/safeeyes/plugins/donotdisturb/plugin.py
@@ -71,7 +71,7 @@ def is_active_window_skipped_xorg(pre_break):
         NET_WM_STATE_FULLSCREEN = x11_display.intern_atom("_NET_WM_STATE_FULLSCREEN")
 
         props = active_window.get_full_property(NET_WM_STATE, Xlib.Xatom.ATOM)
-        is_fullscreen = props.value and NET_WM_STATE_FULLSCREEN in props.value.tolist()
+        is_fullscreen = props and props.value and NET_WM_STATE_FULLSCREEN in props.value.tolist()
 
         process_names = active_window.get_wm_class()
 


### PR DESCRIPTION
## Description

Fixes #683.

This broke in #655, where it was not considered that the window under focus could, on X11, be a child window of the actual window, and so the "_NET_WM_STATE" property could be missing. This is the case in Cinnamon, at least for certain windows with focused inputs.
This PR both ensures that we do not crash when the property is missing.
It also switches the detection to find the active window to the "_NET_ACTIVE_WINDOW" property, which is part of EWMH, so older X11 window managers might not support it. However, according to the [docs](https://docs.gtk.org/gdk3/method.Screen.get_active_window.html), GTK3 also used that property to get the active window, so this should behave the exact same.
