### PR TITLE
Make CI always build the Debian package (in order to detect breakage prior to a release)

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -1,6 +1,8 @@
 name: Build Debian Package
 
 on:
+  pull_request:
+  push:
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
In reaction to https://github.com/slgobinath/SafeEyes/issues/787#issuecomment-3285784400 …

CC @archisman-panigrahi 