### PR TITLE
typing: fix incorrect typing for locale

### DIFF
--- a/safeeyes/__main__.py
+++ b/safeeyes/__main__.py
@@ -28,7 +28,7 @@ from safeeyes.model import Config
 from safeeyes.safeeyes import SafeEyes
 
 
-def main():
+def main() -> None:
     """Start the Safe Eyes."""
     signal.signal(signal.SIGINT, signal.SIG_DFL)  # Handle Ctrl + C
 

--- a/safeeyes/context.py
+++ b/safeeyes/context.py
@@ -18,6 +18,7 @@
 
 from collections.abc import MutableMapping
 import datetime
+import gettext
 import typing
 
 from safeeyes import utility
@@ -78,7 +79,7 @@ class Context(MutableMapping):
     api: API
     desktop: str
     is_wayland: bool
-    locale: str
+    locale: gettext.NullTranslations
     session: dict[str, typing.Any]
     state: State
 
@@ -92,7 +93,7 @@ class Context(MutableMapping):
     def __init__(
         self,
         api: API,
-        locale: str,
+        locale: gettext.NullTranslations,
         version: str,
         session: dict[str, typing.Any],
     ) -> None:

--- a/safeeyes/safeeyes.py
+++ b/safeeyes/safeeyes.py
@@ -21,6 +21,7 @@ application.
 """
 
 import atexit
+import gettext
 import logging
 from importlib import metadata
 import typing
@@ -51,11 +52,11 @@ class SafeEyes(Gtk.Application):
     break_screen: BreakScreen
     safe_eyes_core: SafeEyesCore
     plugins_manager: PluginManager
-    system_locale: str
+    system_locale: gettext.NullTranslations
 
     _settings_dialog: typing.Optional[SettingsDialog] = None
 
-    def __init__(self, system_locale: str, config) -> None:
+    def __init__(self, system_locale: gettext.NullTranslations, config) -> None:
         super().__init__(
             application_id="io.github.slgobinath.SafeEyes",
             flags=Gio.ApplicationFlags.HANDLES_COMMAND_LINE,

--- a/safeeyes/tests/test_core.py
+++ b/safeeyes/tests/test_core.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import datetime
+import gettext
 import pytest
 import typing
 
@@ -129,6 +130,14 @@ class TestSafeEyesCore:
             return handle
 
         yield create_handle
+
+    def get_context(self) -> context.Context:
+        return context.Context(
+            api=mock.Mock(spec=context.API),
+            locale=gettext.NullTranslations(),
+            version="0.0.0",
+            session={},
+        )
 
     def run_next_break(
         self,
@@ -252,9 +261,7 @@ class TestSafeEyesCore:
         ) == datetime.datetime.fromisoformat(string)
 
     def test_start_empty(self, sequential_threading: SequentialThreadingFixture):
-        ctx = context.Context(
-            api=mock.Mock(spec=context.API), locale="en_US", version="0.0.0", session={}
-        )
+        ctx = self.get_context()
         config = model.Config(
             user_config={
                 "short_breaks": [],
@@ -280,9 +287,7 @@ class TestSafeEyesCore:
         on_update_next_break.assert_not_called()
 
     def test_start(self, sequential_threading: SequentialThreadingFixture):
-        ctx = context.Context(
-            api=mock.Mock(spec=context.API), locale="en_US", version="0.0.0", session={}
-        )
+        ctx = self.get_context()
         config = model.Config(
             user_config={
                 "short_breaks": [
@@ -335,9 +340,7 @@ class TestSafeEyesCore:
         sequential_threading: SequentialThreadingFixture,
         time_machine: TimeMachineFixture,
     ):
-        ctx = context.Context(
-            api=mock.Mock(spec=context.API), locale="en_US", version="0.0.0", session={}
-        )
+        ctx = self.get_context()
         short_break_duration = 15  # seconds
         short_break_interval = 15  # minutes
         pre_break_warning_time = 10  # seconds
@@ -462,9 +465,7 @@ class TestSafeEyesCore:
         time_machine: TimeMachineFixture,
     ):
         """Example taken from https://github.com/slgobinath/safeeyes/issues/640."""
-        ctx = context.Context(
-            api=mock.Mock(spec=context.API), locale="en_US", version="0.0.0", session={}
-        )
+        ctx = self.get_context()
         short_break_duration = 300  # seconds = 5min
         short_break_interval = 25  # minutes
         pre_break_warning_time = 10  # seconds
@@ -578,9 +579,7 @@ class TestSafeEyesCore:
         time_machine: TimeMachineFixture,
     ):
         """Test idling for short amount of time."""
-        ctx = context.Context(
-            api=mock.Mock(spec=context.API), locale="en_US", version="0.0.0", session={}
-        )
+        ctx = self.get_context()
         short_break_duration = 15  # seconds
         short_break_interval = 15  # minutes
         pre_break_warning_time = 10  # seconds
@@ -721,9 +720,7 @@ class TestSafeEyesCore:
         time_machine: TimeMachineFixture,
     ):
         """Test idling for longer than long break time."""
-        ctx = context.Context(
-            api=mock.Mock(spec=context.API), locale="en_US", version="0.0.0", session={}
-        )
+        ctx = self.get_context()
         short_break_duration = 15  # seconds
         short_break_interval = 15  # minutes
         pre_break_warning_time = 10  # seconds
@@ -879,9 +876,7 @@ class TestSafeEyesCore:
 
         This used to skip all the short breaks too.
         """
-        ctx = context.Context(
-            api=mock.Mock(spec=context.API), locale="en_US", version="0.0.0", session={}
-        )
+        ctx = self.get_context()
         short_break_duration = 15  # seconds
         short_break_interval = 15  # minutes
         pre_break_warning_time = 10  # seconds

--- a/safeeyes/tests/test_model.py
+++ b/safeeyes/tests/test_model.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import gettext
 import pytest
 import random
 import typing
@@ -52,6 +53,14 @@ class TestBreak:
 
 
 class TestBreakQueue:
+    def get_context(self) -> context.Context:
+        return context.Context(
+            api=mock.Mock(spec=context.API),
+            locale=gettext.NullTranslations(),
+            version="0.0.0",
+            session={},
+        )
+
     def test_create_empty(self) -> None:
         config = model.Config(
             user_config={
@@ -66,11 +75,7 @@ class TestBreakQueue:
             system_config={},
         )
 
-        ctx = context.Context(
-            api=mock.Mock(spec=context.API), locale="en_US", version="0.0.0", session={}
-        )
-
-        bq = model.BreakQueue.create(config, ctx)
+        bq = model.BreakQueue.create(config, self.get_context())
 
         assert bq is None
 
@@ -101,11 +106,7 @@ class TestBreakQueue:
             system_config={},
         )
 
-        ctx = context.Context(
-            api=mock.Mock(spec=context.API), locale="en_US", version="0.0.0", session={}
-        )
-
-        bq = model.BreakQueue.create(config, ctx)
+        bq = model.BreakQueue.create(config, self.get_context())
 
         assert bq is not None
 
@@ -138,11 +139,7 @@ class TestBreakQueue:
             system_config={},
         )
 
-        ctx = context.Context(
-            api=mock.Mock(spec=context.API), locale="en_US", version="0.0.0", session={}
-        )
-
-        bq = model.BreakQueue.create(config, ctx)
+        bq = model.BreakQueue.create(config, self.get_context())
 
         assert bq is not None
 
@@ -180,11 +177,7 @@ class TestBreakQueue:
             system_config={},
         )
 
-        ctx = context.Context(
-            api=mock.Mock(spec=context.API), locale="en_US", version="0.0.0", session={}
-        )
-
-        bq = model.BreakQueue.create(config, ctx)
+        bq = model.BreakQueue.create(config, self.get_context())
 
         assert bq is not None
 

--- a/safeeyes/translations.py
+++ b/safeeyes/translations.py
@@ -26,7 +26,7 @@ from safeeyes import utility
 _translations = gettext.NullTranslations()
 
 
-def setup():
+def setup() -> gettext.NullTranslations:
     global _translations
     _translations = gettext.translation(
         "safeeyes",


### PR DESCRIPTION
## Description

This was incorrectly typed as `str` before, when it was actually a [gettext.GNUTranslations](https://docs.python.org/3/library/gettext.html#gettext.GNUTranslations) instance (with a `NullTranslations` base class).
This makes the tests just slightly more annoying, as now we have to mock that class too - but it was just luck that it worked before.
