### PR TITLE
donotdisturb: allow ignoring specific inhibitors

### DIFF
--- a/safeeyes/config/safeeyes.json
+++ b/safeeyes/config/safeeyes.json
@@ -53,7 +53,8 @@
                 "skip_break_windows": "",
                 "take_break_windows": "",
                 "unfullscreen": true,
-                "while_on_battery": false
+                "while_on_battery": false,
+                "ignored_inhibitor_apps": ""
             }
         },
         {

--- a/safeeyes/glade/item_text_with_picker.glade
+++ b/safeeyes/glade/item_text_with_picker.glade
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Safe Eyes is a utility to remind you to take break frequently
+~ to protect your eyes from eye strain.
+
+~ Copyright (C) 2017  Gobinath
+
+~ This program is free software: you can redistribute it and/or modify
+~ it under the terms of the GNU General Public License as published by
+~ the Free Software Foundation, either version 3 of the License, or
+~ (at your option) any later version.
+
+~ This program is distributed in the hope that it will be useful,
+~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+~ GNU General Public License for more details.
+
+~ You should have received a copy of the GNU General Public License
+~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<interface domain="safeeyes">
+  <requires lib="gtk" version="4.0"/>
+  <template parent="GtkBox" class="TextWithPickerItem">
+    <property name="visible">1</property>
+    <property name="margin-start">5</property>
+    <property name="margin-end">5</property>
+    <property name="margin-top">5</property>
+    <property name="margin-bottom">5</property>
+    <property name="spacing">10</property>
+    <child>
+      <object class="GtkLabel" id="lbl_name">
+        <property name="visible">1</property>
+        <property name="valign">center</property>
+        <property name="halign">start</property>
+        <property name="label">label</property>
+        <property name="xalign">0</property>
+        <property name="hexpand">1</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkEntry" id="txt_value">
+        <property name="visible">1</property>
+        <property name="can-focus">1</property>
+        <property name="valign">center</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkButton" id="btn_pick">
+        <property name="visible">1</property>
+        <property name="label" translatable="yes">Select…</property>
+        <property name="valign">center</property>
+        <signal name="clicked" handler="on_btn_pick_clicked"/>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/safeeyes/plugins/donotdisturb/config.json
+++ b/safeeyes/plugins/donotdisturb/config.json
@@ -34,6 +34,13 @@
             "label": "Do not disturb while on battery",
             "type": "BOOL",
             "default": false
+        },
+        {
+            "id": "ignored_inhibitor_apps",
+            "label": "Ignored inhibitor applications (GNOME only)",
+            "info": "Applications whose idle inhibitors should be ignored. Use Select to pick from active inhibitors.",
+            "type": "TEXT_WITH_PICKER",
+            "default": ""
         }
     ],
     "break_override_allowed": true

--- a/safeeyes/plugins/donotdisturb/plugin.py
+++ b/safeeyes/plugins/donotdisturb/plugin.py
@@ -21,6 +21,7 @@
 import os
 import logging
 import subprocess
+import typing
 
 import gi
 
@@ -33,6 +34,8 @@ skip_break_window_classes: list[str] = []
 take_break_window_classes: list[str] = []
 unfullscreen_allowed = True
 dnd_while_on_battery = False
+ignored_inhibitor_apps: set[str] = set()
+_kde_warning_logged = False
 
 
 def is_active_window_skipped_wayland(pre_break):
@@ -154,11 +157,74 @@ def is_active_window_skipped_xorg(pre_break):
     return False
 
 
+def get_active_inhibitors() -> typing.Optional[list[tuple[str, str, int]]]:
+    """Query GNOME SessionManager for active inhibitors.
+
+    Returns list of (app_id, reason, flags) tuples.
+    Returns None on error (callers should handle this as a failure, not empty).
+    """
+    try:
+        session_proxy = Gio.DBusProxy.new_for_bus_sync(
+            bus_type=Gio.BusType.SESSION,
+            flags=Gio.DBusProxyFlags.NONE,
+            info=None,
+            name="org.gnome.SessionManager",
+            object_path="/org/gnome/SessionManager",
+            interface_name="org.gnome.SessionManager",
+            cancellable=None,
+        )
+        inhibitors_variant = session_proxy.call_sync(
+            "GetInhibitors",
+            None,
+            Gio.DBusCallFlags.NONE,
+            -1,
+            None,
+        )
+        inhibitor_paths = inhibitors_variant.unpack()[0]
+
+        result = []
+        for inhibitor_path in inhibitor_paths:
+            try:
+                inhibitor_proxy = Gio.DBusProxy.new_for_bus_sync(
+                    bus_type=Gio.BusType.SESSION,
+                    flags=Gio.DBusProxyFlags.NONE,
+                    info=None,
+                    name="org.gnome.SessionManager",
+                    object_path=inhibitor_path,
+                    interface_name="org.gnome.SessionManager.Inhibitor",
+                    cancellable=None,
+                )
+                app_id = inhibitor_proxy.call_sync(
+                    "GetAppId", None, Gio.DBusCallFlags.NONE, -1, None
+                ).unpack()[0]
+                reason = inhibitor_proxy.call_sync(
+                    "GetReason", None, Gio.DBusCallFlags.NONE, -1, None
+                ).unpack()[0]
+                flags = inhibitor_proxy.call_sync(
+                    "GetFlags", None, Gio.DBusCallFlags.NONE, -1, None
+                ).unpack()[0]
+                result.append((app_id, reason, flags))
+            except Exception:
+                logging.warning(
+                    "Failed to query inhibitor at %s, skipping",
+                    inhibitor_path,
+                )
+                continue
+        return result
+    except Exception:
+        logging.warning("Failed to enumerate inhibitors")
+        return None
+
+
 def is_idle_inhibited_gnome():
     """GNOME Shell doesn't work with wlrctl, and there is no way to enumerate
     fullscreen windows, but GNOME does expose whether idle actions like
     starting a screensaver are inhibited, which is a close approximation if not
     a better metric.
+
+    When ignored_inhibitor_apps is configured, enumerates individual inhibitors
+    and filters out ignored ones, so breaks can proceed when only ignored apps
+    (e.g. Caffeine) are inhibiting idle.
     """
     dbus_proxy = Gio.DBusProxy.new_for_bus_sync(
         bus_type=Gio.BusType.SESSION,
@@ -174,7 +240,43 @@ def is_idle_inhibited_gnome():
     # The result is a bitfield, documented here:
     # https://gitlab.gnome.org/GNOME/gnome-session/-/blob/9aa419397b7f6d42bee6e66cc5c5aad12902fba0/gnome-session/org.gnome.SessionManager.xml#L155
     # The fourth bit indicates that idle is inhibited.
-    return bool(result & 0b1000)
+    is_inhibited = bool(result & 0b1000)
+
+    if not is_inhibited:
+        return False
+
+    # Fast path: no exceptions configured, preserve current behavior
+    if not ignored_inhibitor_apps:
+        return True
+
+    # Slow path: enumerate inhibitors, filter out ignored ones
+    inhibitors = get_active_inhibitors()
+    if inhibitors is None:
+        logging.warning(
+            "Failed to enumerate inhibitors, falling back to bitfield result"
+        )
+        return True
+
+    for app_id, reason, flags in inhibitors:
+        logging.debug("Found inhibitor: %s (flags: %d)", app_id.lower(), flags)
+
+        # Only care about idle inhibitors (fourth bit)
+        if not (flags & 0b1000):
+            continue
+
+        if app_id.lower() in ignored_inhibitor_apps:
+            logging.debug(
+                "Ignoring idle inhibitor: %s (in ignored list)", app_id.lower()
+            )
+            continue
+
+        # Found a non-ignored idle inhibitor
+        logging.debug("Non-ignored idle inhibitor found: %s", app_id.lower())
+        return True
+
+    # All idle inhibitors were in the ignored list (or enumeration failed)
+    logging.debug("All idle inhibitors are in ignored list, proceeding with break")
+    return False
 
 
 def is_idle_inhibited_kde() -> bool:
@@ -183,7 +285,18 @@ def is_idle_inhibited_kde() -> bool:
     org.freedesktop.Notifications, which does communicate the Do Not Disturb status
     on KDE.
     This is also only an approximation, but comes pretty close.
+
+    Note: ignored_inhibitor_apps is not supported on KDE as there is no
+    per-inhibitor enumeration API available.
     """
+    global _kde_warning_logged
+
+    if ignored_inhibitor_apps and not _kde_warning_logged:
+        logging.warning(
+            "ignored_inhibitor_apps is not supported on KDE, ignoring setting"
+        )
+        _kde_warning_logged = True
+
     dbus_proxy = Gio.DBusProxy.new_for_bus_sync(
         bus_type=Gio.BusType.SESSION,
         flags=Gio.DBusProxyFlags.NONE,
@@ -240,7 +353,10 @@ def init(ctx, safeeyes_config, plugin_config):
     global take_break_window_classes
     global unfullscreen_allowed
     global dnd_while_on_battery
+    global ignored_inhibitor_apps
+    global _kde_warning_logged
     logging.debug("Initialize Skip Fullscreen plugin")
+    _kde_warning_logged = False
     context = ctx
     skip_break_window_classes = _normalize_window_classes(
         plugin_config["skip_break_windows"]
@@ -250,10 +366,18 @@ def init(ctx, safeeyes_config, plugin_config):
     )
     unfullscreen_allowed = plugin_config["unfullscreen"]
     dnd_while_on_battery = plugin_config["while_on_battery"]
+    ignored_inhibitor_apps = set(
+        _parse_space_separated_list(plugin_config.get("ignored_inhibitor_apps", ""))
+    )
 
 
-def _normalize_window_classes(classes_as_str: str):
-    return [w.lower() for w in classes_as_str.split()]
+def _parse_space_separated_list(value: str) -> list[str]:
+    """Parse a space-separated string into a lowercased list."""
+    return [w.lower() for w in value.split()]
+
+
+def _normalize_window_classes(classes_as_str: str) -> list[str]:
+    return _parse_space_separated_list(classes_as_str)
 
 
 def __should_skip_break(pre_break: bool) -> bool:

--- a/safeeyes/tests/conftest.py
+++ b/safeeyes/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Conftest for Safe Eyes tests.
+
+Mocks gi and related modules so that tests can import plugins
+without requiring PyGObject/GTK libraries to be installed.
+"""
+
+import sys
+from unittest import mock
+
+# Mock gi and its submodules before any plugin imports
+_gi_mock = mock.MagicMock()
+_gio_mock = mock.MagicMock()
+_glib_mock = mock.MagicMock()
+
+_gi_mock.repository.Gio = _gio_mock
+_gi_mock.repository.GLib = _glib_mock
+
+sys.modules.setdefault("gi", _gi_mock)
+sys.modules.setdefault("gi.repository", _gi_mock.repository)
+sys.modules.setdefault("gi.repository.Gio", _gio_mock)
+sys.modules.setdefault("gi.repository.GLib", _glib_mock)

--- a/safeeyes/tests/test_donotdisturb.py
+++ b/safeeyes/tests/test_donotdisturb.py
@@ -1,0 +1,266 @@
+# Safe Eyes is a utility to remind you to take break frequently
+# to protect your eyes from eye strain.
+
+# Copyright (C) 2026  Safe Eyes Contributors
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import mock
+
+
+from safeeyes.plugins.donotdisturb import plugin
+
+_PATCH_DBUS = "safeeyes.plugins.donotdisturb.plugin.Gio.DBusProxy"
+_PATCH_LOGGING = "safeeyes.plugins.donotdisturb.plugin.logging"
+
+
+class TestParseSpaceSeparatedList:
+    def test_empty_string(self):
+        assert plugin._parse_space_separated_list("") == []
+
+    def test_single_item(self):
+        assert plugin._parse_space_separated_list("caffeine") == ["caffeine"]
+
+    def test_multiple_items(self):
+        result = plugin._parse_space_separated_list("caffeine Totem Firefox")
+        assert result == ["caffeine", "totem", "firefox"]
+
+    def test_extra_whitespace(self):
+        result = plugin._parse_space_separated_list("  caffeine   totem  ")
+        assert result == ["caffeine", "totem"]
+
+
+def _make_dbus_proxy_mock(inhibited_actions: int):
+    """Create a mock Gio.DBusProxy that returns the given InhibitedActions value."""
+    proxy = mock.MagicMock()
+    prop = mock.MagicMock()
+    prop.unpack.return_value = inhibited_actions
+    proxy.get_cached_property.return_value = prop
+    return proxy
+
+
+def _make_inhibitor_proxy_mock(app_id: str, flags: int, reason: str = ""):
+    """Create a mock for an individual inhibitor's DBus proxy.
+
+    DBus call_sync returns GLib.Variant tuples, so unpack() returns a tuple.
+    """
+    proxy = mock.MagicMock()
+
+    def call_sync_side_effect(method, *args, **kwargs):
+        variant = mock.MagicMock()
+        if method == "GetAppId":
+            variant.unpack.return_value = (app_id,)
+        elif method == "GetReason":
+            variant.unpack.return_value = (reason,)
+        elif method == "GetFlags":
+            variant.unpack.return_value = (flags,)
+        return variant
+
+    proxy.call_sync.side_effect = call_sync_side_effect
+    return proxy
+
+
+def _make_session_proxy_mock(inhibited_actions: int, inhibitor_paths: list):
+    """Create a session proxy mock for get_active_inhibitors.
+
+    Since get_active_inhibitors() creates its own session proxy, we need a
+    second session proxy mock that responds to GetInhibitors.
+    """
+    proxy = mock.MagicMock()
+    inhibitors_variant = mock.MagicMock()
+    inhibitors_variant.unpack.return_value = (inhibitor_paths,)
+    proxy.call_sync.return_value = inhibitors_variant
+    return proxy
+
+
+class TestInit:
+    def test_init_populates_ignored_inhibitor_apps(self):
+        """init() should populate ignored_inhibitor_apps from config."""
+        plugin_config = {
+            "skip_break_windows": "",
+            "take_break_windows": "",
+            "unfullscreen": True,
+            "while_on_battery": False,
+            "ignored_inhibitor_apps": "caffeine-gnome-extension Zoom",
+        }
+        plugin.init(mock.MagicMock(), {}, plugin_config)
+        assert plugin.ignored_inhibitor_apps == {"caffeine-gnome-extension", "zoom"}
+
+    def test_init_missing_key_defaults_to_empty(self):
+        """init() should default to empty set when key is missing."""
+        plugin_config = {
+            "skip_break_windows": "",
+            "take_break_windows": "",
+            "unfullscreen": True,
+            "while_on_battery": False,
+        }
+        plugin.init(mock.MagicMock(), {}, plugin_config)
+        assert plugin.ignored_inhibitor_apps == set()
+
+
+class TestIsIdleInhibitedGnome:
+    """Tests for is_idle_inhibited_gnome with ignored_inhibitor_apps."""
+
+    def test_not_inhibited_returns_false(self):
+        """When InhibitedActions has no idle bit, return False regardless."""
+        with mock.patch(_PATCH_DBUS) as mock_proxy_cls:
+            mock_proxy_cls.new_for_bus_sync.return_value = _make_dbus_proxy_mock(0)
+            plugin.ignored_inhibitor_apps = set()
+            assert plugin.is_idle_inhibited_gnome() is False
+
+    def test_inhibited_no_exceptions_returns_true(self):
+        """When idle is inhibited and no exceptions configured, return True.
+
+        GetInhibitors should NOT be called (fast path).
+        """
+        session_proxy = _make_dbus_proxy_mock(0b1000)
+        with mock.patch(_PATCH_DBUS) as mock_proxy_cls:
+            mock_proxy_cls.new_for_bus_sync.return_value = session_proxy
+            plugin.ignored_inhibitor_apps = set()
+            assert plugin.is_idle_inhibited_gnome() is True
+            session_proxy.call_sync.assert_not_called()
+
+    def test_inhibited_all_ignored_returns_false(self):
+        """When idle is inhibited but all inhibitors are ignored, return False."""
+        session_proxy = _make_dbus_proxy_mock(0b1000)
+        inhibitor_paths = ["/org/gnome/SessionManager/Inhibitor1"]
+        session_proxy2 = _make_session_proxy_mock(0b1000, inhibitor_paths)
+
+        inhibitor_proxy = _make_inhibitor_proxy_mock("caffeine-gnome-extension", 0b1000)
+
+        with mock.patch(_PATCH_DBUS) as mock_proxy_cls:
+            mock_proxy_cls.new_for_bus_sync.side_effect = [
+                session_proxy,
+                session_proxy2,
+                inhibitor_proxy,
+            ]
+            plugin.ignored_inhibitor_apps = {"caffeine-gnome-extension"}
+            assert plugin.is_idle_inhibited_gnome() is False
+
+    def test_inhibited_some_not_ignored_returns_true(self):
+        """When idle is inhibited and a non-ignored inhibitor exists, return True."""
+        session_proxy = _make_dbus_proxy_mock(0b1000)
+        inhibitor_paths = [
+            "/org/gnome/SessionManager/Inhibitor1",
+            "/org/gnome/SessionManager/Inhibitor2",
+        ]
+        session_proxy2 = _make_session_proxy_mock(0b1000, inhibitor_paths)
+
+        caffeine_proxy = _make_inhibitor_proxy_mock("caffeine-gnome-extension", 0b1000)
+        totem_proxy = _make_inhibitor_proxy_mock("org.gnome.Totem", 0b1000)
+
+        with mock.patch(_PATCH_DBUS) as mock_proxy_cls:
+            mock_proxy_cls.new_for_bus_sync.side_effect = [
+                session_proxy,
+                session_proxy2,
+                caffeine_proxy,
+                totem_proxy,
+            ]
+            plugin.ignored_inhibitor_apps = {"caffeine-gnome-extension"}
+            assert plugin.is_idle_inhibited_gnome() is True
+
+    def test_inhibited_non_idle_inhibitor_not_ignored_returns_false(self):
+        """When a non-ignored inhibitor exists but lacks idle flag, return False."""
+        session_proxy = _make_dbus_proxy_mock(0b1000)
+        inhibitor_paths = [
+            "/org/gnome/SessionManager/Inhibitor1",
+            "/org/gnome/SessionManager/Inhibitor2",
+        ]
+        session_proxy2 = _make_session_proxy_mock(0b1000, inhibitor_paths)
+
+        caffeine_proxy = _make_inhibitor_proxy_mock("caffeine-gnome-extension", 0b1000)
+        # This inhibitor has flag 0b0100 (suspend inhibit, NOT idle)
+        other_proxy = _make_inhibitor_proxy_mock("org.gnome.PowerManager", 0b0100)
+
+        with mock.patch(_PATCH_DBUS) as mock_proxy_cls:
+            mock_proxy_cls.new_for_bus_sync.side_effect = [
+                session_proxy,
+                session_proxy2,
+                caffeine_proxy,
+                other_proxy,
+            ]
+            plugin.ignored_inhibitor_apps = {"caffeine-gnome-extension"}
+            assert plugin.is_idle_inhibited_gnome() is False
+
+    def test_dbus_error_during_enumeration_falls_back_to_true(self):
+        """When GetInhibitors fails, fall back to bitfield result (True)."""
+        session_proxy = _make_dbus_proxy_mock(0b1000)
+        # get_active_inhibitors creates its own session_proxy2 that fails on
+        # GetInhibitors
+        session_proxy2 = mock.MagicMock()
+        session_proxy2.call_sync.side_effect = Exception("DBus error")
+
+        with mock.patch(_PATCH_DBUS) as mock_proxy_cls:
+            mock_proxy_cls.new_for_bus_sync.side_effect = [
+                session_proxy,
+                session_proxy2,
+            ]
+            plugin.ignored_inhibitor_apps = {"caffeine-gnome-extension"}
+            assert plugin.is_idle_inhibited_gnome() is True
+
+    def test_case_insensitive_matching(self):
+        """App IDs should be compared case-insensitively."""
+        session_proxy = _make_dbus_proxy_mock(0b1000)
+        inhibitor_paths = ["/org/gnome/SessionManager/Inhibitor1"]
+        session_proxy2 = _make_session_proxy_mock(0b1000, inhibitor_paths)
+
+        inhibitor_proxy = _make_inhibitor_proxy_mock("Caffeine-GNOME-Extension", 0b1000)
+
+        with mock.patch(_PATCH_DBUS) as mock_proxy_cls:
+            mock_proxy_cls.new_for_bus_sync.side_effect = [
+                session_proxy,
+                session_proxy2,
+                inhibitor_proxy,
+            ]
+            plugin.ignored_inhibitor_apps = {"caffeine-gnome-extension"}
+            assert plugin.is_idle_inhibited_gnome() is False
+
+
+class TestIsIdleInhibitedKde:
+    """Tests for KDE warning when ignored_inhibitor_apps is set."""
+
+    def test_kde_logs_warning_when_exceptions_configured(self):
+        """KDE should log a warning when ignored_inhibitor_apps is non-empty."""
+        kde_proxy = mock.MagicMock()
+        prop = mock.MagicMock()
+        prop.unpack.return_value = True
+        kde_proxy.get_cached_property.return_value = prop
+
+        with mock.patch(_PATCH_DBUS) as mock_proxy_cls:
+            mock_proxy_cls.new_for_bus_sync.return_value = kde_proxy
+            plugin.ignored_inhibitor_apps = {"caffeine"}
+            plugin._kde_warning_logged = False
+
+            with mock.patch(_PATCH_LOGGING) as mock_logging:
+                result = plugin.is_idle_inhibited_kde()
+                assert result is True
+                mock_logging.warning.assert_called_once()
+                assert "not supported on KDE" in mock_logging.warning.call_args[0][0]
+
+    def test_kde_warning_logged_only_once(self):
+        """KDE warning should only be logged once across multiple calls."""
+        kde_proxy = mock.MagicMock()
+        prop = mock.MagicMock()
+        prop.unpack.return_value = True
+        kde_proxy.get_cached_property.return_value = prop
+
+        with mock.patch(_PATCH_DBUS) as mock_proxy_cls:
+            mock_proxy_cls.new_for_bus_sync.return_value = kde_proxy
+            plugin.ignored_inhibitor_apps = {"caffeine"}
+            plugin._kde_warning_logged = False
+
+            with mock.patch(_PATCH_LOGGING) as mock_logging:
+                plugin.is_idle_inhibited_kde()
+                plugin.is_idle_inhibited_kde()
+                assert mock_logging.warning.call_count == 1

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -51,6 +51,9 @@ SETTINGS_PLUGIN_ITEM_GLADE = os.path.join(
 SETTINGS_ITEM_INT_GLADE = os.path.join(utility.BIN_DIRECTORY, "glade/item_int.glade")
 SETTINGS_ITEM_TEXT_GLADE = os.path.join(utility.BIN_DIRECTORY, "glade/item_text.glade")
 SETTINGS_ITEM_BOOL_GLADE = os.path.join(utility.BIN_DIRECTORY, "glade/item_bool.glade")
+SETTINGS_ITEM_TEXT_WITH_PICKER_GLADE = os.path.join(
+    utility.BIN_DIRECTORY, "glade/item_text_with_picker.glade"
+)
 
 
 @Gtk.Template(filename=SETTINGS_DIALOG_GLADE)
@@ -511,6 +514,158 @@ class BoolItem(Gtk.Box):
         return self.switch_value.get_active()
 
 
+class InhibitorPickerDialog(Gtk.Window):
+    """Dialog showing active idle inhibitors with checkboxes."""
+
+    def __init__(
+        self,
+        parent: Gtk.Window,
+        current_value: str,
+        on_result: typing.Callable[[str], None],
+    ):
+        super().__init__(
+            transient_for=parent,
+            title=_("Select Inhibitors to Ignore"),
+            default_width=450,
+            default_height=350,
+            modal=True,
+        )
+        self._on_result = on_result
+        self._original_apps = current_value.split() if current_value.strip() else []
+        current_apps = {a.lower() for a in self._original_apps}
+
+        # Main layout
+        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        vbox.set_margin_top(16)
+        vbox.set_margin_bottom(16)
+        vbox.set_margin_start(16)
+        vbox.set_margin_end(16)
+        self.set_child(vbox)
+
+        # Description
+        desc = Gtk.Label(
+            label=_(
+                "These applications are currently inhibiting idle. "
+                "Check the ones Safe Eyes should ignore."
+            ),
+            wrap=True,
+            xalign=0,
+        )
+        desc.add_css_class("dim-label")
+        vbox.append(desc)
+
+        # Scrolled list
+        scrolled = Gtk.ScrolledWindow(vexpand=True)
+        self.listbox = Gtk.ListBox(selection_mode=Gtk.SelectionMode.NONE)
+        self.listbox.add_css_class("boxed-list")
+        scrolled.set_child(self.listbox)
+        vbox.append(scrolled)
+
+        # Populate from DBus
+        self.checks: list[tuple[Gtk.CheckButton, str]] = []
+        try:
+            from safeeyes.plugins.donotdisturb.plugin import get_active_inhibitors
+
+            inhibitors = get_active_inhibitors()
+        except Exception:
+            inhibitors = None
+
+        # Filter to only idle inhibitors (fourth bit of flags)
+        if inhibitors:
+            inhibitors = [(a, r, f) for a, r, f in inhibitors if f & 0b1000]
+
+        if inhibitors:
+            for app_id, reason, flags in inhibitors:
+                row = Gtk.ListBoxRow()
+                hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+                hbox.set_margin_top(8)
+                hbox.set_margin_bottom(8)
+                hbox.set_margin_start(10)
+                hbox.set_margin_end(10)
+
+                check = Gtk.CheckButton()
+                check.set_active(app_id.lower() in current_apps)
+                hbox.append(check)
+
+                labels_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
+                name_label = Gtk.Label(label=app_id, xalign=0)
+                name_label.add_css_class("heading")
+                labels_box.append(name_label)
+
+                if reason:
+                    reason_label = Gtk.Label(label=reason, xalign=0)
+                    reason_label.add_css_class("dim-label")
+                    labels_box.append(reason_label)
+
+                hbox.append(labels_box)
+                row.set_child(hbox)
+                self.listbox.append(row)
+                self.checks.append((check, app_id))
+        else:
+            empty_label = Gtk.Label(
+                label=_(
+                    "No active inhibitors found. "
+                    "You can still type app IDs manually in the text field."
+                ),
+                wrap=True,
+                xalign=0,
+            )
+            empty_label.add_css_class("dim-label")
+            empty_label.set_margin_top(20)
+            empty_label.set_margin_bottom(20)
+            vbox.append(empty_label)
+
+        # Buttons
+        button_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        button_box.set_halign(Gtk.Align.END)
+
+        cancel_btn = Gtk.Button(label=_("Cancel"))
+        cancel_btn.connect("clicked", lambda *_: self.destroy())
+        button_box.append(cancel_btn)
+
+        apply_btn = Gtk.Button(label=_("Apply"))
+        apply_btn.add_css_class("suggested-action")
+        apply_btn.connect("clicked", self._on_apply)
+        button_box.append(apply_btn)
+
+        vbox.append(button_box)
+
+    def _on_apply(self, *args) -> None:
+        selected = [app_id for check, app_id in self.checks if check.get_active()]
+        # Preserve manually-entered IDs not in the active list
+        active_ids = {app_id.lower() for _, app_id in self.checks}
+        manual = [a for a in self._original_apps if a.lower() not in active_ids]
+        self._on_result(" ".join(manual + selected))
+        self.destroy()
+
+
+@Gtk.Template(filename=SETTINGS_ITEM_TEXT_WITH_PICKER_GLADE)
+class TextWithPickerItem(Gtk.Box):
+    __gtype_name__ = "TextWithPickerItem"
+
+    lbl_name: Gtk.Label = Gtk.Template.Child()
+    txt_value: Gtk.Entry = Gtk.Template.Child()
+    btn_pick: Gtk.Button = Gtk.Template.Child()
+
+    def __init__(self, name: str, value: str):
+        super().__init__()
+        self.lbl_name.set_label(_(name))
+        self.txt_value.set_text(value)
+
+    def get_value(self) -> str:
+        return self.txt_value.get_text()
+
+    @Gtk.Template.Callback()
+    def on_btn_pick_clicked(self, *args) -> None:
+        parent = self.get_root()
+        dialog = InhibitorPickerDialog(
+            parent,
+            self.txt_value.get_text(),
+            on_result=self.txt_value.set_text,
+        )
+        dialog.present()
+
+
 @Gtk.Template(filename=SETTINGS_DIALOG_PLUGIN_GLADE)
 class PluginSettingsDialog(Gtk.Window):
     """Builds a settings dialog based on the configuration of a plugin."""
@@ -526,7 +681,7 @@ class PluginSettingsDialog(Gtk.Window):
         self.property_controls = []
 
         for setting in config.get("settings"):
-            box: typing.Union[IntItem, BoolItem, TextItem]
+            box: typing.Union[IntItem, BoolItem, TextItem, TextWithPickerItem]
             if setting["type"].upper() == "INT":
                 box = IntItem(
                     setting["label"],
@@ -540,6 +695,10 @@ class PluginSettingsDialog(Gtk.Window):
                 )
             elif setting["type"].upper() == "BOOL":
                 box = BoolItem(
+                    setting["label"], config["active_plugin_config"][setting["id"]]
+                )
+            elif setting["type"].upper() == "TEXT_WITH_PICKER":
+                box = TextWithPickerItem(
                     setting["label"], config["active_plugin_config"][setting["id"]]
                 )
             else:


### PR DESCRIPTION
I was listening to a Spotify podcast in the background and noticed Safe Eyes never reminded me to take a break. Turns out Spotify inhibits idle when playing audio, and the donotdisturb plugin treats that the same as watching a fullscreen movie . Same thing happens with the Caffeine GNOME extension if you leave it on.

I *do* want do-not-disturb when I'm actually watching a movie or giving a presentation. I just don't want a background podcast or an always-on Caffeine toggle to suppress my break reminders.

This adds an `ignored_inhibitor_apps` setting to the donotdisturb plugin. You list the app IDs of inhibitors you want to ignore, and Safe Eyes will still take breaks even when those apps are inhibiting idle. If a non-ignored app (like a video player) is also inhibiting, breaks are still skipped as before.

When the setting is empty (the default), behavior is identical to the current code with no extra DBus calls or extra overhead.

On GNOME, it works by calling `GetInhibitors()` on `org.gnome.SessionManager` to enumerate individual inhibitors and filter out the ignored ones. On KDE the per-inhibitor API isn't available, so it logs a warning and falls back to the current behavior.

Since the app IDs aren't exactly user-friendly (things like `caffeine-gnome-extension` or `/app/extra/bin/spotify`), I added a picker dialog. There's a "Select…" button next to the text field that show active inhibitors with checkboxes. You just check the ones you want to ignore and hit Apply. The text field is still editable if you prefer typing.

Ran `ruff check`, `ruff format`, and `pytest` locally. Couldn't run `mypy` locally due to missing cairo system deps but didn't change any typed interfaces.

Flatpak built and tested locally, works as intended.

First time contributing, so feel free to give feedback if I've missed something.