### PR TITLE
fix(smartpause): remove duplicated call on x11

### DIFF
--- a/safeeyes/plugins/smartpause/x11.py
+++ b/safeeyes/plugins/smartpause/x11.py
@@ -61,7 +61,6 @@ class IdleMonitorX11(IdleMonitorInterface):
         if not self._is_active():
             # If SmartPause is already started, do not start it again
             self._set_active(True)
-            utility.start_thread(self._start_idle_monitor)
             utility.start_thread(
                 self._start_idle_monitor,
                 on_idle=on_idle,

--- a/safeeyes/utility.py
+++ b/safeeyes/utility.py
@@ -95,18 +95,29 @@ def get_resource_path(resource_name):
     return resource_location
 
 
-def start_thread(target_function, **args):
+P1 = typing.ParamSpec("P1")
+
+
+def start_thread(
+    target_function: typing.Callable[P1, None], *args: P1.args, **kwargs: P1.kwargs
+) -> None:
     """Execute the function in a separate thread."""
     thread = threading.Thread(
         target=target_function,
         name=f"WorkThread {target_function.__qualname__}",
         daemon=False,
-        kwargs=args,
+        args=args,
+        kwargs=kwargs,
     )
     thread.start()
 
 
-def execute_main_thread(target_function, *args, **kwargs):
+P2 = typing.ParamSpec("P2")
+
+
+def execute_main_thread(
+    target_function: typing.Callable[P2, None], *args: P2.args, **kwargs: P2.kwargs
+) -> None:
     """Execute the given function in main thread."""
     GLib.idle_add(lambda: target_function(*args, **kwargs))
 


### PR DESCRIPTION
## Description

Fixes #771.

This was an obviously duplicated call that slipped in when refactoring. I've added type annotations to `start_thread`, that would have caught this issue, so it won't happen again.
