### PR TITLE
smartpause: ext_idle_notify: avoid blocking for long time when shutting down

### DIFF
--- a/safeeyes/plugins/smartpause/ext_idle_notify.py
+++ b/safeeyes/plugins/smartpause/ext_idle_notify.py
@@ -78,7 +78,10 @@ class ExtIdleNotify:
             # unfortunately, this seems like the best way to make sure that dispatch
             # doesn't block potentially forever (up to multiple seconds in my usage)
             read, _w, _x = select.select((display_fd, self._r_channel), (), ())
+
             if self._r_channel in read:
+                # the channel was written to, which means stop() was called
+                # at this point, self._running should be false as well
                 break
 
             if display_fd in read:

--- a/safeeyes/plugins/smartpause/ext_idle_notify.py
+++ b/safeeyes/plugins/smartpause/ext_idle_notify.py
@@ -20,6 +20,8 @@
 
 import threading
 import datetime
+import os
+import select
 
 from pywayland.client import Display
 from pywayland.protocol.wayland.wl_seat import WlSeat
@@ -33,19 +35,26 @@ class ExtIdleNotify:
     _notifier_set = False
     _running = True
     _thread = None
+    _r_channel = None
+    _w_channel = None
 
     _idle_since = None
 
     def __init__(self):
         self._display = Display()
         self._display.connect()
+        self._r_channel, self._w_channel = os.pipe()
 
     def stop(self):
         self._running = False
+        # write anything, just to wake up the channel
+        os.write(self._w_channel, b"!")
         self._notification.destroy()
         self._notification = None
         self._seat = None
         self._thread.join()
+        os.close(self._r_channel)
+        os.close(self._w_channel)
 
     def run(self):
         self._thread = threading.Thread(
@@ -57,8 +66,23 @@ class ExtIdleNotify:
         reg = self._display.get_registry()
         reg.dispatcher["global"] = self._global_handler
 
+        display_fd = self._display.get_fd()
+
         while self._running:
-            self._display.dispatch(block=True)
+            self._display.flush()
+
+            # this blocks until either there are new events in self._display
+            # (retrieved using dispatch())
+            # or until there are events in self._r_channel - which means that stop()
+            # was called
+            # unfortunately, this seems like the best way to make sure that dispatch
+            # doesn't block potentially forever (up to multiple seconds in my usage)
+            read, _w, _x = select.select((display_fd, self._r_channel), (), ())
+            if self._r_channel in read:
+                break
+
+            if display_fd in read:
+                self._display.dispatch(block=True)
 
         self._display.disconnect()
 


### PR DESCRIPTION
## Description

Previously, when using a platform where smartpause was using ext-idle-notify, it could take an arbitrarily long time to shut down the smartpause plugin. In my experience, this was usually around 1-2 seconds, but could take up to 5 seconds.

This PR is somewhat of a hack.
pywayland does not provide a function that blocks, but also allows cancellation from another thread.
We work around this by extracting the file descriptor from pywayland, and using [select](https://docs.python.org/3/library/select.html#select.select) to block until there is something to read from the descriptor.
This allows us to also block on a pipe - which, when shutting down, we can write to to wake up the `select` call.

I took the `select` trick from [plover](https://github.com/bootstrap-prime/plover/blob/5bf60464d8afa820babe4aac881fc56ec90340c1/plover/oslayer/waykeyboardcontrol.py#L219) as well as [toshy](https://github.com/RedBearAK/toshy/blob/8caa80cc3265508e6208afb6bca3d76b19ef57ae/wlroots-dev/query_topl_mgmt_protocol.py#L186), but added the `os.pipe` trick myself.
