### PR TITLE
autostart: add support for flatpak, add buttons to manually request/disable

### DIFF
--- a/safeeyes/config/locale/safeeyes.pot
+++ b/safeeyes/config/locale/safeeyes.pot
@@ -616,3 +616,18 @@ msgstr ""
 
 msgid "take a long break now"
 msgstr ""
+
+msgid "Safe Eyes wants to run in the background."
+msgstr ""
+
+msgid "Startup"
+msgstr ""
+
+msgid "Automatically start on login"
+msgstr ""
+
+msgid "Request autostart"
+msgstr ""
+
+msgid "Disable autostart"
+msgstr ""

--- a/safeeyes/configuration.py
+++ b/safeeyes/configuration.py
@@ -169,6 +169,16 @@ class Config:
         os.chmod(utility.CONFIG_FILE_PATH, 0o600)
 
     @classmethod
+    def request_autostart(cls) -> None:
+        """User requested autostart be enabled."""
+        cls._create_startup_entry(force=True)
+
+    @classmethod
+    def disable_autostart(cls) -> None:
+        """User requested autostart be disabled."""
+        cls._remove_startup_entry()
+
+    @classmethod
     def _create_startup_entry(cls, force: bool = False) -> None:
         """Create start up entry."""
         startup_dir_path = os.path.join(utility.HOME_DIRECTORY, ".config/autostart")
@@ -206,6 +216,19 @@ class Config:
                 os.symlink(utility.SYSTEM_DESKTOP_FILE, startup_entry)
             except OSError:
                 logging.error("Failed to create startup entry at %s" % startup_entry)
+
+        cls._cleanup_old_startup_entry()
+
+    @classmethod
+    def _remove_startup_entry(cls) -> None:
+        """Remove start up entry."""
+        startup_dir_path = os.path.join(utility.CONFIG_DIRECTORY, "autostart")
+        startup_entry = os.path.join(
+            startup_dir_path, "io.github.slgobinath.SafeEyes.desktop"
+        )
+
+        if os.path.exists(startup_entry):
+            utility.delete(startup_entry)
 
         cls._cleanup_old_startup_entry()
 

--- a/safeeyes/configuration.py
+++ b/safeeyes/configuration.py
@@ -175,9 +175,6 @@ class Config:
         startup_entry = os.path.join(
             startup_dir_path, "io.github.slgobinath.SafeEyes.desktop"
         )
-        # until Safe Eyes 2.1.5 the startup entry had another name
-        # https://github.com/slgobinath/safeeyes/commit/684d16265a48794bb3fd670da67283fe4e2f591b#diff-0863348c2143a4928518a4d3661f150ba86d042bf5320b462ea2e960c36ed275L398
-        obsolete_entry = os.path.join(startup_dir_path, "safeeyes.desktop")
 
         create_link = False
 
@@ -197,11 +194,6 @@ class Config:
                     # broken
                     create_link = True
 
-            if os.path.islink(obsolete_entry):
-                # if a link with the old naming exists, delete it and create a new one
-                create_link = True
-                utility.delete(obsolete_entry)
-
         if create_link:
             # Create the folder if not exist
             utility.mkdir(startup_dir_path)
@@ -214,3 +206,16 @@ class Config:
                 os.symlink(utility.SYSTEM_DESKTOP_FILE, startup_entry)
             except OSError:
                 logging.error("Failed to create startup entry at %s" % startup_entry)
+
+        cls._cleanup_old_startup_entry()
+
+    @classmethod
+    def _cleanup_old_startup_entry(cls) -> None:
+        startup_dir_path = os.path.join(utility.CONFIG_DIRECTORY, "autostart")
+
+        # until Safe Eyes 2.1.5 the startup entry had another name
+        # https://github.com/slgobinath/safeeyes/commit/684d16265a48794bb3fd670da67283fe4e2f591b#diff-0863348c2143a4928518a4d3661f150ba86d042bf5320b462ea2e960c36ed275L398
+        obsolete_entry = os.path.join(startup_dir_path, "safeeyes.desktop")
+
+        if os.path.exists(obsolete_entry):
+            utility.delete(obsolete_entry)

--- a/safeeyes/context.py
+++ b/safeeyes/context.py
@@ -79,6 +79,7 @@ class Context(MutableMapping):
     api: API
     desktop: str
     is_wayland: bool
+    is_flatpak: bool
     locale: gettext.NullTranslations
     session: dict[str, typing.Any]
     state: State
@@ -100,6 +101,7 @@ class Context(MutableMapping):
         self.version = version
         self.desktop = utility.desktop_environment()
         self.is_wayland = utility.is_wayland()
+        self.is_flatpak = utility.is_flatpak()
         self.locale = locale
         self.session = session
         self.state = State.START

--- a/safeeyes/glade/settings_dialog.glade
+++ b/safeeyes/glade/settings_dialog.glade
@@ -523,6 +523,55 @@
                             </child>
                           </object>
                         </child>
+                        <child>
+                          <object class="GtkFrame">
+                            <property name="visible">1</property>
+                            <child type="label">
+                              <object class="GtkLabel">
+                                <property name="visible">1</property>
+                                <property name="label" translatable="yes">Startup</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">1</property>
+                                <property name="margin-start">12</property>
+                                <property name="margin-end">10</property>
+                                <property name="margin-top">10</property>
+                                <property name="margin-bottom">10</property>
+                                <property name="orientation">vertical</property>
+                                <property name="spacing">15</property>
+                                <property name="homogeneous">1</property>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="visible">1</property>
+                                    <property name="spacing">5</property>
+                                    <property name="homogeneous">1</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">1</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">Automatically start on login</property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkButton">
+                                        <property name="label" translatable="1">Request autostart</property>
+                                        <signal name="clicked" handler="on_request_autostart_clicked" swapped="no"/>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkButton">
+                                        <property name="label" translatable="1">Disable autostart</property>
+                                        <signal name="clicked" handler="on_disable_autostart_clicked" swapped="no"/>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
                       </object>
                     </child>
                   </object>

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -321,6 +321,14 @@ class SettingsDialog(Gtk.ApplicationWindow):
         dialog.show()
 
     @Gtk.Template.Callback()
+    def on_request_autostart_clicked(self, button: Gtk.Button) -> None:
+        self.config.request_autostart()
+
+    @Gtk.Template.Callback()
+    def on_disable_autostart_clicked(self, button: Gtk.Button) -> None:
+        self.config.disable_autostart()
+
+    @Gtk.Template.Callback()
     def on_window_delete(self, *args) -> None:
         """Event handler for Settings dialog close action."""
         self.config.set(

--- a/safeeyes/utility.py
+++ b/safeeyes/utility.py
@@ -45,6 +45,7 @@ gi.require_version("Gdk", "4.0")
 from gi.repository import Gdk
 from gi.repository import Gtk
 from gi.repository import GLib
+from gi.repository import Gio
 from gi.repository import GdkPixbuf
 from packaging.version import parse
 
@@ -353,6 +354,14 @@ def is_wayland():
     else:
         IS_WAYLAND = bool(re.search(b"wayland", output, re.IGNORECASE))
     return IS_WAYLAND
+
+
+def is_flatpak() -> bool:
+    """Determine if application is running inside flatpak.
+
+    This method is taken from GNOME's geary application.
+    """
+    return Gio.File.new_for_path("/.flatpak-info").query_exists()
 
 
 def execute_command(command, args=[]):


### PR DESCRIPTION
## Description

~Based on #837 and #836, only the last five commits are new.~

This PR adds support for flatpak for autostarting Safe Eyes on boot.
It also adds buttons to the settings to request/disable autostart, both for flatpak and non-flatpak.
Note that the behaviour between flatpak and non-flatpak isn't entirely the same - since it isn't possible to detect whether there is an autostart file in flatpak, we only request it on the first startup (and whenever the user manually triggers it from the settings), and can't check if it's broken or repair it.
