### PR TITLE
refactor: ui: split items with templates into separate classes

### DIFF
--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -445,6 +445,49 @@ class PluginItem:
             self.on_properties()
 
 
+class IntItem:
+    def __init__(self, name, value, min_value, max_value):
+        super().__init__()
+
+        builder = utility.create_gtk_builder(SETTINGS_ITEM_INT_GLADE)
+        builder.get_object("lbl_name").set_label(_(name))
+        self.spin_value = builder.get_object("spin_value")
+        self.spin_value.set_range(min_value, max_value)
+        self.spin_value.set_value(value)
+        self.box = builder.get_object("box")
+
+    def get_value(self):
+        return self.spin_value.get_value()
+
+
+class TextItem:
+    def __init__(self, name, value):
+        super().__init__()
+
+        builder = utility.create_gtk_builder(SETTINGS_ITEM_TEXT_GLADE)
+        builder.get_object("lbl_name").set_label(_(name))
+        self.txt_value = builder.get_object("txt_value")
+        self.txt_value.set_text(value)
+        self.box = builder.get_object("box")
+
+    def get_value(self):
+        return self.txt_value.get_text()
+
+
+class BoolItem:
+    def __init__(self, name, value):
+        super().__init__()
+
+        builder = utility.create_gtk_builder(SETTINGS_ITEM_BOOL_GLADE)
+        builder.get_object("lbl_name").set_label(_(name))
+        self.switch_value = builder.get_object("switch_value")
+        self.switch_value.set_active(value)
+        self.box = builder.get_object("box")
+
+    def get_value(self):
+        return self.switch_value.get_active()
+
+
 class PluginSettingsDialog:
     """Builds a settings dialog based on the configuration of a plugin."""
 
@@ -459,67 +502,33 @@ class PluginSettingsDialog:
         self.window.set_title(_("Plugin Settings"))
         for setting in config.get("settings"):
             if setting["type"].upper() == "INT":
-                box = self.__load_int_item(
+                box = IntItem(
                     setting["label"],
-                    setting["id"],
-                    config["active_plugin_config"],
+                    config["active_plugin_config"][setting["id"]],
                     setting.get("min", 0),
                     setting.get("max", 120),
                 )
             elif setting["type"].upper() == "TEXT":
-                box = self.__load_text_item(
-                    setting["label"], setting["id"], config["active_plugin_config"]
+                box = TextItem(
+                    setting["label"], config["active_plugin_config"][setting["id"]]
                 )
             elif setting["type"].upper() == "BOOL":
-                box = self.__load_bool_item(
-                    setting["label"], setting["id"], config["active_plugin_config"]
+                box = BoolItem(
+                    setting["label"], config["active_plugin_config"][setting["id"]]
                 )
             else:
                 continue
 
-            box_settings.append(box)
+            self.property_controls.append({"key": setting["id"], "box": box})
+            box_settings.append(box.box)
 
         self.window.connect("close-request", self.on_window_delete)
-
-    def __load_int_item(self, name, key, settings, min_value, max_value):
-        """Load the UI control for int property."""
-        builder = utility.create_gtk_builder(SETTINGS_ITEM_INT_GLADE)
-        builder.get_object("lbl_name").set_label(_(name))
-        spin_value = builder.get_object("spin_value")
-        spin_value.set_range(min_value, max_value)
-        spin_value.set_value(settings[key])
-        box = builder.get_object("box")
-        box.set_visible(True)
-        self.property_controls.append({"key": key, "value": spin_value.get_value})
-        return box
-
-    def __load_text_item(self, name, key, settings):
-        """Load the UI control for text property."""
-        builder = utility.create_gtk_builder(SETTINGS_ITEM_TEXT_GLADE)
-        builder.get_object("lbl_name").set_label(_(name))
-        txt_value = builder.get_object("txt_value")
-        txt_value.set_text(settings[key])
-        box = builder.get_object("box")
-        box.set_visible(True)
-        self.property_controls.append({"key": key, "value": txt_value.get_text})
-        return box
-
-    def __load_bool_item(self, name, key, settings):
-        """Load the UI control for boolean property."""
-        builder = utility.create_gtk_builder(SETTINGS_ITEM_BOOL_GLADE)
-        builder.get_object("lbl_name").set_label(_(name))
-        switch_value = builder.get_object("switch_value")
-        switch_value.set_active(settings[key])
-        box = builder.get_object("box")
-        box.set_visible(True)
-        self.property_controls.append({"key": key, "value": switch_value.get_active})
-        return box
 
     def on_window_delete(self, *args):
         """Event handler for Properties dialog close action."""
         for property_control in self.property_controls:
             self.config["active_plugin_config"][property_control["key"]] = (
-                property_control["value"]()
+                property_control["box"].get_value()
             )
         self.window.destroy()
 

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -459,27 +459,25 @@ class PluginSettingsDialog:
         self.window.set_title(_("Plugin Settings"))
         for setting in config.get("settings"):
             if setting["type"].upper() == "INT":
-                box_settings.append(
-                    self.__load_int_item(
-                        setting["label"],
-                        setting["id"],
-                        config["active_plugin_config"],
-                        setting.get("min", 0),
-                        setting.get("max", 120),
-                    )
+                box = self.__load_int_item(
+                    setting["label"],
+                    setting["id"],
+                    config["active_plugin_config"],
+                    setting.get("min", 0),
+                    setting.get("max", 120),
                 )
             elif setting["type"].upper() == "TEXT":
-                box_settings.append(
-                    self.__load_text_item(
-                        setting["label"], setting["id"], config["active_plugin_config"]
-                    )
+                box = self.__load_text_item(
+                    setting["label"], setting["id"], config["active_plugin_config"]
                 )
             elif setting["type"].upper() == "BOOL":
-                box_settings.append(
-                    self.__load_bool_item(
-                        setting["label"], setting["id"], config["active_plugin_config"]
-                    )
+                box = self.__load_bool_item(
+                    setting["label"], setting["id"], config["active_plugin_config"]
                 )
+            else:
+                continue
+
+            box_settings.append(box)
 
         self.window.connect("close-request", self.on_window_delete)
 

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -150,36 +150,30 @@ class SettingsDialog:
         parent_box = self.box_long_breaks
         if is_short:
             parent_box = self.box_short_breaks
-        builder = utility.create_gtk_builder(SETTINGS_BREAK_ITEM_GLADE)
-        box = builder.get_object("box")
-        lbl_name = builder.get_object("lbl_name")
-        lbl_name.set_label(_(break_config["name"]))
-        btn_properties = builder.get_object("btn_properties")
-        btn_properties.connect(
-            "clicked",
-            lambda button: self.__show_break_properties_dialog(
+
+        box = BreakItem(
+            break_name=break_config["name"],
+            on_properties=lambda: self.__show_break_properties_dialog(
                 break_config,
                 is_short,
                 self.config,
-                lambda cfg: lbl_name.set_label(_(cfg["name"])),
+                lambda cfg: box.set_break_name(cfg["name"]),
                 lambda is_short, break_config: self.__create_break_item(
                     break_config, is_short
                 ),
                 lambda: parent_box.remove(box),
             ),
-        )
-        btn_delete = builder.get_object("btn_delete")
-        btn_delete.connect(
-            "clicked",
-            lambda button: self.__delete_break(
+            on_delete=lambda: self.__delete_break(
                 break_config,
                 is_short,
                 lambda: parent_box.remove(box),
             ),
         )
-        box.set_visible(True)
-        parent_box.append(box)
-        return box
+
+        gbox = box.box
+
+        gbox.set_visible(True)
+        parent_box.append(gbox)
 
     def on_reset_menu_clicked(self, button):
         self.popover.hide()
@@ -363,6 +357,32 @@ class SettingsDialog:
 
         self.on_save_settings(self.config)  # Call the provided save method
         self.window.destroy()
+
+
+class BreakItem:
+    def __init__(self, break_name, on_properties, on_delete):
+        super().__init__()
+
+        self.on_properties = on_properties
+        self.on_delete = on_delete
+
+        builder = utility.create_gtk_builder(SETTINGS_BREAK_ITEM_GLADE)
+        self.box = builder.get_object("box")
+        self.lbl_name = builder.get_object("lbl_name")
+        self.lbl_name.set_label(_(break_name))
+        self.btn_properties = builder.get_object("btn_properties")
+        self.btn_properties.connect("clicked", self.on_properties_clicked)
+        self.btn_delete = builder.get_object("btn_delete")
+        self.btn_delete.connect("clicked", self.on_delete_clicked)
+
+    def set_break_name(self, break_name):
+        self.lbl_name.set_label(_(break_name))
+
+    def on_properties_clicked(self, button):
+        self.on_properties()
+
+    def on_delete_clicked(self, button):
+        self.on_delete()
 
 
 class PluginItem:


### PR DESCRIPTION
## Description

Part of a larger refactor, based on #744.

In many places, a new glade template is being loaded on-demand without a separate class attached, specifically for the individual break windows, the plugin and break items within the list in the settings window, and the inputs for a plugin's individual settings.
In some cases, this made the code more complicated and harder to follow, as "business logic" and digging through the ui widgets was intermixed.

This PR splits out all these cases into separate classes. This makes the code more easy to follow, in my opinion, but also allows switching to Gtk.Template (to be done in a followup PR).