### PR TITLE
style: use default theme for reset button for dark mode

### DIFF
--- a/safeeyes/config/style/safeeyes_style.css
+++ b/safeeyes/config/style/safeeyes_style.css
@@ -109,19 +109,3 @@
     opacity: 0.9;
     border-color: transparent;
 }
-
-.btn_menu {
-    border-width: 0px;
-    border-radius: 0px;
-    border-image: None;
-    background: white;
-    border-color: transparent;
-}
-
-.btn_menu:hover {
-    border-width: 0px;
-    border-radius: 0px;
-    border-image: None;
-    background: whitesmoke;
-    border-color: transparent;
-}


### PR DESCRIPTION
## Description

Fixes #679.

~Blocked on #692.~

This PR removes the styling for the Reset button. The styles were added for Gtk 3.12, and I assume it must have looked worse without them then? I have tested this with both Adwaita and Adwaita:dark, and the default styling looks fine to me.

Before GTK4, this was not an issue, as GTK3 did not automatically switch to a dark theme based on the user preferences.
