### PR TITLE
fix(smartpause): remove pywayland from required modules

### DIFF
--- a/safeeyes/plugins/smartpause/config.json
+++ b/safeeyes/plugins/smartpause/config.json
@@ -5,7 +5,7 @@
         "version": "0.0.3"
     },
     "dependencies": {
-        "python_modules": ["pywayland"],
+        "python_modules": [],
         "shell_commands": [],
         "operating_systems": [],
         "desktop_environments": [],


### PR DESCRIPTION
It is already checked by the dependency checker, no need to require it unconditionally in the config as well.

Apparently I didn't understand how the dependency checker works back when I added this.

Fixes #763.
