### PR TITLE
audiblealert: add setting for volume

### DIFF
--- a/safeeyes/config/locale/safeeyes.pot
+++ b/safeeyes/config/locale/safeeyes.pot
@@ -567,3 +567,7 @@ msgstr ""
 
 msgid "seconds"
 msgstr ""
+
+#, python-format
+msgid "Please install one of the command-line tools: %s"
+msgstr ""

--- a/safeeyes/plugins/audiblealert/config.json
+++ b/safeeyes/plugins/audiblealert/config.json
@@ -6,7 +6,7 @@
     },
     "dependencies": {
         "python_modules": [],
-        "shell_commands": ["aplay"],
+        "shell_commands": ["ffplay"],
         "operating_systems": [],
         "desktop_environments": [],
         "resources": ["on_pre_break.wav", "on_stop_break.wav"]

--- a/safeeyes/plugins/audiblealert/config.json
+++ b/safeeyes/plugins/audiblealert/config.json
@@ -6,7 +6,7 @@
     },
     "dependencies": {
         "python_modules": [],
-        "shell_commands": ["ffplay"],
+        "shell_commands": [],
         "operating_systems": [],
         "desktop_environments": [],
         "resources": ["on_pre_break.wav", "on_stop_break.wav"]

--- a/safeeyes/plugins/audiblealert/config.json
+++ b/safeeyes/plugins/audiblealert/config.json
@@ -2,7 +2,7 @@
     "meta": {
         "name": "Audible Alert",
         "description": "Play audible alert before and after breaks",
-        "version": "0.0.3"
+        "version": "0.0.4"
     },
     "dependencies": {
         "python_modules": [],
@@ -22,6 +22,14 @@
         "label": "Play audible alert after breaks",
         "type": "BOOL",
         "default": true
+    },
+    {
+        "id": "volume",
+        "label": "Alert volume",
+        "type": "INT",
+        "default": 100,
+        "max": 100,
+        "min": 0
     }],
     "break_override_allowed": true
 }

--- a/safeeyes/plugins/audiblealert/dependency_checker.py
+++ b/safeeyes/plugins/audiblealert/dependency_checker.py
@@ -1,0 +1,36 @@
+# Safe Eyes is a utility to remind you to take break frequently
+# to protect your eyes from eye strain.
+
+# Copyright (C) 2025  Mel Dafert <m@dafert.at>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from safeeyes import utility
+from safeeyes.translations import translate as _
+
+
+def validate(plugin_config, plugin_settings):
+    commands = ["ffplay", "pw-play"]
+    exists = False
+    for command in commands:
+        if utility.command_exist(command):
+            exists = True
+            break
+
+    if not exists:
+        return _("Please install one of the command-line tools: %s") % ", ".join(
+            [f"'{command}'" for command in commands]
+        )
+    else:
+        return None

--- a/safeeyes/plugins/audiblealert/plugin.py
+++ b/safeeyes/plugins/audiblealert/plugin.py
@@ -42,7 +42,9 @@ def play_sound(resource_name):
         path = utility.get_resource_path(resource_name)
         if path is None:
             return
-        utility.execute_command("aplay", ["-q", path])
+        utility.execute_command(
+            "ffplay", [path, "-nodisp", "-nostats", "-hide_banner", "-autoexit"]
+        )
 
     except BaseException:
         logging.error("Failed to play audible alert %s", resource_name)

--- a/safeeyes/plugins/audiblealert/plugin.py
+++ b/safeeyes/plugins/audiblealert/plugin.py
@@ -45,6 +45,11 @@ def play_sound(resource_name):
         path = utility.get_resource_path(resource_name)
         if path is None:
             return
+    except BaseException:
+        logging.error("Failed to load resource %s", resource_name)
+        return
+
+    if utility.command_exist("ffplay"):  # ffmpeg
         utility.execute_command(
             "ffplay",
             [
@@ -57,9 +62,9 @@ def play_sound(resource_name):
                 str(volume),
             ],
         )
-
-    except BaseException:
-        logging.error("Failed to play audible alert %s", resource_name)
+    elif utility.command_exist("pw-play"):  # pipewire
+        pwvol = volume / 100  # 0 = silent, 1.0 = 100% volume
+        utility.execute_command("pw-play", ["--volume", str(pwvol), path])
 
 
 def init(ctx, safeeyes_config, plugin_config):

--- a/safeeyes/plugins/audiblealert/plugin.py
+++ b/safeeyes/plugins/audiblealert/plugin.py
@@ -26,6 +26,7 @@ from safeeyes import utility
 context = None
 pre_break_alert = False
 post_break_alert = False
+volume: int = 100
 
 
 def play_sound(resource_name):
@@ -36,14 +37,25 @@ def play_sound(resource_name):
         resource_name {string} -- name of the wav file resource
 
     """
-    logging.info("Playing audible alert %s", resource_name)
+    global volume
+
+    logging.info("Playing audible alert %s at volume %s%%", resource_name, volume)
     try:
         # Open the sound file
         path = utility.get_resource_path(resource_name)
         if path is None:
             return
         utility.execute_command(
-            "ffplay", [path, "-nodisp", "-nostats", "-hide_banner", "-autoexit"]
+            "ffplay",
+            [
+                path,
+                "-nodisp",
+                "-nostats",
+                "-hide_banner",
+                "-autoexit",
+                "-volume",
+                str(volume),
+            ],
         )
 
     except BaseException:
@@ -55,10 +67,16 @@ def init(ctx, safeeyes_config, plugin_config):
     global context
     global pre_break_alert
     global post_break_alert
+    global volume
     logging.debug("Initialize Audible Alert plugin")
     context = ctx
     pre_break_alert = plugin_config["pre_break_alert"]
     post_break_alert = plugin_config["post_break_alert"]
+    volume = int(plugin_config.get("volume", 100))
+    if volume > 100:
+        volume = 100
+    if volume < 0:
+        volume = 0
 
 
 def on_pre_break(break_obj):


### PR DESCRIPTION
## Description

This replaces the dependency on aplay with either ffplay (ffmpeg) or pw-play (pipewire).
Both of those tools, unlike aplay, allow controlling the volume directly.
At least one of the tools should be installed on most distros by default.

With the allowed volume control, it's easy to add a setting. It could be something nice like a slider, but right now it's just a number field between 0 and 100, which i think is obvious enough for such a setting.

Closes #445. Closes #738.
CC #488.
