### PR TITLE
fix editorconfig for glade files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,6 @@ indent_size = 4
 
 [*.{py}]
 trim_trailing_whitespace = true
+
+[*.{glade}]
+indent_size = 2


### PR DESCRIPTION
## Description

I missed this in #615, it seems.
This isn't enforced by anything - but the `.glade` files are using 2-space indentation, and with this my editor keeps it that way.