### PR TITLE
typing: add types to Core and BreakQueue, refactor

### DIFF
--- a/safeeyes/__main__.py
+++ b/safeeyes/__main__.py
@@ -112,7 +112,7 @@ def main():
     # Initialize the logging
     utility.initialize_logging(args.debug)
     utility.initialize_platform()
-    config = Config()
+    config = Config.load()
     utility.cleanup_old_user_stylesheet()
 
     if __running():

--- a/safeeyes/model.py
+++ b/safeeyes/model.py
@@ -96,15 +96,6 @@ class BreakQueue:
         self.__build_longs()
         self.__build_shorts()
 
-        # Interface guarantees that short_interval >= 1
-        # And that long_interval is a multiple of short_interval
-        short_interval = config.get("short_break_interval")
-        long_interval = config.get("long_break_interval")
-        self.__cycle_len = int(long_interval / short_interval)
-        # To count every long break as a cycle in .next() if there are no short breaks
-        if self.__short_queue is None:
-            self.__cycle_len = 1
-
         # Restore the last break from session
         if not self.is_empty():
             last_break = context["session"].get("break")

--- a/safeeyes/tests/test_model.py
+++ b/safeeyes/tests/test_model.py
@@ -67,16 +67,9 @@ class TestBreakQueue:
 
         context: dict[str, typing.Any] = {}
 
-        bq = model.BreakQueue(config, context)
+        bq = model.BreakQueue.create(config, context)
 
-        assert bq.is_empty()
-        assert bq.is_empty(model.BreakType.LONG_BREAK)
-        assert bq.is_empty(model.BreakType.SHORT_BREAK)
-
-        with pytest.raises(Exception, match="this should never be called"):
-            bq.next()
-        with pytest.raises(Exception, match="this should never be called"):
-            bq.get_break()
+        assert bq is None
 
     def get_bq_only_short(
         self, monkeypatch: pytest.MonkeyPatch, random_seed: typing.Optional[int] = None
@@ -109,7 +102,11 @@ class TestBreakQueue:
             "session": {},
         }
 
-        return model.BreakQueue(config, context)
+        bq = model.BreakQueue.create(config, context)
+
+        assert bq is not None
+
+        return bq
 
     def get_bq_only_long(
         self, monkeypatch: pytest.MonkeyPatch, random_seed: typing.Optional[int] = None
@@ -142,7 +139,11 @@ class TestBreakQueue:
             "session": {},
         }
 
-        return model.BreakQueue(config, context)
+        bq = model.BreakQueue.create(config, context)
+
+        assert bq is not None
+
+        return bq
 
     def get_bq_full(
         self, monkeypatch: pytest.MonkeyPatch, random_seed: typing.Optional[int] = None
@@ -180,12 +181,15 @@ class TestBreakQueue:
             "session": {},
         }
 
-        return model.BreakQueue(config, context)
+        bq = model.BreakQueue.create(config, context)
+
+        assert bq is not None
+
+        return bq
 
     def test_create_only_short(self, monkeypatch: pytest.MonkeyPatch) -> None:
         bq = self.get_bq_only_short(monkeypatch)
 
-        assert not bq.is_empty()
         assert not bq.is_empty(model.BreakType.SHORT_BREAK)
         assert bq.is_empty(model.BreakType.LONG_BREAK)
 
@@ -254,7 +258,6 @@ class TestBreakQueue:
     def test_create_only_long(self, monkeypatch: pytest.MonkeyPatch) -> None:
         bq = self.get_bq_only_long(monkeypatch)
 
-        assert not bq.is_empty()
         assert not bq.is_empty(model.BreakType.LONG_BREAK)
         assert bq.is_empty(model.BreakType.SHORT_BREAK)
 
@@ -321,7 +324,6 @@ class TestBreakQueue:
     def test_create_full(self, monkeypatch: pytest.MonkeyPatch) -> None:
         bq = self.get_bq_full(monkeypatch)
 
-        assert not bq.is_empty()
         assert not bq.is_empty(model.BreakType.LONG_BREAK)
         assert not bq.is_empty(model.BreakType.SHORT_BREAK)
 

--- a/safeeyes/tests/test_model.py
+++ b/safeeyes/tests/test_model.py
@@ -30,7 +30,7 @@ class TestBreak:
             time=15,
             duration=15,
             image=None,
-            plugins=None,
+            plugins={},
         )
 
         assert b.is_short_break()
@@ -43,7 +43,7 @@ class TestBreak:
             time=75,
             duration=60,
             image=None,
-            plugins=None,
+            plugins={},
         )
 
         assert not b.is_short_break()
@@ -72,8 +72,11 @@ class TestBreakQueue:
         assert bq.is_empty()
         assert bq.is_empty(model.BreakType.LONG_BREAK)
         assert bq.is_empty(model.BreakType.SHORT_BREAK)
-        assert bq.next() is None
-        assert bq.get_break() is None
+
+        with pytest.raises(Exception, match="this should never be called"):
+            bq.next()
+        with pytest.raises(Exception, match="this should never be called"):
+            bq.get_break()
 
     def get_bq_only_short(
         self, monkeypatch: pytest.MonkeyPatch, random_seed: typing.Optional[int] = None

--- a/safeeyes/tests/test_model.py
+++ b/safeeyes/tests/test_model.py
@@ -52,15 +52,18 @@ class TestBreak:
 
 class TestBreakQueue:
     def test_create_empty(self) -> None:
-        config = {
-            "short_breaks": [],
-            "long_breaks": [],
-            "short_break_interval": 15,
-            "long_break_interval": 75,
-            "long_break_duration": 60,
-            "short_break_duration": 15,
-            "random_order": False,
-        }
+        config = model.Config(
+            user_config={
+                "short_breaks": [],
+                "long_breaks": [],
+                "short_break_interval": 15,
+                "long_break_interval": 75,
+                "long_break_duration": 60,
+                "short_break_duration": 15,
+                "random_order": False,
+            },
+            system_config={},
+        )
 
         context: dict[str, typing.Any] = {}
 
@@ -82,19 +85,22 @@ class TestBreakQueue:
             model, "_", lambda message: "translated!: " + message, raising=False
         )
 
-        config = {
-            "short_breaks": [
-                {"name": "break 1"},
-                {"name": "break 2"},
-                {"name": "break 3"},
-            ],
-            "long_breaks": [],
-            "short_break_interval": 15,
-            "long_break_interval": 75,
-            "long_break_duration": 60,
-            "short_break_duration": 15,
-            "random_order": random_seed is not None,
-        }
+        config = model.Config(
+            user_config={
+                "short_breaks": [
+                    {"name": "break 1"},
+                    {"name": "break 2"},
+                    {"name": "break 3"},
+                ],
+                "long_breaks": [],
+                "short_break_interval": 15,
+                "long_break_interval": 75,
+                "long_break_duration": 60,
+                "short_break_duration": 15,
+                "random_order": random_seed is not None,
+            },
+            system_config={},
+        )
 
         context: dict[str, typing.Any] = {
             "session": {},
@@ -112,19 +118,22 @@ class TestBreakQueue:
             model, "_", lambda message: "translated!: " + message, raising=False
         )
 
-        config = {
-            "short_breaks": [],
-            "long_breaks": [
-                {"name": "long break 1"},
-                {"name": "long break 2"},
-                {"name": "long break 3"},
-            ],
-            "short_break_interval": 15,
-            "long_break_interval": 75,
-            "long_break_duration": 60,
-            "short_break_duration": 15,
-            "random_order": random_seed is not None,
-        }
+        config = model.Config(
+            user_config={
+                "short_breaks": [],
+                "long_breaks": [
+                    {"name": "long break 1"},
+                    {"name": "long break 2"},
+                    {"name": "long break 3"},
+                ],
+                "short_break_interval": 15,
+                "long_break_interval": 75,
+                "long_break_duration": 60,
+                "short_break_duration": 15,
+                "random_order": random_seed is not None,
+            },
+            system_config={},
+        )
 
         context: dict[str, typing.Any] = {
             "session": {},
@@ -142,24 +151,27 @@ class TestBreakQueue:
             model, "_", lambda message: "translated!: " + message, raising=False
         )
 
-        config = {
-            "short_breaks": [
-                {"name": "break 1"},
-                {"name": "break 2"},
-                {"name": "break 3"},
-                {"name": "break 4"},
-            ],
-            "long_breaks": [
-                {"name": "long break 1"},
-                {"name": "long break 2"},
-                {"name": "long break 3"},
-            ],
-            "short_break_interval": 15,
-            "long_break_interval": 75,
-            "long_break_duration": 60,
-            "short_break_duration": 15,
-            "random_order": random_seed is not None,
-        }
+        config = model.Config(
+            user_config={
+                "short_breaks": [
+                    {"name": "break 1"},
+                    {"name": "break 2"},
+                    {"name": "break 3"},
+                    {"name": "break 4"},
+                ],
+                "long_breaks": [
+                    {"name": "long break 1"},
+                    {"name": "long break 2"},
+                    {"name": "long break 3"},
+                ],
+                "short_break_interval": 15,
+                "long_break_interval": 75,
+                "long_break_duration": 60,
+                "short_break_duration": 15,
+                "random_order": random_seed is not None,
+            },
+            system_config={},
+        )
 
         context: dict[str, typing.Any] = {
             "session": {},


### PR DESCRIPTION
## Description

This PR adds a lot of type annotations to both `SafeEyesCore` and `BreakQueue`, ensuring that they get typechecked.

It also refactors the interaction between those two classes a lot.
Previously, `BreakQueue` could be completely empty, and there needed to be checks in multiple places to ensure there were breaks.
This PR now only instantiates `BreakQueue` if there is at least one break (this invariant is upheld by `BreakQueue.create()`).
This moves a lot of the checks into `SafeEyesCore` instead, where `_break_queue` can now be `None`.
However, a lot of those checks were already there, just checking `is_empty()` instead - so there isn't too much of a difference.

This PR is best reviewed commit by commit.