### PR TITLE
break screen shortcuts: implement on wayland

### DIFF
--- a/safeeyes/config/locale/safeeyes.pot
+++ b/safeeyes/config/locale/safeeyes.pot
@@ -561,3 +561,6 @@ msgstr ""
 #, python-format
 msgid "Old stylesheet found at '%(old)s', ignoring. For custom styles, create a new stylesheet in '%(new)s' instead."
 msgstr ""
+
+msgid "Customizing the postpone and skip shortcuts does not work on Wayland."
+msgstr ""

--- a/safeeyes/ui/break_screen.py
+++ b/safeeyes/ui/break_screen.py
@@ -305,13 +305,13 @@ class BreakScreen:
                 if self.enable_shortcut and event.type == X.KeyPress:
                     if (
                         event.detail == self.keycode_shortcut_skip
-                        and not self.strict_break
+                        and self.show_skip_button
                     ):
                         self.skip_break()
                         break
                     elif (
-                        self.enable_postpone
-                        and event.detail == self.keycode_shortcut_postpone
+                        event.detail == self.keycode_shortcut_postpone
+                        and self.show_postpone_button
                     ):
                         self.postpone_break()
                         break

--- a/safeeyes/ui/break_screen.py
+++ b/safeeyes/ui/break_screen.py
@@ -71,6 +71,17 @@ class BreakScreen:
         self.enable_postpone = config.get("allow_postpone", False)
         self.keycode_shortcut_postpone = config.get("shortcut_postpone", 65)
         self.keycode_shortcut_skip = config.get("shortcut_skip", 9)
+
+        if self.context["is_wayland"] and (
+            self.keycode_shortcut_postpone != 65 or self.keycode_shortcut_skip != 9
+        ):
+            logging.warning(
+                _(
+                    "Customizing the postpone and skip shortcuts does not work on "
+                    "Wayland."
+                )
+            )
+
         self.shortcut_disable_time = config.get("shortcut_disable_time", 2)
         self.strict_break = config.get("strict_break", False)
 


### PR DESCRIPTION
## Description

Fixes #480.

I've also fixed a bug where on X11, the shortcuts were not disabled in some situations (eg. by the limitconsecutiveskipping plugin). See the second commit.