### PR TITLE
typing: add Context class for gradual typing

### DIFF
--- a/safeeyes/context.py
+++ b/safeeyes/context.py
@@ -1,0 +1,132 @@
+# Safe Eyes is a utility to remind you to take break frequently
+# to protect your eyes from eye strain.
+
+# Copyright (C) 2025 Mel Dafert <m@dafert.at>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from collections.abc import MutableMapping
+import datetime
+import typing
+
+from safeeyes import utility
+from safeeyes.model import State
+
+if typing.TYPE_CHECKING:
+    from safeeyes.safeeyes import SafeEyes
+
+
+class API:
+    _application: "SafeEyes"
+
+    def __init__(
+        self,
+        application: "SafeEyes",
+    ) -> None:
+        self._application = application
+
+    def __getitem__(self, key: str) -> typing.Callable:
+        """This is soft-deprecated - it is preferred to access the property."""
+        return getattr(self, key)
+
+    def show_settings(self) -> None:
+        utility.execute_main_thread(self._application.show_settings)
+
+    def show_about(self) -> None:
+        utility.execute_main_thread(self._application.show_about)
+
+    def enable_safeeyes(self, next_break_time=-1) -> None:
+        utility.execute_main_thread(self._application.enable_safeeyes, next_break_time)
+
+    def disable_safeeyes(self, status=None, is_resting=False) -> None:
+        utility.execute_main_thread(
+            self._application.disable_safeeyes, status, is_resting
+        )
+
+    def status(self) -> str:
+        return self._application.status()
+
+    def quit(self) -> None:
+        utility.execute_main_thread(self._application.quit)
+
+    def take_break(self, break_type=None) -> None:
+        self._application.take_break(break_type)
+
+    def has_breaks(self, break_type=None) -> bool:
+        return self._application.safe_eyes_core.has_breaks(break_type)
+
+    def postpone(self, duration=-1) -> None:
+        self._application.safe_eyes_core.postpone(duration)
+
+    def get_break_time(self, break_type=None) -> typing.Optional[datetime.datetime]:
+        return self._application.safe_eyes_core.get_break_time(break_type)
+
+
+class Context(MutableMapping):
+    version: str
+    api: API
+    desktop: str
+    is_wayland: bool
+    locale: str
+    session: dict[str, typing.Any]
+    state: State
+
+    ext: dict
+
+    def __init__(
+        self,
+        api: API,
+        locale: str,
+        version: str,
+        session: dict[str, typing.Any],
+    ) -> None:
+        self.version = version
+        self.desktop = utility.desktop_environment()
+        self.is_wayland = utility.is_wayland()
+        self.locale = locale
+        self.session = session
+        self.state = State.START
+        self.api = api
+
+        self.ext = {}
+
+    def __setitem__(self, key: str, value: typing.Any) -> None:
+        """This is soft-deprecated - it is preferred to access the property."""
+        if hasattr(self, key):
+            setattr(self, key, value)
+            return
+
+        self.ext[key] = value
+
+    def __getitem__(self, key: str) -> typing.Any:
+        """This is soft-deprecated - it is preferred to access the property."""
+        if hasattr(self, key):
+            return getattr(self, key)
+
+        return self.ext[key]
+
+    def __delitem__(self, key: str) -> None:
+        """This is soft-deprecated - it is preferred to access the property."""
+        if hasattr(self, key):
+            raise Exception("cannot delete property")
+
+        del self.ext[key]
+
+    def __len__(self) -> int:
+        """This is soft-deprecated."""
+        return len(self.ext)
+
+    def __iter__(self) -> typing.Iterator[typing.Any]:
+        """This is soft-deprecated."""
+        return iter(self.ext)

--- a/safeeyes/context.py
+++ b/safeeyes/context.py
@@ -82,6 +82,11 @@ class Context(MutableMapping):
     session: dict[str, typing.Any]
     state: State
 
+    skipped: bool = False
+    postponed: bool = False
+    skip_button_disabled: bool = False
+    postpone_button_disabled: bool = False
+
     ext: dict
 
     def __init__(

--- a/safeeyes/plugins/smartpause/plugin.py
+++ b/safeeyes/plugins/smartpause/plugin.py
@@ -21,6 +21,7 @@ import logging
 import typing
 
 from safeeyes.model import State
+from safeeyes.context import Context
 
 from .interface import IdleMonitorInterface
 from .gnome_dbus import IdleMonitorGnomeDBus
@@ -31,7 +32,7 @@ from .x11 import IdleMonitorX11
 Safe Eyes smart pause plugin
 """
 
-context = None
+context: Context
 idle_time: float = 0
 enable_safeeyes = None
 disable_safeeyes = None
@@ -60,7 +61,7 @@ def _on_idle() -> None:
     global smart_pause_activated
     global idle_start_time
 
-    if context["state"] == State.WAITING:  # type: ignore[index]
+    if context["state"] == State.WAITING:
         smart_pause_activated = True
         idle_start_time = datetime.datetime.now() - datetime.timedelta(
             seconds=idle_time
@@ -73,15 +74,12 @@ def _on_resumed() -> None:
     global smart_pause_activated
     global idle_start_time
 
-    if (
-        context["state"] == State.RESTING  # type: ignore[index]
-        and idle_start_time is not None
-    ):
+    if context["state"] == State.RESTING and idle_start_time is not None:
         logging.info("Resume Safe Eyes due to user activity")
         smart_pause_activated = False
         idle_period = datetime.datetime.now() - idle_start_time
         idle_seconds = idle_period.total_seconds()
-        context["idle_period"] = idle_seconds  # type: ignore[index]
+        context["idle_period"] = idle_seconds
         if idle_seconds < short_break_interval:
             # Credit back the idle time
             if next_break_time is not None:
@@ -281,7 +279,7 @@ def disable() -> None:
     global idle_monitor
 
     # Remove the idle_period
-    context.pop("idle_period", None)  # type: ignore[union-attr]
+    context.pop("idle_period", None)
 
     if idle_monitor is not None:
         idle_monitor.stop()

--- a/safeeyes/tests/test_model.py
+++ b/safeeyes/tests/test_model.py
@@ -19,7 +19,8 @@
 import pytest
 import random
 import typing
-from safeeyes import model
+from unittest import mock
+from safeeyes import context, model
 
 
 class TestBreak:
@@ -65,9 +66,11 @@ class TestBreakQueue:
             system_config={},
         )
 
-        context: dict[str, typing.Any] = {}
+        ctx = context.Context(
+            api=mock.Mock(spec=context.API), locale="en_US", version="0.0.0", session={}
+        )
 
-        bq = model.BreakQueue.create(config, context)
+        bq = model.BreakQueue.create(config, ctx)
 
         assert bq is None
 
@@ -98,11 +101,11 @@ class TestBreakQueue:
             system_config={},
         )
 
-        context: dict[str, typing.Any] = {
-            "session": {},
-        }
+        ctx = context.Context(
+            api=mock.Mock(spec=context.API), locale="en_US", version="0.0.0", session={}
+        )
 
-        bq = model.BreakQueue.create(config, context)
+        bq = model.BreakQueue.create(config, ctx)
 
         assert bq is not None
 
@@ -135,11 +138,11 @@ class TestBreakQueue:
             system_config={},
         )
 
-        context: dict[str, typing.Any] = {
-            "session": {},
-        }
+        ctx = context.Context(
+            api=mock.Mock(spec=context.API), locale="en_US", version="0.0.0", session={}
+        )
 
-        bq = model.BreakQueue.create(config, context)
+        bq = model.BreakQueue.create(config, ctx)
 
         assert bq is not None
 
@@ -177,11 +180,11 @@ class TestBreakQueue:
             system_config={},
         )
 
-        context: dict[str, typing.Any] = {
-            "session": {},
-        }
+        ctx = context.Context(
+            api=mock.Mock(spec=context.API), locale="en_US", version="0.0.0", session={}
+        )
 
-        bq = model.BreakQueue.create(config, context)
+        bq = model.BreakQueue.create(config, ctx)
 
         assert bq is not None
 


### PR DESCRIPTION
## Description

Before this, the `context` was just an untyped dict without any checks.
This PR adds a `Context` class that adds types to the contents that are required to exist, but also retains backwards compatibility. For example, `context.is_wayland` and `context["is_wayland"]` are both accepted, with the former now being statically checked.
Additionally, plugins can still add new keys to the context. This can either happen using a new `ext` property, which is yet again an unchecked dict, or using the dict access for backwards compatibility.
It also adds the types in a few places, and switches to the new access pattern - however, not everywhere yet.