### PR TITLE
refactor: move Config to a separate module

### DIFF
--- a/safeeyes/configuration.py
+++ b/safeeyes/configuration.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+# Safe Eyes is a utility to remind you to take break frequently
+# to protect your eyes from eye strain.
+
+# Copyright (C) 2017  Gobinath
+# Copyright (C) 2026  Mel Dafert <m@dafert.at>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""This module contains the Config class and related logic around handling the
+configuration file.
+"""
+
+import copy
+from packaging.version import parse
+import typing
+
+from safeeyes import utility
+
+
+class Config:
+    """The configuration of Safe Eyes."""
+
+    __user_config: dict[str, typing.Any]
+    __system_config: dict[str, typing.Any]
+
+    @classmethod
+    def load(cls) -> "Config":
+        # Read the config files
+        user_config = utility.load_json(utility.CONFIG_FILE_PATH)
+        system_config = utility.load_json(utility.SYSTEM_CONFIG_FILE_PATH)
+        # If there any breaking changes in long_breaks, short_breaks or any other keys,
+        # use the force_upgrade_keys list
+        force_upgrade_keys: list[str] = []
+        # force_upgrade_keys = ['long_breaks', 'short_breaks']
+
+        # if create_startup_entry finds a broken autostart symlink, it will repair
+        # it
+        utility.create_startup_entry(force=False)
+        if user_config is None:
+            utility.initialize_safeeyes()
+            user_config = copy.deepcopy(system_config)
+            cfg = cls(user_config, system_config)
+            cfg.save()
+            return cfg
+        else:
+            system_config_version = system_config["meta"]["config_version"]
+            meta_obj = user_config.get("meta", None)
+            if meta_obj is None:
+                # Corrupted user config
+                user_config = copy.deepcopy(system_config)
+            else:
+                user_config_version = str(meta_obj.get("config_version", "0.0.0"))
+                if parse(user_config_version) != parse(system_config_version):
+                    # Update the user config
+                    new_user_config = copy.deepcopy(system_config)
+                    cls.__merge_dictionary(
+                        user_config, new_user_config, force_upgrade_keys
+                    )
+                    user_config = new_user_config
+
+        utility.merge_plugins(user_config)
+
+        cfg = cls(user_config, system_config)
+        cfg.save()
+        return cfg
+
+    def __init__(
+        self,
+        user_config: dict[str, typing.Any],
+        system_config: dict[str, typing.Any],
+    ):
+        self.__user_config = user_config
+        self.__system_config = system_config
+
+    @classmethod
+    def __merge_dictionary(cls, old_dict, new_dict, force_upgrade_keys: list[str]):
+        """Merge the dictionaries."""
+        for key in new_dict:
+            if key == "meta" or key in force_upgrade_keys:
+                continue
+            if key in old_dict:
+                new_value = new_dict[key]
+                old_value = old_dict[key]
+                if type(new_value) is type(old_value):
+                    # Both properties have same type
+                    if isinstance(new_value, dict):
+                        cls.__merge_dictionary(old_value, new_value, force_upgrade_keys)
+                    else:
+                        new_dict[key] = old_value
+
+    def clone(self) -> "Config":
+        config = Config(
+            user_config=copy.deepcopy(self.__user_config),
+            system_config=self.__system_config,
+        )
+        return config
+
+    def save(self) -> None:
+        """Save the configuration to file."""
+        utility.write_json(utility.CONFIG_FILE_PATH, self.__user_config)
+
+    def get(self, key, default_value=None):
+        """Get the value."""
+        value = self.__user_config.get(key, default_value)
+        if value is None:
+            value = self.__system_config.get(key, None)
+        return value
+
+    def set(self, key, value):
+        """Set the value."""
+        self.__user_config[key] = value
+
+    def __eq__(self, config):
+        return self.__user_config == config.__user_config
+
+    def __ne__(self, config):
+        return self.__user_config != config.__user_config

--- a/safeeyes/core.py
+++ b/safeeyes/core.py
@@ -22,12 +22,12 @@ import datetime
 import logging
 import typing
 
+from safeeyes.configuration import Config
 from safeeyes.model import Break
 from safeeyes.model import BreakType
 from safeeyes.model import BreakQueue
 from safeeyes.model import EventHook
 from safeeyes.model import State
-from safeeyes.model import Config
 
 from safeeyes.context import Context
 

--- a/safeeyes/plugin_manager.py
+++ b/safeeyes/plugin_manager.py
@@ -71,9 +71,9 @@ import sys
 import typing
 
 from safeeyes import utility
+from safeeyes.configuration import Config
 from safeeyes.context import Context
 from safeeyes.model import (
-    Config,
     Break,
     PluginDependency,
     RequiredPluginException,

--- a/safeeyes/tests/test_core.py
+++ b/safeeyes/tests/test_core.py
@@ -21,6 +21,7 @@ import gettext
 import pytest
 import typing
 
+from safeeyes import configuration
 from safeeyes import context
 from safeeyes import core
 from safeeyes import model
@@ -262,7 +263,7 @@ class TestSafeEyesCore:
 
     def test_start_empty(self, sequential_threading: SequentialThreadingFixture):
         ctx = self.get_context()
-        config = model.Config(
+        config = configuration.Config(
             user_config={
                 "short_breaks": [],
                 "long_breaks": [],
@@ -288,7 +289,7 @@ class TestSafeEyesCore:
 
     def test_start(self, sequential_threading: SequentialThreadingFixture):
         ctx = self.get_context()
-        config = model.Config(
+        config = configuration.Config(
             user_config={
                 "short_breaks": [
                     {"name": "break 1"},
@@ -346,7 +347,7 @@ class TestSafeEyesCore:
         pre_break_warning_time = 10  # seconds
         long_break_duration = 60  # seconds
         long_break_interval = 75  # minutes
-        config = model.Config(
+        config = configuration.Config(
             user_config={
                 "short_breaks": [
                     {"name": "break 1"},
@@ -471,7 +472,7 @@ class TestSafeEyesCore:
         pre_break_warning_time = 10  # seconds
         long_break_duration = 1800  # seconds = 30min
         long_break_interval = 100  # minutes
-        config = model.Config(
+        config = configuration.Config(
             user_config={
                 "short_breaks": [
                     {"name": "break 1"},
@@ -585,7 +586,7 @@ class TestSafeEyesCore:
         pre_break_warning_time = 10  # seconds
         long_break_duration = 60  # seconds
         long_break_interval = 75  # minutes
-        config = model.Config(
+        config = configuration.Config(
             user_config={
                 "short_breaks": [
                     {"name": "break 1"},
@@ -726,7 +727,7 @@ class TestSafeEyesCore:
         pre_break_warning_time = 10  # seconds
         long_break_duration = 60  # seconds
         long_break_interval = 75  # minutes
-        config = model.Config(
+        config = configuration.Config(
             user_config={
                 "short_breaks": [
                     {"name": "break 1"},
@@ -882,7 +883,7 @@ class TestSafeEyesCore:
         pre_break_warning_time = 10  # seconds
         long_break_duration = 60  # seconds
         long_break_interval = 75  # minutes
-        config = model.Config(
+        config = configuration.Config(
             user_config={
                 "short_breaks": [
                     {"name": "break 1"},

--- a/safeeyes/tests/test_model.py
+++ b/safeeyes/tests/test_model.py
@@ -21,7 +21,7 @@ import pytest
 import random
 import typing
 from unittest import mock
-from safeeyes import context, model
+from safeeyes import configuration, context, model
 
 
 class TestBreak:
@@ -62,7 +62,7 @@ class TestBreakQueue:
         )
 
     def test_create_empty(self) -> None:
-        config = model.Config(
+        config = configuration.Config(
             user_config={
                 "short_breaks": [],
                 "long_breaks": [],
@@ -89,7 +89,7 @@ class TestBreakQueue:
             model, "_", lambda message: "translated!: " + message, raising=False
         )
 
-        config = model.Config(
+        config = configuration.Config(
             user_config={
                 "short_breaks": [
                     {"name": "break 1"},
@@ -122,7 +122,7 @@ class TestBreakQueue:
             model, "_", lambda message: "translated!: " + message, raising=False
         )
 
-        config = model.Config(
+        config = configuration.Config(
             user_config={
                 "short_breaks": [],
                 "long_breaks": [
@@ -155,7 +155,7 @@ class TestBreakQueue:
             model, "_", lambda message: "translated!: " + message, raising=False
         )
 
-        config = model.Config(
+        config = configuration.Config(
             user_config={
                 "short_breaks": [
                     {"name": "break 1"},

--- a/safeeyes/ui/break_screen.py
+++ b/safeeyes/ui/break_screen.py
@@ -24,8 +24,9 @@ import typing
 
 import gi
 from safeeyes import utility
+from safeeyes.configuration import Config
 from safeeyes.context import Context
-from safeeyes.model import Break, Config, TrayAction
+from safeeyes.model import Break, TrayAction
 from safeeyes.translations import translate as _
 
 gi.require_version("Gtk", "4.0")

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -172,8 +172,7 @@ class SettingsDialog(Gtk.ApplicationWindow):
         def __confirmation_dialog_response(dialog, result) -> None:
             response_id = dialog.choose_finish(result)
             if response_id == 1:
-                Config.reset_config()
-                self.config = Config.load()
+                self.config = Config.reset_config()
                 # Remove breaks from the container
                 self.__clear_children(self.box_short_breaks)
                 self.__clear_children(self.box_long_breaks)

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -172,7 +172,7 @@ class SettingsDialog(Gtk.ApplicationWindow):
         def __confirmation_dialog_response(dialog, result) -> None:
             response_id = dialog.choose_finish(result)
             if response_id == 1:
-                utility.reset_config()
+                Config.reset_config()
                 self.config = Config.load()
                 # Remove breaks from the container
                 self.__clear_children(self.box_short_breaks)

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -22,7 +22,8 @@ import typing
 
 import gi
 from safeeyes import utility
-from safeeyes.model import Config, PluginDependency
+from safeeyes.configuration import Config
+from safeeyes.model import PluginDependency
 from safeeyes.translations import translate as _
 
 gi.require_version("Gtk", "4.0")


### PR DESCRIPTION
## Description

This PR should not have any behaviour changes at all, simply moving code around to keep related logic together (and move things out of the catch-all `utility` module).

Unfortunately, since there is already a directory named `config`, I had to call the module `configuration.py`.