### PR TITLE
donotdisturb: implement detection on KDE Plasma Wayland 

### DIFF
--- a/safeeyes/plugins/donotdisturb/dependency_checker.py
+++ b/safeeyes/plugins/donotdisturb/dependency_checker.py
@@ -23,7 +23,10 @@ from safeeyes.translations import translate as _
 def validate(plugin_config, plugin_settings):
     command = None
     if utility.IS_WAYLAND:
-        if utility.DESKTOP_ENVIRONMENT == "gnome":
+        if (
+            utility.DESKTOP_ENVIRONMENT == "gnome"
+            or utility.DESKTOP_ENVIRONMENT == "kde"
+        ):
             return None
         command = "wlrctl"
     else:

--- a/safeeyes/plugins/donotdisturb/plugin.py
+++ b/safeeyes/plugins/donotdisturb/plugin.py
@@ -229,29 +229,24 @@ def _normalize_window_classes(classes_as_str: str):
     return [w.lower() for w in classes_as_str.split()]
 
 
-def on_pre_break(break_obj):
-    """Lifecycle method executes before the pre-break period."""
+def __should_skip_break(pre_break: bool) -> bool:
     if utility.IS_WAYLAND:
         if utility.DESKTOP_ENVIRONMENT == "gnome":
             skip_break = is_idle_inhibited_gnome()
         else:
-            skip_break = is_active_window_skipped_wayland(True)
+            skip_break = is_active_window_skipped_wayland(pre_break)
     else:
-        skip_break = is_active_window_skipped_xorg(True)
+        skip_break = is_active_window_skipped_xorg(pre_break)
     if dnd_while_on_battery and not skip_break:
         skip_break = is_on_battery()
     return skip_break
+
+
+def on_pre_break(break_obj):
+    """Lifecycle method executes before the pre-break period."""
+    return __should_skip_break(pre_break=True)
 
 
 def on_start_break(break_obj):
     """Lifecycle method executes just before the break."""
-    if utility.IS_WAYLAND:
-        if utility.DESKTOP_ENVIRONMENT == "gnome":
-            skip_break = is_idle_inhibited_gnome()
-        else:
-            skip_break = is_active_window_skipped_wayland(False)
-    else:
-        skip_break = is_active_window_skipped_xorg(False)
-    if dnd_while_on_battery and not skip_break:
-        skip_break = is_on_battery()
-    return skip_break
+    return __should_skip_break(pre_break=False)

--- a/safeeyes/plugins/donotdisturb/plugin.py
+++ b/safeeyes/plugins/donotdisturb/plugin.py
@@ -176,6 +176,32 @@ def is_idle_inhibited_gnome():
     return bool(result & 0b1000)
 
 
+def is_idle_inhibited_kde() -> bool:
+    """KDE Plasma doesn't work with wlrctl, and there is no way to enumerate
+    fullscreen windows, but KDE does expose a non-standard Inhibited property on
+    org.freedesktop.Notifications, which does communicate the Do Not Disturb status
+    on KDE.
+    This is also only an approximation, but comes pretty close.
+    """
+    dbus_proxy = Gio.DBusProxy.new_for_bus_sync(
+        bus_type=Gio.BusType.SESSION,
+        flags=Gio.DBusProxyFlags.NONE,
+        info=None,
+        name="org.freedesktop.Notifications",
+        object_path="/org/freedesktop/Notifications",
+        interface_name="org.freedesktop.Notifications",
+        cancellable=None,
+    )
+    prop = dbus_proxy.get_cached_property("Inhibited")
+
+    if prop is None:
+        return False
+
+    result = prop.unpack()
+
+    return result
+
+
 def _window_class_matches(window_class: str, classes: list) -> bool:
     return any(map(lambda w: w in classes, window_class.split()))
 
@@ -233,12 +259,18 @@ def __should_skip_break(pre_break: bool) -> bool:
     if utility.IS_WAYLAND:
         if utility.DESKTOP_ENVIRONMENT == "gnome":
             skip_break = is_idle_inhibited_gnome()
+        elif utility.DESKTOP_ENVIRONMENT == "kde":
+            skip_break = is_idle_inhibited_kde()
         else:
             skip_break = is_active_window_skipped_wayland(pre_break)
     else:
         skip_break = is_active_window_skipped_xorg(pre_break)
     if dnd_while_on_battery and not skip_break:
         skip_break = is_on_battery()
+
+    if skip_break:
+        logging.info("Skipping break due to donotdisturb")
+
     return skip_break
 
 


### PR DESCRIPTION
## Description

Fixes #568, cc #644.
This uses a non-standard property "Inhibited" on org.freedesktop.Notifications that is present on KDE Plasma to detect Plasma's Do Not Disturb mode.
This means that while screensharing, or while the screen is mirrored (which probably means presenting), or [while any fullscreen app is focused](https://invent.kde.org/plasma/plasma-workspace/-/merge_requests/4877), we will properly detect DND mode on KDE.