### PR TITLE
trayicon: xdg activation

### DIFF
--- a/safeeyes/context.py
+++ b/safeeyes/context.py
@@ -43,8 +43,8 @@ class API:
     def show_settings(self, activation_token: typing.Optional[str] = None) -> None:
         utility.execute_main_thread(self._application.show_settings, activation_token)
 
-    def show_about(self) -> None:
-        utility.execute_main_thread(self._application.show_about)
+    def show_about(self, activation_token: typing.Optional[str] = None) -> None:
+        utility.execute_main_thread(self._application.show_about, activation_token)
 
     def enable_safeeyes(self, next_break_time=-1) -> None:
         utility.execute_main_thread(self._application.enable_safeeyes, next_break_time)

--- a/safeeyes/context.py
+++ b/safeeyes/context.py
@@ -40,8 +40,8 @@ class API:
         """This is soft-deprecated - it is preferred to access the property."""
         return getattr(self, key)
 
-    def show_settings(self) -> None:
-        utility.execute_main_thread(self._application.show_settings)
+    def show_settings(self, activation_token: typing.Optional[str] = None) -> None:
+        utility.execute_main_thread(self._application.show_settings, activation_token)
 
     def show_about(self) -> None:
         utility.execute_main_thread(self._application.show_about)

--- a/safeeyes/plugins/trayicon/plugin.py
+++ b/safeeyes/plugins/trayicon/plugin.py
@@ -678,12 +678,12 @@ class TrayIcon:
         """
         self.on_show_settings(self.sni_service.last_activation_token)
 
-    def show_about(self):
+    def show_about(self) -> None:
         """Handle About menu action.
 
         This action shows the About dialog.
         """
-        self.on_show_about()
+        self.on_show_about(self.sni_service.last_activation_token)
 
     def next_break_time(self, dateTime):
         """Update the next break time to be displayed in the menu and

--- a/safeeyes/plugins/trayicon/plugin.py
+++ b/safeeyes/plugins/trayicon/plugin.py
@@ -192,7 +192,7 @@ class DBusMenuService(DBusService):
     # TODO: replace dict here with more exact typing for item
     idToItems: dict[str, dict] = {}
 
-    def __init__(self, session_bus, context, items):
+    def __init__(self, session_bus, items):
         super().__init__(
             interface_info=MENU_NODE_INFO,
             object_path=self.DBUS_SERVICE_PATH,
@@ -374,7 +374,7 @@ class StatusNotifierItemService(DBusService):
     ItemIsMenu = True
     Menu = None
 
-    def __init__(self, session_bus, context, menu_items):
+    def __init__(self, session_bus, menu_items):
         super().__init__(
             interface_info=SNI_NODE_INFO,
             object_path=self.DBUS_SERVICE_PATH,
@@ -383,7 +383,7 @@ class StatusNotifierItemService(DBusService):
 
         self.bus = session_bus
 
-        self._menu = DBusMenuService(session_bus, context, menu_items)
+        self._menu = DBusMenuService(session_bus, menu_items)
         self.Menu = self._menu.DBUS_SERVICE_PATH
 
     def register(self):
@@ -453,7 +453,7 @@ class TrayIcon:
         session_bus = Gio.bus_get_sync(Gio.BusType.SESSION)
 
         self.sni_service = StatusNotifierItemService(
-            session_bus, context, menu_items=self.get_items()
+            session_bus, menu_items=self.get_items()
         )
         self.sni_service.register()
 

--- a/safeeyes/plugins/trayicon/plugin.py
+++ b/safeeyes/plugins/trayicon/plugin.py
@@ -24,6 +24,7 @@ gi.require_version("Gtk", "4.0")
 from gi.repository import Gio, GLib
 import logging
 from safeeyes import utility
+from safeeyes.context import Context
 from safeeyes.translations import translate as _
 import threading
 import typing
@@ -32,7 +33,6 @@ import typing
 Safe Eyes tray icon plugin
 """
 
-context = None
 tray_icon = None
 safeeyes_config = None
 
@@ -440,16 +440,16 @@ class TrayIcon:
     _animation_timeout_id: typing.Optional[int] = None
     _animation_icon_enabled: bool = False
 
-    def __init__(self, context, plugin_config):
+    def __init__(self, context: Context, plugin_config):
         self.context = context
-        self.on_show_settings = context["api"]["show_settings"]
-        self.on_show_about = context["api"]["show_about"]
-        self.quit = context["api"]["quit"]
-        self.enable_safeeyes = context["api"]["enable_safeeyes"]
-        self.disable_safeeyes = context["api"]["disable_safeeyes"]
-        self.take_break = context["api"]["take_break"]
-        self.has_breaks = context["api"]["has_breaks"]
-        self.get_break_time = context["api"]["get_break_time"]
+        self.on_show_settings = context.api.show_settings
+        self.on_show_about = context.api.show_about
+        self.quit = context.api.quit
+        self.enable_safeeyes = context.api.enable_safeeyes
+        self.disable_safeeyes = context.api.disable_safeeyes
+        self.take_break = context.api.take_break
+        self.has_breaks = context.api.has_breaks
+        self.get_break_time = context.api.get_break_time
         self.plugin_config = plugin_config
         self.date_time = None
         self.active = True
@@ -830,14 +830,12 @@ class TrayIcon:
 
 def init(ctx, safeeyes_cfg, plugin_config):
     """Initialize the tray icon."""
-    global context
     global tray_icon
     global safeeyes_config
     logging.debug("Initialize Tray Icon plugin")
-    context = ctx
     safeeyes_config = safeeyes_cfg
     if not tray_icon:
-        tray_icon = TrayIcon(context, plugin_config)
+        tray_icon = TrayIcon(ctx, plugin_config)
     else:
         tray_icon.initialize(plugin_config)
 

--- a/safeeyes/safeeyes.py
+++ b/safeeyes/safeeyes.py
@@ -358,12 +358,16 @@ class SafeEyes(Gtk.Application):
 
         self.restart(config, set_active=True)
 
-    def show_about(self):
+    def show_about(self, activation_token: typing.Optional[str] = None):
         """Listen to tray icon About action and send the signal to About
         dialog.
         """
         logging.info("Show About dialog")
         about_dialog = AboutDialog(self, SAFE_EYES_VERSION)
+
+        if activation_token is not None:
+            about_dialog.set_startup_id(activation_token)
+
         about_dialog.show()
 
     def quit(self):

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -266,7 +266,7 @@ class SettingsDialog(Gtk.ApplicationWindow):
 
     def show(self) -> None:
         """Show the SettingsDialog."""
-        super().show()
+        self.present()
 
     @Gtk.Template.Callback()
     def on_switch_postpone_activate(self, switch, state) -> None:


### PR DESCRIPTION
## Description

Fixes #649.

receive an xdg activation token from the trayicon and use it to activate
the settings window.
this is needed to bring the settings window to the front.
