### PR TITLE
Use `0600` for `~/.config/safeeyes/safeeyes.json` instead of `0666`

### DIFF
--- a/safeeyes/utility.py
+++ b/safeeyes/utility.py
@@ -429,7 +429,7 @@ def initialize_safeeyes():
 
     # Copy the safeeyes.json
     shutil.copy2(SYSTEM_CONFIG_FILE_PATH, CONFIG_FILE_PATH)
-    os.chmod(CONFIG_FILE_PATH, 0o666)
+    os.chmod(CONFIG_FILE_PATH, 0o600)
 
     # initialize_safeeyes gets called when the configuration file is not present, which
     # happens just after installation or manual deletion of
@@ -588,7 +588,7 @@ def reset_config():
     shutil.copy2(SYSTEM_CONFIG_FILE_PATH, CONFIG_FILE_PATH)
 
     # Add write permission (e.g. if original file was stored in /nix/store)
-    os.chmod(CONFIG_FILE_PATH, 0o666)
+    os.chmod(CONFIG_FILE_PATH, 0o600)
 
     create_startup_entry()
 


### PR DESCRIPTION
Started out as 777 in 4939d1ff6c34f99c334e94bad7c941929e81dfca, was reduced to 666 in 1d3f8046429a7f345c1f83ae2d19845b66eada63 and is still more than I would expect. Am I missing something?