### PR TITLE
make xlib optional for wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,10 @@ Ensure to meet the following dependencies:
 - `ffmpeg` or `pipewire` (any of them works)
 - `python3` (>= 3.10.0)
 - `python3-gi`
-- `python3-xlib`
 - `python3-babel`
 - `python3-croniter`
 - `python3-packaging`
+- `python3-xlib` (required on x11)
 - **Optional**: Either `python3-pywayland` (provides smartpause in Wayland) or `xprintidle` (provides smartpause in x11).
 
 **To install Safe Eyes from PyPI:**

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,6 @@ Architecture: all
 Depends: ${misc:Depends}, ${python3:Depends}, 
  python3 (>= 3.10.0),
  python3-gi,
- python3-xlib,
  python3-babel,
  python3-croniter,
  python3-packaging,
@@ -20,6 +19,7 @@ Depends: ${misc:Depends}, ${python3:Depends},
  gir1.2-gtk-4.0,
  ffmpeg | pipewire
 Recommends:
+ python3-xlib,
  python3-pywayland
 Suggests:
  xprintidle

--- a/safeeyes/plugins/donotdisturb/plugin.py
+++ b/safeeyes/plugins/donotdisturb/plugin.py
@@ -26,7 +26,6 @@ import gi
 
 gi.require_version("Gio", "2.0")
 from gi.repository import Gio
-import Xlib
 from safeeyes import utility
 
 context = None
@@ -62,6 +61,8 @@ def is_active_window_skipped_xorg(pre_break):
     cause random failure.
     """
     logging.info("Searching for full-screen application")
+
+    import Xlib
 
     def get_window_property(window, prop, proptype):
         result = window.get_full_property(prop, proptype)

--- a/safeeyes/ui/break_screen.py
+++ b/safeeyes/ui/break_screen.py
@@ -27,9 +27,6 @@ from safeeyes import utility
 from safeeyes.context import Context
 from safeeyes.model import Break, Config, TrayAction
 from safeeyes.translations import translate as _
-import Xlib
-from Xlib.display import Display
-from Xlib import X
 
 gi.require_version("Gtk", "4.0")
 from gi.repository import Gdk
@@ -71,7 +68,9 @@ class BreakScreen:
         self.show_postpone_button = False
 
         if not self.context.is_wayland:
-            self.x11_display = Display()
+            import Xlib.display
+
+            self.x11_display = Xlib.display.Display()
 
     def initialize(self, config: Config) -> None:
         """Initialize the internal properties from configuration."""
@@ -231,6 +230,8 @@ class BreakScreen:
         if self.x11_display is None:
             return
 
+        import Xlib
+
         NET_WM_STATE = self.x11_display.intern_atom("_NET_WM_STATE")
         NET_WM_STATE_ABOVE = self.x11_display.intern_atom("_NET_WM_STATE_ABOVE")
         NET_WM_STATE_STICKY = self.x11_display.intern_atom("_NET_WM_STATE_STICKY")
@@ -276,6 +277,8 @@ class BreakScreen:
         """
         if self.x11_display is None:
             return
+
+        from Xlib import X
 
         logging.info("Lock the keyboard")
         self.lock_keyboard = True


### PR DESCRIPTION
## Description

See https://github.com/slgobinath/SafeEyes/pull/762#issuecomment-3223225992.

I moved it to "Recommends" instead of "Suggests" in `debian/control`. Unlike `xprintidle`, this isn't just needed for a plugin, but will break the break screen if it's missing on x11.