### PR TITLE
refactor: switch from Gtk.Builder to Gtk.Template, add types

### DIFF
--- a/safeeyes/glade/about_dialog.glade
+++ b/safeeyes/glade/about_dialog.glade
@@ -35,10 +35,11 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see &lt;https://www.gnu.org/licenses/&gt;.</property>
   </object>
-  <object class="GtkWindow" id="window_about">
+  <template parent="GtkApplicationWindow" class="AboutDialog">
     <property name="title">Safe Eyes</property>
     <property name="resizable">0</property>
     <property name="icon-name">io.github.slgobinath.SafeEyes</property>
+    <signal name="close-request" handler="on_window_delete" swapped="no" />
     <child>
       <object class="GtkBox" id="layout_box">
         <property name="visible">1</property>
@@ -144,6 +145,7 @@ along with this program.  If not, see &lt;https://www.gnu.org/licenses/&gt;.</pr
             </child>
             <child>
               <object class="GtkButton" id="btn_close">
+                <signal name="clicked" handler="on_close_clicked" swapped="no" />
                 <property name="label" translatable="yes">Close</property>
                 <property name="visible">1</property>
                 <property name="can-focus">1</property>
@@ -168,5 +170,5 @@ along with this program.  If not, see &lt;https://www.gnu.org/licenses/&gt;.</pr
         </child>
       </object>
     </child>
-  </object>
+  </template>
 </interface>

--- a/safeeyes/glade/break_screen.glade
+++ b/safeeyes/glade/break_screen.glade
@@ -18,12 +18,13 @@
 ~ You should have received a copy of the GNU General Public License
 ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<interface>
+<interface domain="safeyees">
   <requires lib="gtk" version="4.0"/>
-  <object class="GtkWindow" id="window_main">
+  <template parent="GtkWindow" class="BreakScreenWindow">
     <property name="icon-name">io.github.slgobinath.SafeEyes</property>
     <property name="decorated">0</property>
     <property name="deletable">0</property>
+    <signal name="close-request" handler="on_window_delete" swapped="no"/>
     <child>
       <object class="GtkGrid" id="grid1">
         <property name="row_homogeneous">1</property>
@@ -174,5 +175,5 @@
     <style>
       <class name="window_main"/>
     </style>
-  </object>
+  </template>
 </interface>

--- a/safeeyes/glade/item_bool.glade
+++ b/safeeyes/glade/item_bool.glade
@@ -19,9 +19,9 @@
 ~ You should have received a copy of the GNU General Public License
 ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<interface>
+<interface domain="safeeyes">
   <requires lib="gtk" version="4.0"/>
-  <object class="GtkBox" id="box">
+  <template parent="GtkBox" class="BoolItem">
     <property name="visible">1</property>
     <property name="margin-start">5</property>
     <property name="margin-end">5</property>
@@ -46,5 +46,5 @@
         <property name="valign">center</property>
       </object>
     </child>
-  </object>
+  </template>
 </interface>

--- a/safeeyes/glade/item_break.glade
+++ b/safeeyes/glade/item_break.glade
@@ -19,9 +19,9 @@
 ~ You should have received a copy of the GNU General Public License
 ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<interface>
+<interface domain="safeeyes">
   <requires lib="gtk" version="4.0"/>
-  <object class="GtkBox" id="box">
+  <template parent="GtkBox" class="BreakItem">
     <property name="visible">1</property>
     <property name="margin-start">5</property>
     <property name="margin-end">5</property>
@@ -47,6 +47,7 @@
         <property name="halign">center</property>
         <property name="valign">center</property>
         <property name="icon-name">gtk-properties</property>
+        <signal name="clicked" handler="on_properties_clicked" swapped="no"/>
         <style>
           <class name="btn_circle"/>
         </style>
@@ -59,10 +60,11 @@
         <property name="halign">center</property>
         <property name="valign">center</property>
         <property name="icon-name">edit-delete</property>
+        <signal name="clicked" handler="on_delete_clicked" swapped="no"/>
         <style>
           <class name="btn_circle"/>
         </style>
       </object>
     </child>
-  </object>
+  </template>
 </interface>

--- a/safeeyes/glade/item_int.glade
+++ b/safeeyes/glade/item_int.glade
@@ -19,14 +19,14 @@
 ~ You should have received a copy of the GNU General Public License
 ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<interface>
+<interface domain="safeeyes">
   <requires lib="gtk" version="4.0"/>
   <object class="GtkAdjustment" id="adjustment_value">
     <property name="upper">100</property>
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
   </object>
-  <object class="GtkBox" id="box">
+  <template parent="GtkBox" class="IntItem">
     <property name="visible">1</property>
     <property name="margin-start">5</property>
     <property name="margin-end">5</property>
@@ -52,5 +52,5 @@
         <property name="adjustment">adjustment_value</property>
       </object>
     </child>
-  </object>
+  </template>
 </interface>

--- a/safeeyes/glade/item_plugin.glade
+++ b/safeeyes/glade/item_plugin.glade
@@ -19,9 +19,9 @@
 ~ You should have received a copy of the GNU General Public License
 ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<interface>
+<interface domain="safeeyes">
   <requires lib="gtk" version="4.0"/>
-  <object class="GtkBox" id="box">
+  <template parent="GtkBox" class="PluginItem">
     <property name="visible">1</property>
     <property name="margin-start">5</property>
     <property name="margin-end">5</property>
@@ -108,6 +108,7 @@
             <property name="valign">center</property>
             <property name="icon-name">gtk-cancel</property>
             <property name="tooltip-text" translatable="yes">Disable permanently</property>
+            <signal name="clicked" handler="on_disable_errored" swapped="no"/>
             <style>
               <class name="btn_circle"/>
             </style>
@@ -121,6 +122,7 @@
             <property name="halign">center</property>
             <property name="valign">center</property>
             <property name="icon-name">gtk-properties</property>
+            <signal name="clicked" handler="on_properties_clicked" swapped="no"/>
             <style>
               <class name="btn_circle"/>
             </style>
@@ -128,5 +130,5 @@
         </child>
       </object>
     </child>
-  </object>
+  </template>
 </interface>

--- a/safeeyes/glade/item_text.glade
+++ b/safeeyes/glade/item_text.glade
@@ -19,9 +19,9 @@
 ~ You should have received a copy of the GNU General Public License
 ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<interface>
+<interface domain="safeeyes">
   <requires lib="gtk" version="4.0"/>
-  <object class="GtkBox" id="box">
+  <template parent="GtkBox" class="TextItem">
     <property name="visible">1</property>
     <property name="margin-start">5</property>
     <property name="margin-end">5</property>
@@ -46,5 +46,5 @@
         <property name="valign">center</property>
       </object>
     </child>
-  </object>
+  </template>
 </interface>

--- a/safeeyes/glade/new_break.glade
+++ b/safeeyes/glade/new_break.glade
@@ -19,7 +19,7 @@
 ~ You should have received a copy of the GNU General Public License
 ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<interface>
+<interface domain="safeeyes">
   <requires lib="gtk" version="4.0"/>
   <object class="GtkAdjustment" id="adjustment_duration">
     <property name="upper">100</property>
@@ -40,7 +40,7 @@
       </row>
     </data>
   </object>
-  <object class="GtkWindow" id="dialog_new_break">
+  <template parent="GtkWindow" class="NewBreakDialog">
     <property name="title" translatable="yes">New Break</property>
     <property name="resizable">0</property>
     <property name="modal">1</property>
@@ -48,6 +48,7 @@
     <property name="default-height">50</property>
     <property name="destroy-with-parent">1</property>
     <property name="icon-name">io.github.slgobinath.SafeEyes</property>
+    <signal name="close-request" handler="on_window_delete" swapped="no" />
     <child>
       <object class="GtkBox" id="box_settings">
         <property name="visible">1</property>
@@ -130,6 +131,7 @@
                 <property name="visible">1</property>
                 <property name="can-focus">1</property>
                 <property name="receives-default">1</property>
+                <signal name="clicked" handler="discard" swapped="no"/>
               </object>
             </child>
             <child>
@@ -138,11 +140,12 @@
                 <property name="visible">1</property>
                 <property name="can-focus">1</property>
                 <property name="receives-default">1</property>
+                <signal name="clicked" handler="save" swapped="no"/>
               </object>
             </child>
           </object>
         </child>
       </object>
     </child>
-  </object>
+  </template>
 </interface>

--- a/safeeyes/glade/required_plugin_dialog.glade
+++ b/safeeyes/glade/required_plugin_dialog.glade
@@ -19,12 +19,13 @@
 ~ You should have received a copy of the GNU General Public License
 ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<interface>
+<interface domain="safeeyes">
   <requires lib="gtk" version="4.0"/>
-  <object class="GtkWindow" id="window_required_plugin">
+  <template parent="GtkApplicationWindow" class="RequiredPluginDialog">
     <property name="title" translatable="1">Safe Eyes - Error</property>
     <property name="resizable">0</property>
     <property name="icon-name">io.github.slgobinath.SafeEyes</property>
+    <signal name="close-request" handler="on_window_delete" swapped="no"/>
     <child>
       <object class="GtkBox" id="layout_box">
         <property name="margin-start">5</property>
@@ -105,16 +106,18 @@
                 <property name="label" translatable="1">Quit</property>
                 <property name="receives-default">1</property>
                 <property name="vexpand">1</property>
+                <signal name="clicked" handler="on_close_clicked" swapped="no"/>
               </object>
             </child>
             <child>
               <object class="GtkButton" id="btn_disable_plugin">
                 <property name="label" translatable="1">Disable plugin temporarily</property>
+                <signal name="clicked" handler="on_disable_plugin_clicked" swapped="no"/>
               </object>
             </child>
           </object>
         </child>
       </object>
     </child>
-  </object>
+  </template>
 </interface>

--- a/safeeyes/glade/settings_break.glade
+++ b/safeeyes/glade/settings_break.glade
@@ -19,7 +19,7 @@
 ~ You should have received a copy of the GNU General Public License
 ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<interface>
+<interface domain="safeeyes">
   <requires lib="gtk" version="4.0"/>
   <object class="GtkAdjustment" id="adjustment_duration">
     <property name="lower">1</property>
@@ -47,7 +47,7 @@
       </row>
     </data>
   </object>
-  <object class="GtkWindow" id="dialog_settings_break">
+  <template parent="GtkWindow" class="BreakSettingsDialog">
     <property name="title" translatable="yes">Break Settings</property>
     <property name="resizable">0</property>
     <property name="modal">1</property>
@@ -55,6 +55,7 @@
     <property name="default-height">50</property>
     <property name="destroy-with-parent">1</property>
     <property name="icon-name">io.github.slgobinath.SafeEyes</property>
+    <signal name="close-request" handler="on_window_delete" swapped="no" />
     <child>
       <object class="GtkBox" id="box_settings">
         <property name="visible">1</property>
@@ -134,6 +135,7 @@
                         <property name="can-focus">1</property>
                         <property name="receives-default">1</property>
                         <property name="icon-name">gtk-missing-image</property>
+                        <signal name="clicked" handler="select_image" swapped="no"/>
                       </object>
                     </child>
                   </object>
@@ -179,6 +181,7 @@
                             <property name="can-focus">1</property>
                             <property name="halign">end</property>
                             <property name="valign">center</property>
+                            <signal name="state-set" handler="on_switch_override_interval_activate" swapped="no"/>
                           </object>
                         </child>
                       </object>
@@ -250,6 +253,7 @@
                             <property name="can-focus">1</property>
                             <property name="halign">end</property>
                             <property name="valign">center</property>
+                            <signal name="state-set" handler="on_switch_override_duration_activate" swapped="no"/>
                           </object>
                         </child>
                       </object>
@@ -322,6 +326,7 @@
                             <property name="can-focus">1</property>
                             <property name="halign">end</property>
                             <property name="valign">center</property>
+                            <signal name="state-set" handler="on_switch_override_plugins_activate" swapped="no"/>
                           </object>
                         </child>
                       </object>
@@ -347,5 +352,5 @@
         </child>
       </object>
     </child>
-  </object>
+  </template>
 </interface>

--- a/safeeyes/glade/settings_dialog.glade
+++ b/safeeyes/glade/settings_dialog.glade
@@ -19,7 +19,7 @@
 ~ You should have received a copy of the GNU General Public License
 ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<interface>
+<interface domain="safeeyes">
   <requires lib="gtk" version="4.0"/>
   <object class="GtkAdjustment" id="adjust_disable_keyboard_shortcut_duration">
     <property name="upper">15</property>
@@ -77,6 +77,7 @@
             <property name="receives-default">1</property>
             <property name="hexpand">1</property>
             <property name="vexpand">1</property>
+            <signal name="clicked" handler="on_reset_menu_clicked" swapped="no"/>
             <style>
               <class name="btn_menu"/>
             </style>
@@ -85,11 +86,12 @@
       </object>
     </child>
   </object>
-  <object class="GtkApplicationWindow" id="window_settings">
+  <template parent="GtkApplicationWindow" class="SettingsDialog">
     <property name="title">Safe Eyes</property>
     <property name="default-width">450</property>
     <property name="default-height">650</property>
     <property name="icon-name">io.github.slgobinath.SafeEyes</property>
+    <signal name="close-request" handler="on_window_delete" swapped="no" />
     <child>
       <object class="GtkStack" id="stack">
         <property name="visible">1</property>
@@ -151,6 +153,7 @@
                                         <property name="numeric">1</property>
                                         <property name="update-policy">if-valid</property>
                                         <property name="value">1</property>
+                                        <signal name="value-changed" handler="on_spin_short_break_interval_change" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
@@ -212,6 +215,8 @@
                                     <property name="show-close-button">1</property>
                                     <property name="hexpand">1</property>
                                     <property name="vexpand">1</property>
+                                    <signal name="close" handler="on_info_bar_long_break_close" swapped="no"/>
+                                    <signal name="response" handler="on_info_bar_long_break_close" swapped="no"/>
                                     <child>
                                       <object class="GtkBox">
                                         <property name="spacing">16</property>
@@ -261,6 +266,7 @@
                                         <property name="wrap">1</property>
                                         <property name="update-policy">if-valid</property>
                                         <property name="value">1</property>
+                                        <signal name="value-changed" handler="on_spin_long_break_interval_change" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
@@ -406,6 +412,7 @@
                                         <property name="can-focus">1</property>
                                         <property name="halign">end</property>
                                         <property name="valign">center</property>
+                                        <signal name="state-set" handler="on_switch_postpone_activate" swapped="no"/>
                                       </object>
                                     </child>
                                   </object>
@@ -624,6 +631,7 @@
                         <property name="receives-default">1</property>
                         <property name="halign">end</property>
                         <property name="icon-name">gtk-add</property>
+                        <signal name="clicked" handler="add_break" swapped="no"/>
                       </object>
                     </child>
                   </object>
@@ -711,5 +719,5 @@
         </child>
       </object>
     </child>
-  </object>
+  </template>
 </interface>

--- a/safeeyes/glade/settings_plugin.glade
+++ b/safeeyes/glade/settings_plugin.glade
@@ -19,9 +19,9 @@
 ~ You should have received a copy of the GNU General Public License
 ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<interface>
+<interface domain="safeeyes">
   <requires lib="gtk" version="4.0"/>
-  <object class="GtkWindow" id="dialog_settings_plugin">
+  <template parent="GtkWindow" class="PluginSettingsDialog">
     <property name="title" translatable="yes">Plugin Settings</property>
     <property name="resizable">0</property>
     <property name="modal">1</property>
@@ -29,6 +29,7 @@
     <property name="default-height">10</property>
     <property name="destroy-with-parent">1</property>
     <property name="icon-name">io.github.slgobinath.SafeEyes</property>
+    <signal name="close-request" handler="on_window_delete" swapped="no" />
     <child>
       <object class="GtkBox" id="box_settings">
         <property name="visible">1</property>
@@ -39,5 +40,5 @@
         <property name="homogeneous">1</property>
       </object>
     </child>
-  </object>
+  </template>
 </interface>

--- a/safeeyes/safeeyes.py
+++ b/safeeyes/safeeyes.py
@@ -358,6 +358,7 @@ class SafeEyes(Gtk.Application):
             error.get_message(),
             self.quit,
             lambda: self.disable_plugin(plugin_id),
+            application=self,
         )
         dialog.show()
 

--- a/safeeyes/safeeyes.py
+++ b/safeeyes/safeeyes.py
@@ -346,14 +346,13 @@ class SafeEyes(Gtk.Application):
             )
             settings_dialog.show()
 
-    def show_required_plugin_dialog(self, error: RequiredPluginException):
+    def show_required_plugin_dialog(self, error: RequiredPluginException) -> None:
         self.required_plugin_dialog_active = True
 
         logging.info("Show RequiredPlugin dialog")
         plugin_id = error.get_plugin_id()
 
         dialog = RequiredPluginDialog(
-            error.get_plugin_id(),
             error.get_plugin_name(),
             error.get_message(),
             self.quit,

--- a/safeeyes/ui/about_dialog.py
+++ b/safeeyes/ui/about_dialog.py
@@ -41,11 +41,11 @@ class AboutDialog(Gtk.ApplicationWindow):
 
     __gtype_name__ = "AboutDialog"
 
-    lbl_decription = Gtk.Template.Child()
-    lbl_license = Gtk.Template.Child()
-    lbl_app_name = Gtk.Template.Child()
+    lbl_decription: Gtk.Label = Gtk.Template.Child()
+    lbl_license: Gtk.Label = Gtk.Template.Child()
+    lbl_app_name: Gtk.Label = Gtk.Template.Child()
 
-    def __init__(self, application, version):
+    def __init__(self, application: Gtk.Application, version: str):
         super().__init__(application=application)
 
         self.lbl_decription.set_label(
@@ -59,16 +59,16 @@ class AboutDialog(Gtk.ApplicationWindow):
         # Set the version at the runtime
         self.lbl_app_name.set_label("Safe Eyes " + version)
 
-    def show(self):
+    def show(self) -> None:
         """Show the About dialog."""
         self.present()
 
     @Gtk.Template.Callback()
-    def on_window_delete(self, *args):
+    def on_window_delete(self, *args) -> None:
         """Window close event handler."""
         self.destroy()
 
     @Gtk.Template.Callback()
-    def on_close_clicked(self, *args):
+    def on_close_clicked(self, *args) -> None:
         """Close button click event handler."""
         self.destroy()

--- a/safeeyes/ui/about_dialog.py
+++ b/safeeyes/ui/about_dialog.py
@@ -19,6 +19,10 @@
 """This module creates the AboutDialog which shows the version and license."""
 
 import os
+import gi
+
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gtk
 
 from safeeyes import utility
 from safeeyes.translations import translate as _
@@ -26,7 +30,8 @@ from safeeyes.translations import translate as _
 ABOUT_DIALOG_GLADE = os.path.join(utility.BIN_DIRECTORY, "glade/about_dialog.glade")
 
 
-class AboutDialog:
+@Gtk.Template(filename=ABOUT_DIALOG_GLADE)
+class AboutDialog(Gtk.ApplicationWindow):
     """AboutDialog reads the about_dialog.glade and build the user interface
     using that file.
 
@@ -34,33 +39,36 @@ class AboutDialog:
     license and the GitHub url.
     """
 
+    __gtype_name__ = "AboutDialog"
+
+    lbl_decription = Gtk.Template.Child()
+    lbl_license = Gtk.Template.Child()
+    lbl_app_name = Gtk.Template.Child()
+
     def __init__(self, application, version):
-        builder = utility.create_gtk_builder(ABOUT_DIALOG_GLADE)
-        self.window = builder.get_object("window_about")
-        self.window.set_application(application)
+        super().__init__(application=application)
 
-        self.window.connect("close-request", self.on_window_delete)
-        builder.get_object("btn_close").connect("clicked", self.on_close_clicked)
-
-        builder.get_object("lbl_decription").set_label(
+        self.lbl_decription.set_label(
             _(
                 "Safe Eyes protects your eyes from eye strain (asthenopia) by reminding"
                 " you to take breaks while you're working long hours at the computer"
             )
         )
-        builder.get_object("lbl_license").set_label(_("License") + ":")
+        self.lbl_license.set_label(_("License") + ":")
 
         # Set the version at the runtime
-        builder.get_object("lbl_app_name").set_label("Safe Eyes " + version)
+        self.lbl_app_name.set_label("Safe Eyes " + version)
 
     def show(self):
         """Show the About dialog."""
-        self.window.present()
+        self.present()
 
+    @Gtk.Template.Callback()
     def on_window_delete(self, *args):
         """Window close event handler."""
-        self.window.destroy()
+        self.destroy()
 
+    @Gtk.Template.Callback()
     def on_close_clicked(self, *args):
         """Close button click event handler."""
-        self.window.destroy()
+        self.destroy()

--- a/safeeyes/ui/break_screen.py
+++ b/safeeyes/ui/break_screen.py
@@ -20,10 +20,11 @@
 import logging
 import os
 import time
+import typing
 
 import gi
 from safeeyes import utility
-from safeeyes.model import TrayAction
+from safeeyes.model import Break, Config, TrayAction
 from safeeyes.translations import translate as _
 import Xlib
 from Xlib.display import Display
@@ -44,7 +45,15 @@ class BreakScreen:
     This class creates and manages the fullscreen windows for every monitor.
     """
 
-    def __init__(self, application, context, on_skipped, on_postponed):
+    windows: list["BreakScreenWindow"]
+
+    def __init__(
+        self,
+        application: Gtk.Application,
+        context,
+        on_skipped: typing.Callable[[], None],
+        on_postponed: typing.Callable[[], None],
+    ):
         self.application = application
         self.context = context
         self.x11_display = None
@@ -64,7 +73,7 @@ class BreakScreen:
         if not self.context["is_wayland"]:
             self.x11_display = Display()
 
-    def initialize(self, config):
+    def initialize(self, config: Config) -> None:
         """Initialize the internal properties from configuration."""
         logging.info("Initialize the break screen")
         self.enable_postpone = config.get("allow_postpone", False)
@@ -84,7 +93,7 @@ class BreakScreen:
         self.shortcut_disable_time = config.get("shortcut_disable_time", 2)
         self.strict_break = config.get("strict_break", False)
 
-    def skip_break(self):
+    def skip_break(self) -> None:
         """Skip the break from the break screen."""
         logging.info("User skipped the break")
         # Must call on_skipped before close to lock screen before closing the break
@@ -92,28 +101,30 @@ class BreakScreen:
         self.on_skipped()
         self.close()
 
-    def postpone_break(self):
+    def postpone_break(self) -> None:
         """Postpone the break from the break screen."""
         logging.info("User postponed the break")
         self.on_postponed()
         self.close()
 
-    def on_skip_clicked(self, button):
+    def on_skip_clicked(self, button) -> None:
         """Skip button press event handler."""
         self.skip_break()
 
-    def on_postpone_clicked(self, button):
+    def on_postpone_clicked(self, button) -> None:
         """Postpone button press event handler."""
         self.postpone_break()
 
-    def show_count_down(self, countdown, seconds):
+    def show_count_down(self, countdown: int, seconds: int) -> None:
         """Show/update the count down on all screens."""
         self.enable_shortcut = self.shortcut_disable_time <= seconds
         mins, secs = divmod(countdown, 60)
         timeformat = "{:02d}:{:02d}".format(mins, secs)
         GLib.idle_add(lambda: self.__update_count_down(timeformat))
 
-    def show_message(self, break_obj, widget, tray_actions=[]):
+    def show_message(
+        self, break_obj: Break, widget: str, tray_actions: list[TrayAction] = []
+    ) -> None:
         """Show the break screen with the given message on all displays."""
         message = break_obj.name
         image_path = break_obj.image
@@ -122,7 +133,7 @@ class BreakScreen:
             lambda: self.__show_break_screen(message, image_path, widget, tray_actions)
         )
 
-    def close(self):
+    def close(self) -> None:
         """Hide the break screen from active window and destroy all other
         windows.
         """
@@ -133,14 +144,24 @@ class BreakScreen:
         # Destroy other windows if exists
         GLib.idle_add(lambda: self.__destroy_all_screens())
 
-    def __show_break_screen(self, message, image_path, widget, tray_actions):
+    def __show_break_screen(
+        self,
+        message: str,
+        image_path: typing.Optional[str],
+        widget: str,
+        tray_actions: list[TrayAction],
+    ) -> None:
         """Show an empty break screen on all screens."""
         # Lock the keyboard
         if not self.context["is_wayland"]:
             utility.start_thread(self.__lock_keyboard_x11)
 
         display = Gdk.Display.get_default()
-        monitors = display.get_monitors()
+
+        if display is None:
+            raise Exception("display not found")
+
+        monitors = typing.cast(typing.Sequence[Gdk.Monitor], display.get_monitors())
         logging.info("Show break screens in %d display(s)", len(monitors))
 
         skip_button_disabled = self.context.get("skip_button_disabled", False)
@@ -196,17 +217,22 @@ class BreakScreen:
 
             if self.context["is_wayland"]:
                 # this may or may not be granted by the window system
-                window.get_surface().inhibit_system_shortcuts(None)
+                surface = window.get_surface()
+                if surface is not None:
+                    typing.cast(Gdk.Toplevel, surface).inhibit_system_shortcuts(None)
 
             i = i + 1
 
-    def __update_count_down(self, count):
+    def __update_count_down(self, count: str) -> None:
         """Update the countdown on all break screens."""
         for window in self.windows:
             window.set_count_down(count)
 
-    def __window_set_keep_above_x11(self, window):
+    def __window_set_keep_above_x11(self, window: "BreakScreenWindow") -> None:
         """Use EWMH hints to keep window above and on all desktops."""
+        if self.x11_display is None:
+            return
+
         NET_WM_STATE = self.x11_display.intern_atom("_NET_WM_STATE")
         NET_WM_STATE_ABOVE = self.x11_display.intern_atom("_NET_WM_STATE_ABOVE")
         NET_WM_STATE_STICKY = self.x11_display.intern_atom("_NET_WM_STATE_STICKY")
@@ -216,7 +242,12 @@ class BreakScreen:
         # See https://specifications.freedesktop.org/wm-spec/1.3/ar01s05.html#id-1.6.8
         root_window = self.x11_display.screen().root
 
-        xid = GdkX11.X11Surface.get_xid(window.get_surface())
+        surface = window.get_surface()
+
+        if surface is None or not isinstance(surface, GdkX11.X11Surface):
+            return
+
+        xid = GdkX11.X11Surface.get_xid(surface)
 
         root_window.send_event(
             Xlib.protocol.event.ClientMessage(
@@ -240,11 +271,14 @@ class BreakScreen:
 
         self.x11_display.sync()
 
-    def __lock_keyboard_x11(self):
+    def __lock_keyboard_x11(self) -> None:
         """Lock the keyboard to prevent the user from using keyboard shortcuts.
 
         (X11 only)
         """
+        if self.x11_display is None:
+            return
+
         logging.info("Lock the keyboard")
         self.lock_keyboard = True
 
@@ -275,7 +309,9 @@ class BreakScreen:
                 # Reduce the CPU usage by sleeping for a second
                 time.sleep(1)
 
-    def on_key_pressed_wayland(self, event_controller_key, keyval, keycode, state):
+    def on_key_pressed_wayland(
+        self, event_controller_key, keyval, keycode, state
+    ) -> bool:
         if self.enable_shortcut:
             if keyval == Gdk.KEY_space and self.show_postpone_button:
                 self.postpone_break()
@@ -286,14 +322,17 @@ class BreakScreen:
 
         return False
 
-    def __release_keyboard_x11(self):
+    def __release_keyboard_x11(self) -> None:
         """Release the locked keyboard."""
+        if self.x11_display is None:
+            return
+
         logging.info("Unlock the keyboard")
         self.lock_keyboard = False
         self.x11_display.ungrab_keyboard(X.CurrentTime)
         self.x11_display.flush()
 
-    def __destroy_all_screens(self):
+    def __destroy_all_screens(self) -> None:
         """Close all the break screens."""
         for win in self.windows:
             win.destroy()
@@ -309,25 +348,25 @@ class BreakScreenWindow(Gtk.Window):
 
     __gtype_name__ = "BreakScreenWindow"
 
-    lbl_message = Gtk.Template.Child()
-    lbl_count = Gtk.Template.Child()
-    lbl_widget = Gtk.Template.Child()
-    img_break = Gtk.Template.Child()
-    box_buttons = Gtk.Template.Child()
-    toolbar = Gtk.Template.Child()
+    lbl_message: Gtk.Label = Gtk.Template.Child()
+    lbl_count: Gtk.Label = Gtk.Template.Child()
+    lbl_widget: Gtk.Label = Gtk.Template.Child()
+    img_break: Gtk.Image = Gtk.Template.Child()
+    box_buttons: Gtk.Box = Gtk.Template.Child()
+    toolbar: Gtk.Box = Gtk.Template.Child()
 
     def __init__(
         self,
-        application,
-        message,
-        image_path,
-        widget,
-        tray_actions,
-        on_close,
-        show_postpone,
-        on_postpone,
-        show_skip,
-        on_skip,
+        application: Gtk.Application,
+        message: str,
+        image_path: typing.Optional[str],
+        widget: str,
+        tray_actions: list[TrayAction],
+        on_close: typing.Callable[[], None],
+        show_postpone: bool,
+        on_postpone: typing.Callable[[Gtk.Button], None],
+        show_skip: bool,
+        on_skip: typing.Callable[[Gtk.Button], None],
     ):
         super().__init__(application=application)
 
@@ -372,10 +411,10 @@ class BreakScreenWindow(Gtk.Window):
         self.lbl_message.set_label(message)
         self.lbl_widget.set_markup(widget)
 
-    def set_count_down(self, count):
+    def set_count_down(self, count: str) -> None:
         self.lbl_count.set_text(count)
 
-    def __tray_action(self, button, tray_action: TrayAction):
+    def __tray_action(self, button, tray_action: TrayAction) -> None:
         """Tray action handler.
 
         Hides all toolbar buttons for this action and call the action
@@ -386,7 +425,7 @@ class BreakScreenWindow(Gtk.Window):
         tray_action.action()
 
     @Gtk.Template.Callback()
-    def on_window_delete(self, *args):
+    def on_window_delete(self, *args) -> None:
         """Window close event handler."""
         logging.info("Closing the break screen")
         self.on_close()

--- a/safeeyes/ui/required_plugin_dialog.py
+++ b/safeeyes/ui/required_plugin_dialog.py
@@ -21,6 +21,10 @@ required plugin.
 """
 
 import os
+import gi
+
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gtk
 
 from safeeyes import utility
 from safeeyes.model import PluginDependency
@@ -31,62 +35,53 @@ REQUIRED_PLUGIN_DIALOG_GLADE = os.path.join(
 )
 
 
-class RequiredPluginDialog:
+@Gtk.Template(filename=REQUIRED_PLUGIN_DIALOG_GLADE)
+class RequiredPluginDialog(Gtk.ApplicationWindow):
     """RequiredPluginDialog shows an error when a plugin has required
     dependencies.
     """
 
-    def __init__(self, plugin_id, plugin_name, message, on_quit, on_disable_plugin):
+    __gtype_name__ = "RequiredPluginDialog"
+
+    lbl_header = Gtk.Template.Child()
+    lbl_message = Gtk.Template.Child()
+    btn_extra_link = Gtk.Template.Child()
+
+    def __init__(
+        self, plugin_id, plugin_name, message, on_quit, on_disable_plugin, application
+    ):
+        super().__init__(application=application)
+
         self.on_quit = on_quit
         self.on_disable_plugin = on_disable_plugin
 
-        builder = utility.create_gtk_builder(REQUIRED_PLUGIN_DIALOG_GLADE)
-        self.window = builder.get_object("window_required_plugin")
-
-        self.window.connect("close-request", self.on_window_delete)
-        builder.get_object("btn_close").connect("clicked", self.on_close_clicked)
-        builder.get_object("btn_disable_plugin").connect(
-            "clicked", self.on_disable_plugin_clicked
-        )
-
-        builder.get_object("lbl_header").set_label(
+        self.lbl_header.set_label(
             _("The required plugin '%s' is missing dependencies!") % _(plugin_name)
         )
 
-        builder.get_object("lbl_main").set_label(
-            _(
-                "Please install the dependencies or disable the plugin. To hide this"
-                " message, you can also deactivate the plugin in the settings."
-            )
-        )
-
-        builder.get_object("btn_close").set_label(_("Quit"))
-        builder.get_object("btn_disable_plugin").set_label(
-            _("Disable plugin temporarily")
-        )
-
         if isinstance(message, PluginDependency):
-            builder.get_object("lbl_message").set_label(_(message.message))
-            btn_extra_link = builder.get_object("btn_extra_link")
-            btn_extra_link.set_label(_("Click here for more information"))
-            btn_extra_link.set_uri(message.link)
-            btn_extra_link.set_visible(True)
+            self.lbl_message.set_label(_(message.message))
+            self.btn_extra_link.set_uri(message.link)
+            self.btn_extra_link.set_visible(True)
         else:
-            builder.get_object("lbl_message").set_label(_(message))
+            self.lbl_message.set_label(_(message))
 
     def show(self):
         """Show the dialog."""
-        self.window.present()
+        self.present()
 
+    @Gtk.Template.Callback()
     def on_window_delete(self, *args):
         """Window close event handler."""
-        self.window.destroy()
+        self.destroy()
         self.on_quit()
 
+    @Gtk.Template.Callback()
     def on_close_clicked(self, *args):
-        self.window.destroy()
+        self.destroy()
         self.on_quit()
 
+    @Gtk.Template.Callback()
     def on_disable_plugin_clicked(self, *args):
-        self.window.destroy()
+        self.destroy()
         self.on_disable_plugin()

--- a/safeeyes/ui/required_plugin_dialog.py
+++ b/safeeyes/ui/required_plugin_dialog.py
@@ -22,6 +22,7 @@ required plugin.
 
 import os
 import gi
+import typing
 
 gi.require_version("Gtk", "4.0")
 from gi.repository import Gtk
@@ -43,12 +44,17 @@ class RequiredPluginDialog(Gtk.ApplicationWindow):
 
     __gtype_name__ = "RequiredPluginDialog"
 
-    lbl_header = Gtk.Template.Child()
-    lbl_message = Gtk.Template.Child()
-    btn_extra_link = Gtk.Template.Child()
+    lbl_header: Gtk.Label = Gtk.Template.Child()
+    lbl_message: Gtk.Label = Gtk.Template.Child()
+    btn_extra_link: Gtk.LinkButton = Gtk.Template.Child()
 
     def __init__(
-        self, plugin_id, plugin_name, message, on_quit, on_disable_plugin, application
+        self,
+        plugin_name: str,
+        message: typing.Union[str, PluginDependency],
+        on_quit: typing.Callable[[], None],
+        on_disable_plugin: typing.Callable[[], None],
+        application: Gtk.Application,
     ):
         super().__init__(application=application)
 
@@ -61,27 +67,28 @@ class RequiredPluginDialog(Gtk.ApplicationWindow):
 
         if isinstance(message, PluginDependency):
             self.lbl_message.set_label(_(message.message))
-            self.btn_extra_link.set_uri(message.link)
+            if message.link is not None:
+                self.btn_extra_link.set_uri(message.link)
             self.btn_extra_link.set_visible(True)
         else:
             self.lbl_message.set_label(_(message))
 
-    def show(self):
+    def show(self) -> None:
         """Show the dialog."""
         self.present()
 
     @Gtk.Template.Callback()
-    def on_window_delete(self, *args):
+    def on_window_delete(self, *args) -> None:
         """Window close event handler."""
         self.destroy()
         self.on_quit()
 
     @Gtk.Template.Callback()
-    def on_close_clicked(self, *args):
+    def on_close_clicked(self, *args) -> None:
         self.destroy()
         self.on_quit()
 
     @Gtk.Template.Callback()
-    def on_disable_plugin_clicked(self, *args):
+    def on_disable_plugin_clicked(self, *args) -> None:
         self.destroy()
         self.on_disable_plugin()

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -431,44 +431,53 @@ class PluginItem(Gtk.Box):
             self.on_properties()
 
 
-class IntItem:
+@Gtk.Template(filename=SETTINGS_ITEM_INT_GLADE)
+class IntItem(Gtk.Box):
+    __gtype_name__ = "IntItem"
+
+    lbl_name = Gtk.Template.Child()
+    spin_value = Gtk.Template.Child()
+
     def __init__(self, name, value, min_value, max_value):
         super().__init__()
 
-        builder = utility.create_gtk_builder(SETTINGS_ITEM_INT_GLADE)
-        builder.get_object("lbl_name").set_label(_(name))
-        self.spin_value = builder.get_object("spin_value")
+        self.lbl_name.set_label(_(name))
         self.spin_value.set_range(min_value, max_value)
         self.spin_value.set_value(value)
-        self.box = builder.get_object("box")
 
     def get_value(self):
         return self.spin_value.get_value()
 
 
-class TextItem:
+@Gtk.Template(filename=SETTINGS_ITEM_TEXT_GLADE)
+class TextItem(Gtk.Box):
+    __gtype_name__ = "TextItem"
+
+    lbl_name = Gtk.Template.Child()
+    txt_value = Gtk.Template.Child()
+
     def __init__(self, name, value):
         super().__init__()
 
-        builder = utility.create_gtk_builder(SETTINGS_ITEM_TEXT_GLADE)
-        builder.get_object("lbl_name").set_label(_(name))
-        self.txt_value = builder.get_object("txt_value")
+        self.lbl_name.set_label(_(name))
         self.txt_value.set_text(value)
-        self.box = builder.get_object("box")
 
     def get_value(self):
         return self.txt_value.get_text()
 
 
-class BoolItem:
+@Gtk.Template(filename=SETTINGS_ITEM_BOOL_GLADE)
+class BoolItem(Gtk.Box):
+    __gtype_name__ = "BoolItem"
+
+    lbl_name = Gtk.Template.Child()
+    switch_value = Gtk.Template.Child()
+
     def __init__(self, name, value):
         super().__init__()
 
-        builder = utility.create_gtk_builder(SETTINGS_ITEM_BOOL_GLADE)
-        builder.get_object("lbl_name").set_label(_(name))
-        self.switch_value = builder.get_object("switch_value")
+        self.lbl_name.set_label(_(name))
         self.switch_value.set_active(value)
-        self.box = builder.get_object("box")
 
     def get_value(self):
         return self.switch_value.get_active()
@@ -508,7 +517,7 @@ class PluginSettingsDialog(Gtk.Window):
                 continue
 
             self.property_controls.append({"key": setting["id"], "box": box})
-            self.box_settings.append(box.box)
+            self.box_settings.append(box)
 
     @Gtk.Template.Callback()
     def on_window_delete(self, *args):

--- a/safeeyes/utility.py
+++ b/safeeyes/utility.py
@@ -713,26 +713,6 @@ def open_session():
     return session
 
 
-def create_gtk_builder(glade_file):
-    """Create a Gtk builder and load the glade file."""
-    from safeeyes.translations import translate as _
-
-    builder = Gtk.Builder()
-    builder.set_translation_domain("safeeyes")
-    builder.add_from_file(glade_file)
-    # Tranlslate all sub components
-    for obj in builder.get_objects():
-        if hasattr(obj, "get_label"):
-            label = obj.get_label()
-            if label is not None:
-                obj.set_label(_(label))
-        elif hasattr(obj, "get_title"):
-            title = obj.get_title()
-            if title is not None:
-                obj.set_title(_(title))
-    return builder
-
-
 def load_and_scale_image(
     path: str, width: int, height: int
 ) -> typing.Optional[Gtk.Image]:


### PR DESCRIPTION
## Description

This PR switches from Gtk.Builder calls to [Gtk.Template](https://pygobject.gnome.org/guide/gtk_template.html) decorations.
This is the larger refactor prepared by #744 and #745.

This has multiple upsides:
- It restores the ability to use `<signal>` declarations within the xml templates, as before the GTK4 migration.
- It allows giving types to objects within the templates in the `Gtk.Template.Child()` properties, unlocking wider type checks.
- It often allows for cleaner code, as the classes are now the root widget instance (eg. `BreakScreenWindow` now is the `Gtk.Window`, instead of having an indirection).
- Translation is natively built in, without needing to manually translate all contents again.