### PR TITLE
`pyproject.toml`: Use PEP 0621 license format for Debian

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "safeeyes"
 version = "3.0.1"
 description = "Protect your eyes from eye strain using this continuous breaks reminder."
-license = "GPL-3.0-or-later"
+license = {text = "GPL-3.0-or-later"}
 keywords = ["linux utility health eye-strain safe-eyes"]
 readme = "README.md"
 authors = [


### PR DESCRIPTION
In reaction to https://github.com/slgobinath/SafeEyes/pull/782#issuecomment-3285718215

CC @archisman-panigrahi 