### PR TITLE
rework custom stylesheet loading

### DIFF
--- a/safeeyes/__main__.py
+++ b/safeeyes/__main__.py
@@ -130,7 +130,7 @@ def main():
     utility.initialize_logging(args.debug)
     utility.initialize_platform()
     config = Config()
-    utility.create_user_stylesheet_if_missing()
+    utility.cleanup_old_user_stylesheet()
 
     if __running():
         logging.info("Safe Eyes is already running")

--- a/safeeyes/config/locale/safeeyes.pot
+++ b/safeeyes/config/locale/safeeyes.pot
@@ -557,3 +557,7 @@ msgstr ""
 
 msgid "License:"
 msgstr ""
+
+#, python-format
+msgid "Old stylesheet found at '%(old)s', ignoring. For custom styles, create a new stylesheet in '%(new)s' instead."
+msgstr ""

--- a/safeeyes/model.py
+++ b/safeeyes/model.py
@@ -327,8 +327,6 @@ class Config:
                             self.__user_config, self.__system_config
                         )
                         self.__user_config = self.__system_config
-                        # Update the style sheet
-                        utility.replace_style_sheet()
 
             utility.merge_plugins(self.__user_config)
             self.save()

--- a/safeeyes/safeeyes.py
+++ b/safeeyes/safeeyes.py
@@ -170,7 +170,9 @@ class SafeEyes(Gtk.Application):
             utility.SYSTEM_STYLE_SHEET_PATH, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
         )
         utility.load_css_file(
-            utility.CUSTOM_STYLE_SHEET_PATH, Gtk.STYLE_PROVIDER_PRIORITY_USER
+            utility.CUSTOM_STYLE_SHEET_PATH,
+            Gtk.STYLE_PROVIDER_PRIORITY_USER,
+            required=False,
         )
 
     def _retry_errored_plugins(self):

--- a/safeeyes/safeeyes.py
+++ b/safeeyes/safeeyes.py
@@ -167,7 +167,10 @@ class SafeEyes(Gtk.Application):
 
     def _initialize_styles(self):
         utility.load_css_file(
-            utility.STYLE_SHEET_PATH, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+            utility.SYSTEM_STYLE_SHEET_PATH, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        )
+        utility.load_css_file(
+            utility.CUSTOM_STYLE_SHEET_PATH, Gtk.STYLE_PROVIDER_PRIORITY_USER
         )
 
     def _retry_errored_plugins(self):

--- a/safeeyes/safeeyes.py
+++ b/safeeyes/safeeyes.py
@@ -104,12 +104,11 @@ class SafeEyes(Gtk.Application):
         else:
             self.context["session"] = {"plugin": {}}
 
+        # Initialize the theme
+        self._initialize_styles()
+
         self.break_screen = BreakScreen(
-            self,
-            self.context,
-            self.on_skipped,
-            self.on_postponed,
-            utility.STYLE_SHEET_PATH,
+            self, self.context, self.on_skipped, self.on_postponed
         )
         self.break_screen.initialize(self.config)
         self.plugins_manager = PluginManager()
@@ -165,6 +164,11 @@ class SafeEyes(Gtk.Application):
             self.show_settings()
         elif self.cli_args.take_break:
             self.take_break()
+
+    def _initialize_styles(self):
+        utility.load_css_file(
+            utility.STYLE_SHEET_PATH, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        )
 
     def _retry_errored_plugins(self):
         if not self.plugins_manager.needs_retry():

--- a/safeeyes/ui/break_screen.py
+++ b/safeeyes/ui/break_screen.py
@@ -43,9 +43,7 @@ class BreakScreen:
     interface.
     """
 
-    def __init__(
-        self, application, context, on_skipped, on_postponed, style_sheet_path
-    ):
+    def __init__(self, application, context, on_skipped, on_postponed):
         self.application = application
         self.context = context
         self.count_labels = []
@@ -63,15 +61,6 @@ class BreakScreen:
 
         if not self.context["is_wayland"]:
             self.x11_display = Display()
-
-        # Initialize the theme
-        css_provider = Gtk.CssProvider()
-        css_provider.load_from_path(style_sheet_path)
-
-        display = Gdk.Display.get_default()
-        Gtk.StyleContext.add_provider_for_display(
-            display, css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
-        )
 
     def initialize(self, config):
         """Initialize the internal properties from configuration."""

--- a/safeeyes/utility.py
+++ b/safeeyes/utility.py
@@ -38,12 +38,13 @@ import babel.dates
 import gi
 
 gi.require_version("Gtk", "4.0")
+gi.require_version("Gdk", "4.0")
+
+from gi.repository import Gdk
 from gi.repository import Gtk
 from gi.repository import GLib
 from gi.repository import GdkPixbuf
 from packaging.version import parse
-
-gi.require_version("Gdk", "4.0")
 
 BIN_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
 HOME_DIRECTORY = os.environ.get("HOME") or os.path.expanduser("~")
@@ -370,6 +371,14 @@ def merge_configs(new_config, old_config):
     new_config = new_config.copy()
     new_config.update(old_config)
     return new_config
+
+
+def load_css_file(style_sheet_path, priority):
+    css_provider = Gtk.CssProvider()
+    css_provider.load_from_path(style_sheet_path)
+
+    display = Gdk.Display.get_default()
+    Gtk.StyleContext.add_provider_for_display(display, css_provider, priority)
 
 
 def initialize_safeeyes():

--- a/safeeyes/utility.py
+++ b/safeeyes/utility.py
@@ -388,7 +388,12 @@ def sha256sum(filename):
     return h.hexdigest()
 
 
-def load_css_file(style_sheet_path, priority):
+def load_css_file(style_sheet_path, priority, required=True):
+    if not os.path.isfile(style_sheet_path):
+        if required:
+            logging.warning("Failed loading required stylesheet")
+        return
+
     css_provider = Gtk.CssProvider()
     css_provider.load_from_path(style_sheet_path)
 


### PR DESCRIPTION
## Description

Previously, the stylesheet was copied to the user's .config dir, and this was then loaded as a style (with priority "application").
The user could alter this stylesheet directly.
This stylesheet was called "safeeyes_styles.css".

Now, we split the stylesheets into two:
- The system stylesheet, which is directly loaded with priority "application".
- The user's stylesheet, if it exists, which is loaded from the .config dir with priority "user", overriding both the system stylesheet and any themes the user might have.
  This is now called "safeeyes_custom_styles.css".

This means in the future, we can simply add new default styles to the system stylesheet without breaking the user. Additionally, any styles loaded with a higher priority than "application" (eg. certain GTK themes, see https://github.com/slgobinath/SafeEyes/issues/687), can now be overridden by the user's stylesheet.

We also check if the old path ("safeeyes_styles.css") contains an old default stylesheet. If it does, we delete it.
If it (likely) contains a customized stylesheet, don't delete it, but warn the user that they should use "safeeyes_custom_styles.css" instead now.