### PR TITLE
Use name "Safe Eyes" more consistently (part of #820)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ It is also available in Ubuntu PPA, Arch AUR and Python PyPI. You can choose any
 
 ### Ubuntu, Linux Mint and other Ubuntu Derivatives
 
-The [Official PPA for Safe Eyes](https://launchpad.net/~safeeyes-team/+archive/ubuntu/safeeyes) hosts the latest (as much as allowed by dependencies) version of safeeyes **for Ubuntu 22.04 and above**. 
+The [Official PPA for Safe Eyes](https://launchpad.net/~safeeyes-team/+archive/ubuntu/safeeyes) hosts the latest (as much as allowed by dependencies) version of Safe Eyes **for Ubuntu 22.04 and above**. 
 ```bash
 sudo add-apt-repository ppa:safeeyes-team/safeeyes
 sudo apt update

--- a/safeeyes/plugins/smartpause/ext_idle_notify.py
+++ b/safeeyes/plugins/smartpause/ext_idle_notify.py
@@ -128,7 +128,7 @@ class IdleMonitorExtIdleNotify(IdleMonitorInterface):
         # Note that this creates a new connection to the wayland compositor.
         # This is not an issue per se, but does mean that the compositor sees this as
         # a new, separate client, that just happens to run in the same process as
-        # the SafeEyes gtk application.
+        # the Safe Eyes gtk application.
         # (This is not a problem, currently. swayidle does the same, it even runs in a
         # separate process.)
         # If in the future, a compositor decides to lock down ext-idle-notify-v1 to

--- a/safeeyes/plugins/smartpause/plugin.py
+++ b/safeeyes/plugins/smartpause/plugin.py
@@ -287,7 +287,7 @@ def disable() -> None:
 
 
 def on_exit() -> None:
-    """SafeEyes is exiting."""
+    """Safe Eyes is exiting."""
     global idle_monitor
 
     if idle_monitor is not None:

--- a/safeeyes/safeeyes.py
+++ b/safeeyes/safeeyes.py
@@ -137,7 +137,7 @@ class SafeEyes(Gtk.Application):
         utility.cleanup_old_user_stylesheet()
 
         if options.contains("version"):
-            print(f"safeeyes {SAFE_EYES_VERSION}")
+            print(f"Safe Eyes {SAFE_EYES_VERSION}")
             return 0  # exit
 
         # needed for calling is_remote
@@ -347,7 +347,7 @@ class SafeEyes(Gtk.Application):
         dialog.show()
 
     def disable_plugin(self, plugin_id):
-        """Temporarily disable plugin, and restart SafeEyes."""
+        """Temporarily disable plugin, and restart Safe Eyes."""
         config = self.config.clone()
 
         for plugin in config.get("plugins"):

--- a/safeeyes/utility.py
+++ b/safeeyes/utility.py
@@ -480,7 +480,7 @@ def create_startup_entry(force=False):
     startup_entry = os.path.join(
         startup_dir_path, "io.github.slgobinath.SafeEyes.desktop"
     )
-    # until SafeEyes 2.1.5 the startup entry had another name
+    # until Safe Eyes 2.1.5 the startup entry had another name
     # https://github.com/slgobinath/safeeyes/commit/684d16265a48794bb3fd670da67283fe4e2f591b#diff-0863348c2143a4928518a4d3661f150ba86d042bf5320b462ea2e960c36ed275L398
     obsolete_entry = os.path.join(startup_dir_path, "safeeyes.desktop")
 
@@ -568,7 +568,8 @@ def initialize_platform():
                 # This icon is already added to the /usr/share/icons/hicolor folder.
                 # No need to create a link but we delete potentially stale symlinks
                 # from e.g. past runs from a virtualenv that has been removed in the
-                # meantime to avoid ending up with hard-to-debug SafeEyes without icons.
+                # meantime to avoid ending up with hard-to-debug Safe Eyes without
+                # icons.
                 if os.path.lexists(local_icon):
                     logging.debug(f"Delete duplicate icon link at {local_icon}")
                     delete(local_icon)


### PR DESCRIPTION
Part of #820

(This touches non-translation strings only for now.)

Please note that `--version` output is affected. I can revert that part if not wanted.