### PR TITLE
Automatically create a .deb file in GitHub release

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y python3-stdeb fakeroot dpkg-dev debhelper dh-python python3 python3-packaging python3-setuptools
+          sudo apt-get install -y build-essential python3-stdeb fakeroot dpkg-dev debhelper dh-python python3 python3-packaging python3-setuptools
 
       - name: Build .deb package
         run: |


### PR DESCRIPTION
Debian trixie does not include safeeyes as it stopped working with python3.12 (and Debian is too slow to adapt to changes and package later versions before package freeze). It will come handy to Debian users.

This may be helpful for those who want to install the latest version without adding a PPA.