### PR TITLE
ci: release: use updated toml action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           sudo apt-get install -y gettext
 
       - name: Get Current Version
-        uses: SebRollen/toml-action@v1.2.0
+        uses: deltragon/toml-action@9858d6baada20622d2f4dd175aff33d0c82f0515
         with:
           file: "pyproject.toml"
           field: project.version


### PR DESCRIPTION
## Description

This failed in #750, since https://github.com/SebRollen/toml-action does not yet support TOML v1.0.0.
Switch to a forked version with an updated library which supports 1.0.0.
