### PR TITLE
Fix window icons for Wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ python3 -m safeeyes
 
 Safe Eyes installers install the required icons to `/usr/share/icons/hicolor`. When you run Safe Eyes from source without, some icons may not appear.
 
+Note that on Wayland, this may still not be enough to get window icons working properly, as Wayland requires the .desktop file to match the running application, which is hard to do when running from source. If at all possible, prefer using an installed package.
+
 
 ### Install in a virtual environment
 
@@ -175,6 +177,8 @@ Some Linux systems like CentOS do not have matching dependencies available in th
     ```
 
 For more details, please check the issue: [#329](https://github.com/slgobinath/SafeEyes/issues/329)
+
+This method has the same caveats about icons/window icons as running from source.
 
 ## Features
 

--- a/safeeyes/glade/about_dialog.glade
+++ b/safeeyes/glade/about_dialog.glade
@@ -38,7 +38,7 @@ along with this program.  If not, see &lt;https://www.gnu.org/licenses/&gt;.</pr
   <object class="GtkWindow" id="window_about">
     <property name="title">Safe Eyes</property>
     <property name="resizable">0</property>
-    <property name="icon-name">safeeyes</property>
+    <property name="icon-name">io.github.slgobinath.SafeEyes</property>
     <child>
       <object class="GtkBox" id="layout_box">
         <property name="visible">1</property>

--- a/safeeyes/glade/break_screen.glade
+++ b/safeeyes/glade/break_screen.glade
@@ -21,7 +21,7 @@
 <interface>
   <requires lib="gtk" version="4.0"/>
   <object class="GtkWindow" id="window_main">
-    <property name="icon_name">safeeyes</property>
+    <property name="icon-name">io.github.slgobinath.SafeEyes</property>
     <property name="decorated">0</property>
     <property name="deletable">0</property>
     <child>

--- a/safeeyes/glade/new_break.glade
+++ b/safeeyes/glade/new_break.glade
@@ -47,7 +47,7 @@
     <property name="default-width">500</property>
     <property name="default-height">50</property>
     <property name="destroy-with-parent">1</property>
-    <property name="icon-name">safeeyes</property>
+    <property name="icon-name">io.github.slgobinath.SafeEyes</property>
     <child>
       <object class="GtkBox" id="box_settings">
         <property name="visible">1</property>

--- a/safeeyes/glade/settings_break.glade
+++ b/safeeyes/glade/settings_break.glade
@@ -54,7 +54,7 @@
     <property name="default-width">500</property>
     <property name="default-height">50</property>
     <property name="destroy-with-parent">1</property>
-    <property name="icon-name">safeeyes</property>
+    <property name="icon-name">io.github.slgobinath.SafeEyes</property>
     <child>
       <object class="GtkBox" id="box_settings">
         <property name="visible">1</property>

--- a/safeeyes/glade/settings_plugin.glade
+++ b/safeeyes/glade/settings_plugin.glade
@@ -28,7 +28,7 @@
     <property name="default-width">400</property>
     <property name="default-height">10</property>
     <property name="destroy-with-parent">1</property>
-    <property name="icon-name">safeeyes</property>
+    <property name="icon-name">io.github.slgobinath.SafeEyes</property>
     <child>
       <object class="GtkBox" id="box_settings">
         <property name="visible">1</property>

--- a/safeeyes/safeeyes.py
+++ b/safeeyes/safeeyes.py
@@ -105,7 +105,11 @@ class SafeEyes(Gtk.Application):
             self.context["session"] = {"plugin": {}}
 
         self.break_screen = BreakScreen(
-            self.context, self.on_skipped, self.on_postponed, utility.STYLE_SHEET_PATH
+            self,
+            self.context,
+            self.on_skipped,
+            self.on_postponed,
+            utility.STYLE_SHEET_PATH,
         )
         self.break_screen.initialize(self.config)
         self.plugins_manager = PluginManager()
@@ -193,7 +197,9 @@ class SafeEyes(Gtk.Application):
         if not self.settings_dialog_active:
             logging.info("Show Settings dialog")
             self.settings_dialog_active = True
-            settings_dialog = SettingsDialog(self.config.clone(), self.save_settings)
+            settings_dialog = SettingsDialog(
+                self, self.config.clone(), self.save_settings
+            )
             settings_dialog.show()
 
     def show_required_plugin_dialog(self, error: RequiredPluginException):
@@ -228,7 +234,7 @@ class SafeEyes(Gtk.Application):
         dialog.
         """
         logging.info("Show About dialog")
-        about_dialog = AboutDialog(SAFE_EYES_VERSION)
+        about_dialog = AboutDialog(self, SAFE_EYES_VERSION)
         about_dialog.show()
 
     def quit(self):

--- a/safeeyes/ui/about_dialog.py
+++ b/safeeyes/ui/about_dialog.py
@@ -33,9 +33,10 @@ class AboutDialog:
     license and the GitHub url.
     """
 
-    def __init__(self, version):
+    def __init__(self, application, version):
         builder = utility.create_gtk_builder(ABOUT_DIALOG_GLADE)
         self.window = builder.get_object("window_about")
+        self.window.set_application(application)
 
         self.window.connect("close-request", self.on_window_delete)
         builder.get_object("btn_close").connect("clicked", self.on_close_clicked)

--- a/safeeyes/ui/break_screen.py
+++ b/safeeyes/ui/break_screen.py
@@ -43,7 +43,10 @@ class BreakScreen:
     interface.
     """
 
-    def __init__(self, context, on_skipped, on_postponed, style_sheet_path):
+    def __init__(
+        self, application, context, on_skipped, on_postponed, style_sheet_path
+    ):
+        self.application = application
         self.context = context
         self.count_labels = []
         self.x11_display = None
@@ -162,6 +165,7 @@ class BreakScreen:
             builder.add_from_file(BREAK_SCREEN_GLADE)
 
             window = builder.get_object("window_main")
+            window.set_application(self.application)
             window.connect("close-request", self.on_window_delete)
             window.set_title("SafeEyes-" + str(i))
             lbl_message = builder.get_object("lbl_message")

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -54,7 +54,8 @@ SETTINGS_ITEM_BOOL_GLADE = os.path.join(utility.BIN_DIRECTORY, "glade/item_bool.
 class SettingsDialog:
     """Create and initialize SettingsDialog instance."""
 
-    def __init__(self, config, on_save_settings):
+    def __init__(self, application, config, on_save_settings):
+        self.application = application
         self.config = config
         self.on_save_settings = on_save_settings
         self.plugin_switches = {}
@@ -67,6 +68,7 @@ class SettingsDialog:
         builder = utility.create_gtk_builder(SETTINGS_DIALOG_GLADE)
 
         self.window = builder.get_object("window_settings")
+        self.window.set_application(application)
         self.box_short_breaks = builder.get_object("box_short_breaks")
         self.box_long_breaks = builder.get_object("box_long_breaks")
         self.box_plugins = builder.get_object("box_plugins")
@@ -291,7 +293,7 @@ class SettingsDialog:
 
     def __show_plugins_properties_dialog(self, plugin_config):
         """Show the PluginProperties dialog."""
-        dialog = PluginSettingsDialog(plugin_config)
+        dialog = PluginSettingsDialog(self.application, plugin_config)
         dialog.show()
 
     def __disable_errored_plugin(self, button, plugin_config):
@@ -304,7 +306,14 @@ class SettingsDialog:
     ):
         """Show the BreakProperties dialog."""
         dialog = BreakSettingsDialog(
-            break_config, is_short, parent, self.plugin_map, on_close, on_add, on_remove
+            self.application,
+            break_config,
+            is_short,
+            parent,
+            self.plugin_map,
+            on_close,
+            on_add,
+            on_remove,
         )
         dialog.show()
 
@@ -413,12 +422,13 @@ class SettingsDialog:
 class PluginSettingsDialog:
     """Builds a settings dialog based on the configuration of a plugin."""
 
-    def __init__(self, config):
+    def __init__(self, application, config):
         self.config = config
         self.property_controls = []
 
         builder = utility.create_gtk_builder(SETTINGS_DIALOG_PLUGIN_GLADE)
         self.window = builder.get_object("dialog_settings_plugin")
+        self.window.set_application(application)
         box_settings = builder.get_object("box_settings")
         self.window.set_title(_("Plugin Settings"))
         for setting in config.get("settings"):
@@ -505,6 +515,7 @@ class BreakSettingsDialog:
 
     def __init__(
         self,
+        application,
         break_config,
         is_short,
         parent_config,
@@ -523,6 +534,7 @@ class BreakSettingsDialog:
 
         builder = utility.create_gtk_builder(SETTINGS_DIALOG_BREAK_GLADE)
         self.window = builder.get_object("dialog_settings_break")
+        self.window.set_application(application)
         self.txt_break = builder.get_object("txt_break")
         self.switch_override_interval = builder.get_object("switch_override_interval")
         self.switch_override_duration = builder.get_object("switch_override_duration")
@@ -702,12 +714,13 @@ class BreakSettingsDialog:
 class NewBreakDialog:
     """Builds a new break dialog."""
 
-    def __init__(self, parent_config, on_add):
+    def __init__(self, application, parent_config, on_add):
         self.parent_config = parent_config
         self.on_add = on_add
 
         builder = utility.create_gtk_builder(SETTINGS_DIALOG_NEW_BREAK_GLADE)
         self.window = builder.get_object("dialog_new_break")
+        self.window.set_application(application)
         self.txt_break = builder.get_object("txt_break")
         self.cmb_type = builder.get_object("cmb_type")
         list_types = builder.get_object("lst_break_types")

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -372,9 +372,10 @@ class SettingsDialog:
         """Event handler for warning bar close action."""
         self.warn_bar_rpc_server.hide()
 
-    def add_break(self, button):
+    def add_break(self, button) -> None:
         """Event handler for add break button."""
         dialog = NewBreakDialog(
+            self.application,
             self.config,
             lambda is_short, break_config: self.__create_break_item(
                 break_config, is_short


### PR DESCRIPTION
Fixes #607.

Wayland is picky about window icons, currently. The icon needs to be correctly set when the window is open, otherwise it shows the wayland fallback icon.
The only way for wayland to show an icon is for it to match the application name with the .desktop file. For that to work, we need to manually associate the Gtk.Window with the Gtk.Application, and also ensure that the `icon-name` matches the application name.

Tested on KDE Wayland, GNOME Wayland and GNOME X11.
Note that this means the application needs to be installed properly (eg. via debian package, or flatpak) - when running from the command line from the git repo alone, it does not work, as the system cannot find the .desktop file.
(This does work if run from the git repo while the .desktop file is installed from another version of SafeEyes.)

