### PR TITLE
typing: import gettext instead of global function

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,8 +1,5 @@
 target-version = "py310"
 
-# gettext
-builtins = ["_"]
-
 [lint]
 select = ["E", "W", "F", "D2", "D3", "D4"]
 ignore = [

--- a/safeeyes/__main__.py
+++ b/safeeyes/__main__.py
@@ -21,20 +21,17 @@ your eyes from eye strain.
 """
 
 import argparse
-import gettext
-import locale
 import logging
 import signal
 import sys
 
 import psutil
-from safeeyes import utility
+from safeeyes import utility, translations
+from safeeyes.translations import translate as _
 from safeeyes.model import Config
 from safeeyes.safeeyes import SafeEyes
 from safeeyes.safeeyes import SAFE_EYES_VERSION
 from safeeyes.rpc import RPCClient
-
-gettext.install("safeeyes", utility.LOCALE_PATH)
 
 
 def __running():
@@ -68,21 +65,7 @@ def __running():
 
 def main():
     """Start the Safe Eyes."""
-    system_locale = gettext.translation(
-        "safeeyes",
-        localedir=utility.LOCALE_PATH,
-        languages=[utility.system_locale(), "en_US"],
-        fallback=True,
-    )
-    system_locale.install()
-    try:
-        # locale.bindtextdomain is required for Glade files
-        locale.bindtextdomain("safeeyes", utility.LOCALE_PATH)
-    except AttributeError:
-        logging.warning(
-            "installed python's gettext module does not support locale.bindtextdomain."
-            " locale.bindtextdomain is required for Glade files"
-        )
+    system_locale = translations.setup()
 
     parser = argparse.ArgumentParser(prog="safeeyes")
     group = parser.add_mutually_exclusive_group()

--- a/safeeyes/model.py
+++ b/safeeyes/model.py
@@ -34,6 +34,7 @@ gi.require_version("Gtk", "4.0")
 from gi.repository import Gtk
 
 from safeeyes import utility
+from safeeyes.translations import translate as _
 
 
 class Break:

--- a/safeeyes/plugins/donotdisturb/dependency_checker.py
+++ b/safeeyes/plugins/donotdisturb/dependency_checker.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from safeeyes import utility
+from safeeyes.translations import translate as _
 
 
 def validate(plugin_config, plugin_settings):

--- a/safeeyes/plugins/healthstats/dependency_checker.py
+++ b/safeeyes/plugins/healthstats/dependency_checker.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from safeeyes import utility
+from safeeyes.translations import translate as _
 
 
 def validate(plugin_config, plugin_settings):

--- a/safeeyes/plugins/healthstats/plugin.py
+++ b/safeeyes/plugins/healthstats/plugin.py
@@ -21,6 +21,7 @@
 import croniter
 import datetime
 import logging
+from safeeyes.translations import translate as _
 
 context = None
 session = None

--- a/safeeyes/plugins/limitconsecutiveskipping/plugin.py
+++ b/safeeyes/plugins/limitconsecutiveskipping/plugin.py
@@ -19,6 +19,7 @@
 """Limit how many breaks can be skipped or postponed in a row."""
 
 import logging
+from safeeyes.translations import translate as _
 
 context = None
 no_of_skipped_breaks = 0

--- a/safeeyes/plugins/notification/plugin.py
+++ b/safeeyes/plugins/notification/plugin.py
@@ -20,6 +20,7 @@ import logging
 
 import gi
 from safeeyes.model import BreakType
+from safeeyes.translations import translate as _
 
 gi.require_version("Notify", "0.7")
 from gi.repository import Notify

--- a/safeeyes/plugins/smartpause/dependency_checker.py
+++ b/safeeyes/plugins/smartpause/dependency_checker.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from safeeyes import utility
+from safeeyes.translations import translate as _
 
 
 def validate(plugin_config, plugin_settings):

--- a/safeeyes/plugins/trayicon/dependency_checker.py
+++ b/safeeyes/plugins/trayicon/dependency_checker.py
@@ -18,6 +18,7 @@
 
 from safeeyes import utility
 from safeeyes.model import PluginDependency
+from safeeyes.translations import translate as _
 
 import gi
 

--- a/safeeyes/plugins/trayicon/plugin.py
+++ b/safeeyes/plugins/trayicon/plugin.py
@@ -24,6 +24,7 @@ gi.require_version("Gtk", "4.0")
 from gi.repository import Gio, GLib
 import logging
 from safeeyes import utility
+from safeeyes.translations import translate as _
 import threading
 import time
 import typing

--- a/safeeyes/safeeyes.py
+++ b/safeeyes/safeeyes.py
@@ -32,6 +32,7 @@ from safeeyes.ui.break_screen import BreakScreen
 from safeeyes.ui.required_plugin_dialog import RequiredPluginDialog
 from safeeyes.model import State, RequiredPluginException
 from safeeyes.rpc import RPCServer
+from safeeyes.translations import translate as _
 from safeeyes.plugin_manager import PluginManager
 from safeeyes.core import SafeEyesCore
 from safeeyes.ui.settings_dialog import SettingsDialog

--- a/safeeyes/translations.py
+++ b/safeeyes/translations.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# Safe Eyes is a utility to remind you to take break frequently
+# to protect your eyes from eye strain.
+
+# Copyright (C) 2024 Mel Dafert <m@dafert.at>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Translation setup and helpers."""
+
+import locale
+import logging
+import gettext
+from safeeyes import utility
+
+_translations = gettext.NullTranslations()
+
+
+def setup():
+    global _translations
+    _translations = gettext.translation(
+        "safeeyes",
+        localedir=utility.LOCALE_PATH,
+        languages=[utility.system_locale(), "en_US"],
+        fallback=True,
+    )
+    try:
+        # locale.bindtextdomain is required for Glade files
+        locale.bindtextdomain("safeeyes", utility.LOCALE_PATH)
+    except AttributeError:
+        logging.warning(
+            "installed python's gettext module does not support locale.bindtextdomain."
+            " locale.bindtextdomain is required for Glade files"
+        )
+
+    return _translations
+
+
+def translate(message: str) -> str:
+    """Translate the message using the current translator."""
+    return _translations.gettext(message)

--- a/safeeyes/ui/about_dialog.py
+++ b/safeeyes/ui/about_dialog.py
@@ -21,6 +21,7 @@
 import os
 
 from safeeyes import utility
+from safeeyes.translations import translate as _
 
 ABOUT_DIALOG_GLADE = os.path.join(utility.BIN_DIRECTORY, "glade/about_dialog.glade")
 

--- a/safeeyes/ui/break_screen.py
+++ b/safeeyes/ui/break_screen.py
@@ -23,6 +23,7 @@ import time
 
 import gi
 from safeeyes import utility
+from safeeyes.translations import translate as _
 import Xlib
 from Xlib.display import Display
 from Xlib import X

--- a/safeeyes/ui/required_plugin_dialog.py
+++ b/safeeyes/ui/required_plugin_dialog.py
@@ -24,6 +24,7 @@ import os
 
 from safeeyes import utility
 from safeeyes.model import PluginDependency
+from safeeyes.translations import translate as _
 
 REQUIRED_PLUGIN_DIALOG_GLADE = os.path.join(
     utility.BIN_DIRECTORY, "glade/required_plugin_dialog.glade"

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -22,6 +22,7 @@ import os
 import gi
 from safeeyes import utility
 from safeeyes.model import Config, PluginDependency
+from safeeyes.translations import translate as _
 
 gi.require_version("Gtk", "4.0")
 from gi.repository import Gtk, Gio

--- a/safeeyes/utility.py
+++ b/safeeyes/utility.py
@@ -46,6 +46,7 @@ from gi.repository import Gtk
 from gi.repository import GLib
 from gi.repository import GdkPixbuf
 from packaging.version import parse
+from safeeyes.translations import translate as _
 
 BIN_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
 HOME_DIRECTORY = os.environ.get("HOME") or os.path.expanduser("~")
@@ -533,7 +534,7 @@ def initialize_platform():
             logging.error("Failed to create desktop entry at %s" % desktop_entry)
 
     # Add links for all icons
-    for path, _, filenames in os.walk(SYSTEM_ICONS):
+    for path, _dirnames, filenames in os.walk(SYSTEM_ICONS):
         for filename in filenames:
             system_icon = os.path.join(path, filename)
             local_icon = os.path.join(


### PR DESCRIPTION
## Description

This PR moves all gettext setup handling to a new file, `safeeyes/translations.py`.
It also switches the `_` function from being a global to being imported from that file everywhere it is used.
This makes it understandable to type checkers, and is a prerequisite for more type checking.

I have checked that `python validate_po.py` (both with `--extract` and with `--validate`) still works correctly with these changes. This should also mean that it works with Weblate, but we should still keep an eye on it after this is merged.