### PR TITLE
core: refactor to run on main thread

### DIFF
--- a/safeeyes/core.py
+++ b/safeeyes/core.py
@@ -245,13 +245,7 @@ class SafeEyesCore:
 
         self.__wait_for(time_to_wait)
 
-        logging.info("Pre-break waiting is over")
-
-        if not self.running:
-            # This can be reached if another thread changed running while __wait_for was
-            # blocking
-            return  # type: ignore[unreachable]
-        utility.execute_main_thread(self.__fire_pre_break)
+        self.__do_pre_break()
 
     def __fire_on_update_next_break(self, next_break_time: datetime.datetime) -> None:
         """Pass the next break information to the registered listeners."""
@@ -259,6 +253,16 @@ class SafeEyesCore:
             # This will only be called by methods which check this
             return
         self.on_update_next_break.fire(self._break_queue.get_break(), next_break_time)
+
+    def __do_pre_break(self) -> None:
+        logging.info("Pre-break waiting is over")
+
+        if not self.running:
+            # This can be reached if another thread changed running while __wait_for was
+            # blocking
+            return
+
+        utility.execute_main_thread(self.__fire_pre_break)
 
     def __fire_pre_break(self) -> None:
         """Show the notification and start the break after the notification."""

--- a/safeeyes/core.py
+++ b/safeeyes/core.py
@@ -186,7 +186,7 @@ class SafeEyesCore:
 
         if break_type is not None and self._break_queue.get_break().type != break_type:
             self._break_queue.next(break_type)
-        utility.execute_main_thread(self.__fire_start_break)
+        utility.execute_main_thread(self.__do_start_break)
 
     def __scheduler_job(self) -> None:
         """Scheduler task to execute during every interval."""
@@ -280,13 +280,13 @@ class SafeEyesCore:
         self.__wait_for(self.pre_break_warning_time)
         if not self.running:
             return
-        utility.execute_main_thread(self.__fire_start_break)
+        utility.execute_main_thread(self.__do_start_break)
 
     def __postpone_break(self) -> None:
         self.__wait_for(self.postpone_duration)
-        utility.execute_main_thread(self.__fire_start_break)
+        utility.execute_main_thread(self.__do_start_break)
 
-    def __fire_start_break(self) -> None:
+    def __do_start_break(self) -> None:
         if self._break_queue is None:
             # This will only be called by methods which check this
             return

--- a/safeeyes/safeeyes.py
+++ b/safeeyes/safeeyes.py
@@ -23,7 +23,6 @@ application.
 import atexit
 import logging
 import typing
-from threading import Timer
 from importlib import metadata
 
 import gi
@@ -492,8 +491,7 @@ class SafeEyes(Gtk.Application):
             self.active = True
 
         if self.active and self.safe_eyes_core.has_breaks():
-            # 1 sec delay is required to give enough time for core to be stopped
-            Timer(1.0, self.safe_eyes_core.start).start()
+            self.safe_eyes_core.start()
             self.plugins_manager.start()
 
     def enable_safeeyes(self, scheduled_next_break_time=-1, reset_breaks=False):


### PR DESCRIPTION
## Description

This PR refactors, in steps, `SafeEyesCore` to run all the logic on the main thread, with the timeouts being handled by GLib timeouts.

This is done for a few reasons:
- Data races/locks. The previous implementation used locks in some places, but not all, and it was frankly hard to understand where they were necessary and where they were missing.
- Readability. Previously, it was hard to understand which parts were running in parallel and which ones weren't.
- GTK. Almost all GTK methods must be run from the main thread. By having no other threads, it is easier to ensure this is the case.
- Performance. Previously, there were some blocking `time.sleep()` calls that were waiting for background threads to finish, in some cases even blocking the main thread. With this PR, everything runs synchronously right away, with no need to block.
- Testability. In #641, I was trying to write tests `SafeEyesCore`. However, due to the complicated architecture using multiple threads, I had to implement a relatively complicated scheduler just for the tests. With this PR, the tests become much simpler.

This PR is best reviewed commit by commit.
