### PR TITLE
screensaver: add tray action to lock screen now

### DIFF
--- a/safeeyes/glade/break_screen.glade
+++ b/safeeyes/glade/break_screen.glade
@@ -25,9 +25,6 @@
     <property name="decorated">0</property>
     <property name="deletable">0</property>
     <child>
-      <placeholder/>
-    </child>
-    <property name="child">
       <object class="GtkGrid" id="grid1">
         <property name="row_homogeneous">1</property>
         <property name="column_homogeneous">1</property>
@@ -151,7 +148,6 @@
             <child>
               <object class="GtkBox" id="toolbar">
                 <property name="css-classes">toolbar</property>
-                <property name="can_focus">0</property>
                 <property name="halign">end</property>
                 <property name="valign">start</property>
                 <style>
@@ -174,7 +170,7 @@
           </object>
         </child>
       </object>
-    </property>
+    </child>
     <style>
       <class name="window_main"/>
     </style>

--- a/safeeyes/model.py
+++ b/safeeyes/model.py
@@ -379,13 +379,19 @@ class TrayAction:
     __toolbar_buttons: list[Gtk.Button]
 
     def __init__(
-        self, name: str, icon: str, action: typing.Callable, system_icon: bool
+        self,
+        name: str,
+        icon: str,
+        action: typing.Callable,
+        system_icon: bool,
+        single_use: bool,
     ) -> None:
         self.name = name
         self.__icon = icon
         self.action = action
         self.system_icon = system_icon
         self.__toolbar_buttons = []
+        self.single_use = single_use
 
     def get_icon(self) -> Gtk.Image:
         if not self.system_icon:
@@ -412,13 +418,14 @@ class TrayAction:
         icon_path: typing.Optional[str],
         icon_id: str,
         action: typing.Callable,
+        single_use: bool = True,
     ) -> "TrayAction":
         if icon_path is not None:
             image = utility.load_and_scale_image(icon_path, 12, 12)
             if image is not None:
-                return TrayAction(name, icon_path, action, False)
+                return TrayAction(name, icon_path, action, False, single_use)
 
-        return TrayAction(name, icon_id, action, True)
+        return TrayAction(name, icon_id, action, True, single_use)
 
 
 @dataclass

--- a/safeeyes/model.py
+++ b/safeeyes/model.py
@@ -24,6 +24,7 @@ import logging
 import random
 from enum import Enum
 from dataclasses import dataclass
+import typing
 from typing import Optional, Union
 
 from packaging.version import parse
@@ -375,21 +376,26 @@ class Config:
 class TrayAction:
     """Data object wrapping name, icon and action."""
 
-    def __init__(self, name, icon, action, system_icon):
+    __toolbar_buttons: list[Gtk.Button]
+
+    def __init__(
+        self, name: str, icon: str, action: typing.Callable, system_icon: bool
+    ) -> None:
         self.name = name
         self.__icon = icon
         self.action = action
         self.system_icon = system_icon
         self.__toolbar_buttons = []
 
-    def get_icon(self):
-        if self.system_icon:
-            image = Gtk.Image.new_from_icon_name(self.__icon)
-            return image
-        else:
+    def get_icon(self) -> Gtk.Image:
+        if not self.system_icon:
             image = utility.load_and_scale_image(self.__icon, 16, 16)
-            image.show()
-            return image
+            if image is not None:
+                image.show()
+                return image
+
+        image = Gtk.Image.new_from_icon_name(self.__icon)
+        return image
 
     def add_toolbar_button(self, button):
         self.__toolbar_buttons.append(button)
@@ -400,12 +406,19 @@ class TrayAction:
         self.__toolbar_buttons.clear()
 
     @classmethod
-    def build(cls, name, icon_path, icon_id, action):
-        image = utility.load_and_scale_image(icon_path, 12, 12)
-        if image is None:
-            return TrayAction(name, icon_id, action, True)
-        else:
-            return TrayAction(name, icon_path, action, False)
+    def build(
+        cls,
+        name: str,
+        icon_path: typing.Optional[str],
+        icon_id: str,
+        action: typing.Callable,
+    ) -> "TrayAction":
+        if icon_path is not None:
+            image = utility.load_and_scale_image(icon_path, 12, 12)
+            if image is not None:
+                return TrayAction(name, icon_path, action, False)
+
+        return TrayAction(name, icon_id, action, True)
 
 
 @dataclass

--- a/safeeyes/plugin_manager.py
+++ b/safeeyes/plugin_manager.py
@@ -24,9 +24,7 @@ A plugin must have the following directory structure:
     |- plugin.py
     |- icon.png (Optional)
 
-The plugin.py can have following methods but all are optional:
- - description()
-    If a custom description has to be displayed, use this function
+The plugin.py can have following lifecycle methods but all are optional:
  - init(context, safeeyes_config, plugin_config)
     Initialize the plugin. Will be called after loading and after every changes in
     configuration
@@ -50,6 +48,20 @@ The plugin.py can have following methods but all are optional:
     Executes once the plugin.py is loaded as a module
  - disable()
     Executes if the plugin is disabled at the runtime by the user
+
+The plugin.py can additionally have the following methods:
+ - get_widget_title(break_obj)
+    Returns title of this plugin's widget on the break screen
+    If this is used, it must also use get_widget_content to work correctly
+ - get_widget_content(break_obj)
+    Returns content of this plugin's widget on the break screen
+    If this is used, it must also use get_widget_title to work correctly
+ - get_tray_action(break_obj) -> TrayAction
+    Display a button on the break screen's tray that triggers an action
+
+This method is unused:
+ - description()
+    If a custom description has to be displayed, use this function
 """
 
 import importlib

--- a/safeeyes/plugin_manager.py
+++ b/safeeyes/plugin_manager.py
@@ -56,8 +56,8 @@ The plugin.py can additionally have the following methods:
  - get_widget_content(break_obj)
     Returns content of this plugin's widget on the break screen
     If this is used, it must also use get_widget_title to work correctly
- - get_tray_action(break_obj) -> TrayAction
-    Display a button on the break screen's tray that triggers an action
+ - get_tray_action(break_obj) -> TrayAction | list[TrayAction]
+    Display button(s) on the break screen's tray that triggers an action
 
 This method is unused:
  - description()
@@ -70,7 +70,7 @@ import os
 import sys
 
 from safeeyes import utility
-from safeeyes.model import PluginDependency, RequiredPluginException
+from safeeyes.model import Break, PluginDependency, RequiredPluginException, TrayAction
 
 sys.path.append(os.path.abspath(utility.SYSTEM_PLUGINS_DIR))
 sys.path.append(os.path.abspath(utility.USER_PLUGINS_DIR))
@@ -219,15 +219,19 @@ class PluginManager:
                 continue
         return widget.strip()
 
-    def get_break_screen_tray_actions(self, break_obj):
+    def get_break_screen_tray_actions(self, break_obj: Break) -> list[TrayAction]:
         """Return Tray Actions."""
         actions = []
         for plugin in self.__plugins.values():
             action = plugin.call_plugin_method_break_obj(
                 "get_tray_action", 1, break_obj
             )
-            if action:
+            if isinstance(action, TrayAction):
                 actions.append(action)
+            elif isinstance(action, list):
+                for a in action:
+                    if isinstance(a, TrayAction):
+                        actions.append(a)
 
         return actions
 

--- a/safeeyes/plugins/screensaver/resource/rotation-lock-symbolic.svg
+++ b/safeeyes/plugins/screensaver/resource/rotation-lock-symbolic.svg
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16px"
+   viewBox="0 0 16 16"
+   width="16px"
+   version="1.1"
+   id="svg3"
+   sodipodi:docname="rotation-lock-symbolic.svg"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs3" />
+  <sodipodi:namedview
+     id="namedview3"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="39.8125"
+     inkscape:cx="7.9874411"
+     inkscape:cy="8"
+     inkscape:window-width="1536"
+     inkscape:window-height="888"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3" />
+  <g
+     fill="#222222"
+     id="g3"
+     style="fill:#ababab;fill-opacity:1">
+    <path
+       d="m 8.589844 1 c 0.617187 0.007812 1.238281 0.089844 1.851562 0.257812 c 3.273438 0.875 5.558594 3.851563 5.558594 7.242188 s -2.285156 6.367188 -5.558594 7.242188 c -3.273437 0.878906 -6.742187 -0.554688 -8.4375 -3.492188 c -0.277344 -0.476562 -0.109375 -1.089844 0.367188 -1.363281 c 0.476562 -0.277344 1.089844 -0.113281 1.363281 0.363281 c 1.25 2.160156 3.78125 3.207031 6.1875 2.5625 c 2.410156 -0.644531 4.078125 -2.816406 4.078125 -5.3125 s -1.667969 -4.667969 -4.078125 -5.3125 c -2.40625 -0.644531 -4.9375 0.402344 -6.1875 2.5625 c -0.054687 0.085938 -0.121094 0.164062 -0.199219 0.230469 l 0.015625 0.011719 l 0.011719 0.007812 h 0.4375 c 0.550781 0 1 0.449219 1 1 v 1 h -5 v -5 h 1 c 0.550781 0 1 0.449219 1 1 v 0.6875 l 0.011719 0.011719 l 0.015625 0.011719 c 1.273437 -2.179688 3.53125 -3.519532 5.953125 -3.691407 c 0.203125 -0.015625 0.40625 -0.019531 0.609375 -0.015625 z m 0 0"
+       id="path1"
+       style="fill:#ababab;fill-opacity:1" />
+    <path
+       d="m 6 8 h 5.003906 c 0.539063 0 0.996094 0.550781 0.996094 1 v 3 h -7 v -2.984375 c 0 -0.511719 0.523438 -1.015625 1 -1.015625 z m 0 0"
+       id="path2"
+       style="fill:#ababab;fill-opacity:1" />
+    <path
+       d="m 8.5 5 c -1.375 0 -2.5 1.148438 -2.5 2.519531 v 0.960938 c 0 1.371093 1.125 2.519531 2.5 2.519531 s 2.5 -1.148438 2.5 -2.519531 v -0.960938 c 0 -1.371093 -1.125 -2.519531 -2.5 -2.519531 z m 0 2 c 0.289062 0 0.5 0.207031 0.5 0.519531 v 0.960938 c 0 0.3125 -0.210938 0.519531 -0.5 0.519531 s -0.5 -0.207031 -0.5 -0.519531 v -0.960938 c 0 -0.3125 0.210938 -0.519531 0.5 -0.519531 z m 0 0"
+       id="path3"
+       style="fill:#ababab;fill-opacity:1" />
+  </g>
+</svg>

--- a/safeeyes/ui/break_screen.py
+++ b/safeeyes/ui/break_screen.py
@@ -23,6 +23,7 @@ import time
 
 import gi
 from safeeyes import utility
+from safeeyes.model import TrayAction
 import Xlib
 from Xlib.display import Display
 from Xlib import X
@@ -125,13 +126,14 @@ class BreakScreen:
         # Destroy other windows if exists
         GLib.idle_add(lambda: self.__destroy_all_screens())
 
-    def __tray_action(self, button, tray_action):
+    def __tray_action(self, button, tray_action: TrayAction):
         """Tray action handler.
 
-        Hides all toolbar buttons for this action and call the action
-        provided by the plugin.
+        Hides all toolbar buttons for this action, if it is single use,
+        and call the action provided by the plugin.
         """
-        tray_action.reset()
+        if tray_action.single_use:
+            tray_action.reset()
         tray_action.action()
 
     def __show_break_screen(self, message, image_path, widget, tray_actions):

--- a/safeeyes/utility.py
+++ b/safeeyes/utility.py
@@ -31,6 +31,7 @@ import sys
 import shutil
 import subprocess
 import threading
+import typing
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
@@ -723,7 +724,9 @@ def create_gtk_builder(glade_file):
     return builder
 
 
-def load_and_scale_image(path, width, height):
+def load_and_scale_image(
+    path: str, width: int, height: int
+) -> typing.Optional[Gtk.Image]:
     if not os.path.isfile(path):
         return None
     pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_scale(


### PR DESCRIPTION
## Description

This PR adds a new tray action to the screensaver plugin. It locks the screen right away, while the break is still running.
This was requested in #724.

It changes the icon that locks the screen later:

![image](https://github.com/user-attachments/assets/7a57e781-151f-4e59-b1cf-389c2c10f803)

The padlock icon will lock the screen right away, while the padlock+arrow icon will lock it at the end of the break.

This needs some technical changes too:
Plugins now have the ability to add multiple tray icons, as well as tray icons that are not "single use", meaning they stay around after being clicked.