### PR TITLE
Add option to postpone breaks by seconds rather than minutes

### DIFF
--- a/safeeyes/config/locale/safeeyes.pot
+++ b/safeeyes/config/locale/safeeyes.pot
@@ -558,3 +558,12 @@ msgstr ""
 
 msgid "A required plugin is missing dependencies!"
 msgstr ""
+
+msgid "Postponement duration in"
+msgstr ""
+
+msgid "minutes"
+msgstr ""
+
+msgid "seconds"
+msgstr ""

--- a/safeeyes/config/safeeyes.json
+++ b/safeeyes/config/safeeyes.json
@@ -11,6 +11,7 @@
     "short_break_duration": 15,
     "persist_state": false,
     "postpone_duration": 5,
+    "postpone_unit": "minutes",
     "shortcut_disable_time": 2,
     "shortcut_skip": 9,
     "shortcut_postpone": 65,

--- a/safeeyes/core.py
+++ b/safeeyes/core.py
@@ -73,9 +73,11 @@ class SafeEyesCore:
         logging.info("Initialize the core")
         self.pre_break_warning_time = config.get("pre_break_warning_time")
         self._break_queue = BreakQueue.create(config, self.context)
-        self.default_postpone_duration = (
-            config.get("postpone_duration") * 60
-        )  # Convert to seconds
+        self.default_postpone_duration = int(config.get("postpone_duration"))
+        self.postpone_unit = config.get("postpone_unit")
+        if self.postpone_unit == "minutes":
+            self.default_postpone_duration *= 60
+
         self.postpone_duration = self.default_postpone_duration
 
     def start(self, next_break_time=-1, reset_breaks=False) -> None:
@@ -236,7 +238,11 @@ class SafeEyesCore:
         )
 
         # Wait for the pre break warning period
-        logging.info("Waiting for %d minutes until next break", (time_to_wait / 60))
+        if self.postpone_unit == "minutes":
+            logging.info("Waiting for %d minutes until next break", (time_to_wait / 60))
+        else:
+            logging.info("Waiting for %d seconds until next break", time_to_wait)
+
         self.__wait_for(time_to_wait)
 
         logging.info("Pre-break waiting is over")

--- a/safeeyes/glade/settings_dialog.glade
+++ b/safeeyes/glade/settings_dialog.glade
@@ -412,28 +412,46 @@
                                 </child>
                                 <child>
                                   <object class="GtkBox" id="box10">
-                                    <property name="visible">1</property>
                                     <property name="spacing">5</property>
-                                    <property name="homogeneous">1</property>
+                                    <property name="visible">1</property>
                                     <child>
                                       <object class="GtkLabel" id="lbl_postpone_duration">
-                                        <property name="visible">1</property>
                                         <property name="halign">start</property>
-                                        <property name="label" translatable="yes">Postponement duration (in minutes)</property>
+                                        <property name="label" translatable="yes">Postponement duration in</property>
+                                        <property name="visible">1</property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkDropDown" id="dropdown_postpone_unit">
+                                        <property name="halign">start</property>
+                                        <property name="valign">center</property>
+                                        <property name="hexpand">true</property>
+                                        <property name="vexpand">false</property>
+                                        <property name="selected">0</property>
+                                        <property name="model">
+                                          <object class="GtkStringList">
+                                            <items>
+                                              <item translatable="yes">minutes</item>
+                                              <item translatable="yes">seconds</item>
+                                            </items>
+                                          </object>
+                                        </property>
                                       </object>
                                     </child>
                                     <child>
                                       <object class="GtkSpinButton" id="spin_postpone_duration">
-                                        <property name="visible">1</property>
-                                        <property name="can-focus">1</property>
-                                        <property name="halign">end</property>
-                                        <property name="valign">center</property>
-                                        <property name="text">1</property>
                                         <property name="adjustment">adjust_postpone_duration</property>
+                                        <property name="can-focus">1</property>
                                         <property name="climb-rate">1</property>
+                                        <property name="halign">end</property>
+                                        <property name="hexpand">True</property>
+                                        <property name="hexpand-set">True</property>
                                         <property name="numeric">1</property>
+                                        <property name="text">1</property>
                                         <property name="update-policy">if-valid</property>
+                                        <property name="valign">center</property>
                                         <property name="value">1</property>
+                                        <property name="visible">1</property>
                                       </object>
                                     </child>
                                   </object>

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -325,7 +325,6 @@ class SettingsDialog:
         self.spin_postpone_duration.set_sensitive(self.switch_postpone.get_active())
         self.dropdown_postpone_unit.set_sensitive(self.switch_postpone.get_active())
 
-
     def on_spin_short_break_interval_change(self, spin_button, *value):
         """Event handler for value change of short break interval."""
         short_break_interval = self.spin_short_break_interval.get_value_as_int()
@@ -385,7 +384,8 @@ class SettingsDialog:
             "postpone_duration", self.spin_postpone_duration.get_value_as_int()
         )
         self.config.set(
-            "postpone_unit", self.dropdown_postpone_unit.get_selected_item().get_string()
+            "postpone_unit",
+            self.dropdown_postpone_unit.get_selected_item().get_string(),
         )
         self.config.set(
             "shortcut_disable_time",

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -80,6 +80,7 @@ class SettingsDialog:
         self.spin_long_break_interval = builder.get_object("spin_long_break_interval")
         self.spin_time_to_prepare = builder.get_object("spin_time_to_prepare")
         self.spin_postpone_duration = builder.get_object("spin_postpone_duration")
+        self.dropdown_postpone_unit = builder.get_object("dropdown_postpone_unit")
         self.spin_disable_keyboard_shortcut = builder.get_object(
             "spin_disable_keyboard_shortcut"
         )
@@ -130,6 +131,11 @@ class SettingsDialog:
         self.spin_long_break_interval.set_value(config.get("long_break_interval"))
         self.spin_time_to_prepare.set_value(config.get("pre_break_warning_time"))
         self.spin_postpone_duration.set_value(config.get("postpone_duration"))
+        # Set the active item in the dropdown based on the postpone unit
+        if config.get("postpone_unit") == "seconds":
+            self.dropdown_postpone_unit.set_selected(1)
+        else:
+            self.dropdown_postpone_unit.set_selected(0)
         self.spin_disable_keyboard_shortcut.set_value(
             config.get("shortcut_disable_time")
         )
@@ -140,7 +146,7 @@ class SettingsDialog:
         self.infobar_long_break_shown = False
 
     def __create_break_item(self, break_config, is_short):
-        """Create an entry for break to be listed in the break tab."""
+        """Create an entry for break  be listed in the break tab."""
         parent_box = self.box_long_breaks
         if is_short:
             parent_box = self.box_short_breaks
@@ -317,6 +323,8 @@ class SettingsDialog:
         state of the postpone switch.
         """
         self.spin_postpone_duration.set_sensitive(self.switch_postpone.get_active())
+        self.dropdown_postpone_unit.set_sensitive(self.switch_postpone.get_active())
+
 
     def on_spin_short_break_interval_change(self, spin_button, *value):
         """Event handler for value change of short break interval."""
@@ -375,6 +383,9 @@ class SettingsDialog:
         )
         self.config.set(
             "postpone_duration", self.spin_postpone_duration.get_value_as_int()
+        )
+        self.config.set(
+            "postpone_unit", self.dropdown_postpone_unit.get_selected_item().get_string()
         )
         self.config.set(
             "shortcut_disable_time",


### PR DESCRIPTION

# Add support for postponing breaks by seconds

## Summary
This PR extends the break postpone functionality to support postponing in seconds as well as minutes. My short breaks are 20 seconds, I only allow myself postponing so that I can finish my thought or writing the line. However, by the time a whole minute passes, I usually start on something else so I decided to just add the functionality to postpone in seconds. It's my first time committing to an open source project so please tell me if I'm doing anything wrong.

## Changes
- Added a drop-down unit selector in the settings dialog to choose between "minutes" and "seconds" for postpone duration
- Added `postpone_unit` to the config
- Whenever the postpone duration was used the unit is checked and if it's set to seconds it no longer multiplies the postpone duration by 60 

Please let me know if there's anything that should've been done differently and I can change it!
