### PR TITLE
utility: fix module detection

### DIFF
--- a/safeeyes/utility.py
+++ b/safeeyes/utility.py
@@ -362,12 +362,9 @@ def command_exist(command):
 
 
 def module_exist(module):
-    """Check wther the given Python module exists or not."""
-    try:
-        importlib.util.find_spec(module)
-        return True
-    except ImportError:
-        return False
+    """Check whether the given Python module exists or not."""
+    module_spec = importlib.util.find_spec(module)
+    return module_spec is not None
 
 
 def merge_configs(new_config, old_config):


### PR DESCRIPTION
## Description

This PR fixes the `utility.module_exist` check - it previously would always return `True`, even if the module didn't exist.
Before, this was using `imp.find_module`, where checking for an exception is the correct way.
However, `importlib.util.find_spec` will return `None` if the module doesn't exist, and not throw an exception.
See [this](https://stackoverflow.com/a/14050282/3067153) for more information.