### PR TITLE
CI: Type checking: mypy

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,0 +1,36 @@
+# Workflow to run mypy
+# Adapted from the CPython mypy action
+name: mypy
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+env:
+  UV_SYSTEM_PYTHON: 1
+  PIP_DISABLE_PIP_VERSION_CHECK: 1
+  FORCE_COLOR: 1
+  TERM: xterm-256color  # needed for FORCE_COLOR to work on mypy on Ubuntu, see https://github.com/python/mypy/issues/13817
+
+jobs:
+  mypy:
+    name: mypy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 # v5.4.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: ''
+          cache-suffix: '3.13'
+      - name: Setup Python
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
+        with:
+          python-version: '3.13'
+      - run: sudo apt-get install -y libwayland-dev libcairo2-dev libgirepository-2.0-dev
+      - run: uv pip install -r pyproject.toml
+      - run: uv pip install --group types
+      - run: mypy safeeyes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,3 +66,15 @@ types = [
     "types-psutil==7.0.0.20250218",
     "types-python-xlib==0.33.0.20240407"
 ]
+
+[tool.mypy]
+# catch typos in configuration file
+warn_unused_configs = true
+disallow_any_unimported = true
+#check_untyped_defs = true
+warn_unused_ignores = true
+warn_unreachable = true
+enable_error_code = [
+    "ignore-without-code",
+    "possibly-undefined"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,3 +46,23 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 include=["safeeyes*"]
+
+[dependency-groups]
+dev = [
+    {include-group = "lint"},
+    {include-group = "scripts"},
+    {include-group = "types"}
+]
+lint = [
+    "ruff==0.11.2"
+]
+scripts = [
+    "polib==1.2.0"
+]
+types = [
+    "mypy==1.15.0",
+    "PyGObject-stubs==2.13.0",
+    "types-croniter==5.0.1.20250322",
+    "types-psutil==7.0.0.20250218",
+    "types-python-xlib==0.33.0.20240407"
+]

--- a/safeeyes/plugins/donotdisturb/plugin.py
+++ b/safeeyes/plugins/donotdisturb/plugin.py
@@ -30,8 +30,8 @@ import Xlib
 from safeeyes import utility
 
 context = None
-skip_break_window_classes = []
-take_break_window_classes = []
+skip_break_window_classes: list[str] = []
+take_break_window_classes: list[str] = []
 unfullscreen_allowed = True
 dnd_while_on_battery = False
 

--- a/safeeyes/plugins/limitconsecutiveskipping/plugin.py
+++ b/safeeyes/plugins/limitconsecutiveskipping/plugin.py
@@ -82,7 +82,7 @@ def get_widget_title(break_obj):
     return _("Limit Consecutive Skipping")
 
 
-def get_widget_content(break_obj):
+def get_widget_content(break_obj) -> None:
     """Return the statistics."""
     # Check if the plugin is enabled
     if not enabled:

--- a/safeeyes/plugins/limitconsecutiveskipping/plugin.py
+++ b/safeeyes/plugins/limitconsecutiveskipping/plugin.py
@@ -82,7 +82,7 @@ def get_widget_title(break_obj):
     return _("Limit Consecutive Skipping")
 
 
-def get_widget_content(break_obj) -> None:
+def get_widget_content(break_obj):
     """Return the statistics."""
     # Check if the plugin is enabled
     if not enabled:

--- a/safeeyes/plugins/trayicon/plugin.py
+++ b/safeeyes/plugins/trayicon/plugin.py
@@ -26,6 +26,7 @@ import logging
 from safeeyes import utility
 import threading
 import time
+import typing
 
 """
 Safe Eyes tray icon plugin
@@ -186,8 +187,10 @@ class DBusMenuService(DBusService):
 
     revision = 0
 
-    items = []
-    idToItems = {}
+    # TODO: replace dict here with more exact typing for item
+    items: list[dict] = []
+    # TODO: replace dict here with more exact typing for item
+    idToItems: dict[str, dict] = {}
 
     def __init__(self, session_bus, context, items):
         super().__init__(
@@ -366,7 +369,7 @@ class StatusNotifierItemService(DBusService):
     Status = "Active"
     IconName = "io.github.slgobinath.SafeEyes-enabled"
     IconThemePath = ""
-    ToolTip = ("", [], "Safe Eyes", "")
+    ToolTip: tuple[str, list[typing.Any], str, str] = ("", [], "Safe Eyes", "")
     XAyatanaLabel = ""
     ItemIsMenu = True
     Menu = None

--- a/safeeyes/ui/break_screen.py
+++ b/safeeyes/ui/break_screen.py
@@ -24,7 +24,7 @@ import time
 import gi
 from safeeyes import utility
 from Xlib.display import Display
-from Xlib.display import X
+from Xlib import X
 
 gi.require_version("Gtk", "4.0")
 from gi.repository import Gdk


### PR DESCRIPTION
## Description

CC #589.

This PR implements the minimum changes for type checking using mypy to pass, and adds mypy to CI.
Since mypy only checks functions, methods etc. when they have type annotations by default, this means that this catches very little right now. However, I wanted to get the baseline in before adding more types.

Additionally, this PR adds the required dependencies for type checking and linting as dependency groups.
Note that `pip` only has support for easily installing dependency groups in its development version, but not yet in a released version (which will presumably come out in June). For now, one has to install those dependencies manually or using something like `uv`, but that's still better than them being not documented at all.
