### PR TITLE
settings: small ui fixes

### DIFF
--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -288,7 +288,7 @@ class SettingsDialog:
 
     def __show_plugins_properties_dialog(self, plugin_config):
         """Show the PluginProperties dialog."""
-        dialog = PluginSettingsDialog(self.application, plugin_config)
+        dialog = PluginSettingsDialog(self.window, plugin_config)
         dialog.show()
 
     def __disable_errored_plugin(self, button, plugin_config):
@@ -301,7 +301,7 @@ class SettingsDialog:
     ):
         """Show the BreakProperties dialog."""
         dialog = BreakSettingsDialog(
-            self.application,
+            self.window,
             break_config,
             is_short,
             parent,
@@ -355,7 +355,7 @@ class SettingsDialog:
     def add_break(self, button) -> None:
         """Event handler for add break button."""
         dialog = NewBreakDialog(
-            self.application,
+            self.window,
             self.config,
             lambda is_short, break_config: self.__create_break_item(
                 break_config, is_short
@@ -406,13 +406,13 @@ class SettingsDialog:
 class PluginSettingsDialog:
     """Builds a settings dialog based on the configuration of a plugin."""
 
-    def __init__(self, application, config):
+    def __init__(self, parent, config):
         self.config = config
         self.property_controls = []
 
         builder = utility.create_gtk_builder(SETTINGS_DIALOG_PLUGIN_GLADE)
         self.window = builder.get_object("dialog_settings_plugin")
-        self.window.set_application(application)
+        self.window.set_transient_for(parent)
         box_settings = builder.get_object("box_settings")
         self.window.set_title(_("Plugin Settings"))
         for setting in config.get("settings"):
@@ -493,7 +493,7 @@ class BreakSettingsDialog:
 
     def __init__(
         self,
-        application,
+        parent,
         break_config,
         is_short,
         parent_config,
@@ -512,7 +512,7 @@ class BreakSettingsDialog:
 
         builder = utility.create_gtk_builder(SETTINGS_DIALOG_BREAK_GLADE)
         self.window = builder.get_object("dialog_settings_break")
-        self.window.set_application(application)
+        self.window.set_transient_for(parent)
         self.txt_break = builder.get_object("txt_break")
         self.switch_override_interval = builder.get_object("switch_override_interval")
         self.switch_override_duration = builder.get_object("switch_override_duration")
@@ -692,13 +692,13 @@ class BreakSettingsDialog:
 class NewBreakDialog:
     """Builds a new break dialog."""
 
-    def __init__(self, application, parent_config, on_add):
+    def __init__(self, parent, parent_config, on_add):
         self.parent_config = parent_config
         self.on_add = on_add
 
         builder = utility.create_gtk_builder(SETTINGS_DIALOG_NEW_BREAK_GLADE)
         self.window = builder.get_object("dialog_new_break")
-        self.window.set_application(application)
+        self.window.set_transient_for(parent)
         self.txt_break = builder.get_object("txt_break")
         self.cmb_type = builder.get_object("cmb_type")
         list_types = builder.get_object("lst_break_types")

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -421,7 +421,7 @@ class PluginSettingsDialog:
                     self.__load_int_item(
                         setting["label"],
                         setting["id"],
-                        setting["safeeyes_config"],
+                        config["active_plugin_config"],
                         setting.get("min", 0),
                         setting.get("max", 120),
                     )
@@ -429,13 +429,13 @@ class PluginSettingsDialog:
             elif setting["type"].upper() == "TEXT":
                 box_settings.append(
                     self.__load_text_item(
-                        setting["label"], setting["id"], setting["safeeyes_config"]
+                        setting["label"], setting["id"], config["active_plugin_config"]
                     )
                 )
             elif setting["type"].upper() == "BOOL":
                 box_settings.append(
                     self.__load_bool_item(
-                        setting["label"], setting["id"], setting["safeeyes_config"]
+                        setting["label"], setting["id"], config["active_plugin_config"]
                     )
                 )
 
@@ -450,9 +450,7 @@ class PluginSettingsDialog:
         spin_value.set_value(settings[key])
         box = builder.get_object("box")
         box.set_visible(True)
-        self.property_controls.append(
-            {"key": key, "settings": settings, "value": spin_value.get_value}
-        )
+        self.property_controls.append({"key": key, "value": spin_value.get_value})
         return box
 
     def __load_text_item(self, name, key, settings):
@@ -463,9 +461,7 @@ class PluginSettingsDialog:
         txt_value.set_text(settings[key])
         box = builder.get_object("box")
         box.set_visible(True)
-        self.property_controls.append(
-            {"key": key, "settings": settings, "value": txt_value.get_text}
-        )
+        self.property_controls.append({"key": key, "value": txt_value.get_text})
         return box
 
     def __load_bool_item(self, name, key, settings):
@@ -476,17 +472,15 @@ class PluginSettingsDialog:
         switch_value.set_active(settings[key])
         box = builder.get_object("box")
         box.set_visible(True)
-        self.property_controls.append(
-            {"key": key, "settings": settings, "value": switch_value.get_active}
-        )
+        self.property_controls.append({"key": key, "value": switch_value.get_active})
         return box
 
     def on_window_delete(self, *args):
         """Event handler for Properties dialog close action."""
         for property_control in self.property_controls:
-            property_control["settings"][property_control["key"]] = property_control[
-                "value"
-            ]()
+            self.config["active_plugin_config"][property_control["key"]] = (
+                property_control["value"]()
+            )
         self.window.destroy()
 
     def show(self):

--- a/safeeyes/utility.py
+++ b/safeeyes/utility.py
@@ -259,8 +259,8 @@ def load_plugins_config(safeeyes_config):
         config["id"] = plugin["id"]
         config["icon"] = icon
         config["enabled"] = plugin["enabled"]
-        for setting in config["settings"]:
-            setting["safeeyes_config"] = plugin["settings"]
+        config["active_plugin_config"] = plugin.get("settings")
+
         configs.append(config)
     return configs
 


### PR DESCRIPTION
## Description

Two small fixes, see the separate commits. Part of a larger refactoring.

The first commit is moves the active plugin config from being duplicated per-setting with a very generic key "settings" to being stored once per plugin with a more unique and hopefully understandable key.
This also avoids having to pass the setting through the input item callbacks.

The second commit changes the plugin and break dialogs from being normal application windows to using [transient-for](https://docs.gtk.org/gtk4/method.Window.set_transient_for.html). This makes them behave like dialogs, ie. blocking interaction with the main window while they are open, which is the expected behaviour and should avoid weird bugs.