### PR TITLE
Add option for the break to fade in

### DIFF
--- a/safeeyes/config/locale/safeeyes.pot
+++ b/safeeyes/config/locale/safeeyes.pot
@@ -570,3 +570,6 @@ msgstr ""
 
 msgid "Skipping/postponing disabled period (in seconds)"
 msgstr ""
+
+msgid "Fade in when breaks start"
+msgstr ""

--- a/safeeyes/config/locale/safeeyes.pot
+++ b/safeeyes/config/locale/safeeyes.pot
@@ -573,3 +573,6 @@ msgstr ""
 
 msgid "Fade in when breaks start"
 msgstr ""
+
+msgid "Fade in duration (in milliseconds)"
+msgstr ""

--- a/safeeyes/config/safeeyes.json
+++ b/safeeyes/config/safeeyes.json
@@ -16,6 +16,7 @@
     "shortcut_skip": 9,
     "shortcut_postpone": 65,
     "fade_in_break_screen": true,
+    "fade_in_break_screen_duration": 3000,
     "strict_break": false,
     "short_breaks": [{
             "name": "Gently close your eyes"

--- a/safeeyes/config/safeeyes.json
+++ b/safeeyes/config/safeeyes.json
@@ -15,6 +15,7 @@
     "shortcut_disable_time": 2,
     "shortcut_skip": 9,
     "shortcut_postpone": 65,
+    "fade_in_break_screen": true,
     "strict_break": false,
     "short_breaks": [{
             "name": "Gently close your eyes"

--- a/safeeyes/glade/settings_dialog.glade
+++ b/safeeyes/glade/settings_dialog.glade
@@ -351,6 +351,28 @@
                                   </object>
                                 </child>
                                 <child>
+                                  <object class="GtkBox" id="box17_fade_in_break_screen">
+                                    <property name="visible">1</property>
+                                    <property name="spacing">5</property>
+                                    <property name="homogeneous">1</property>
+                                    <child>
+                                      <object class="GtkLabel" id="lbl_fade_in_break_screen">
+                                        <property name="visible">1</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">Fade in when breaks start</property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSwitch" id="switch_fade_in_break_screen">
+                                        <property name="visible">1</property>
+                                        <property name="can-focus">1</property>
+                                        <property name="halign">end</property>
+                                        <property name="valign">center</property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child>
                                   <object class="GtkBox" id="box16_random_order">
                                     <property name="visible">1</property>
                                     <property name="spacing">5</property>

--- a/safeeyes/glade/settings_dialog.glade
+++ b/safeeyes/glade/settings_dialog.glade
@@ -26,6 +26,12 @@
     <property name="step-increment">1</property>
     <property name="page-increment">5</property>
   </object>
+  <object class="GtkAdjustment" id="adjust_fade_in_break_screen_duration">
+    <property name="lower">1</property>
+    <property name="upper">8000</property>
+    <property name="step-increment">100</property>
+    <property name="page-increment">500</property>
+  </object>
   <object class="GtkAdjustment" id="adjust_long_break_duration">
     <property name="lower">1</property>
     <property name="upper">3600</property>
@@ -368,6 +374,34 @@
                                         <property name="can-focus">1</property>
                                         <property name="halign">end</property>
                                         <property name="valign">center</property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkBox" id="box18_fade_in_break_screen_duration">
+                                    <property name="visible">1</property>
+                                    <property name="spacing">5</property>
+                                    <property name="homogeneous">1</property>
+                                    <child>
+                                      <object class="GtkLabel" id="lbl_fade_in_break_screen_duration">
+                                        <property name="visible">1</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">Fade in duration (in milliseconds)</property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="spin_fade_in_break_screen_duration">
+                                        <property name="visible">1</property>
+                                        <property name="can-focus">1</property>
+                                        <property name="halign">end</property>
+                                        <property name="valign">center</property>
+                                        <property name="text">3000</property>
+                                        <property name="adjustment">adjust_fade_in_break_screen_duration</property>
+                                        <property name="climb-rate">1</property>
+                                        <property name="numeric">1</property>
+                                        <property name="update-policy">if-valid</property>
+                                        <property name="value">3000</property>
                                       </object>
                                     </child>
                                   </object>

--- a/safeeyes/ui/break_screen.py
+++ b/safeeyes/ui/break_screen.py
@@ -65,6 +65,7 @@ class BreakScreen:
         self.on_postponed = on_postponed
         self.on_skipped = on_skipped
         self.fade_in_break_screen = True
+        self.fade_in_break_screen_duration = 3000
         self.shortcut_disable_time = 2
         self.strict_break = False
         self.windows = []
@@ -98,6 +99,9 @@ class BreakScreen:
         # the buttons are locked
         self.shortcut_disable_time = config.get("shortcut_disable_time", 2)
         self.fade_in_break_screen = config.get("fade_in_break_screen", True)
+        self.fade_in_break_screen_duration = config.get(
+            "fade_in_break_screen_duration", 3000
+        )
         self.strict_break = config.get("strict_break", False)
 
     def skip_break(self) -> None:
@@ -197,6 +201,7 @@ class BreakScreen:
                 self.show_skip_button,
                 self.on_skip_clicked,
                 self.enable_shortcut,
+                self.fade_in_break_screen_duration,
             )
 
             if self.context.is_wayland:
@@ -376,7 +381,6 @@ class BreakScreenWindow(Gtk.Window):
     box_buttons: Gtk.Box = Gtk.Template.Child()
     toolbar: Gtk.Box = Gtk.Template.Child()
 
-    FADE_IN_DURATION_MS = 3000
     FADE_IN_STEP_MS = 16
 
     def __init__(
@@ -394,6 +398,7 @@ class BreakScreenWindow(Gtk.Window):
         show_skip: bool,
         on_skip: typing.Callable[[Gtk.Button], None],
         enable_shortcut: bool,
+        fade_in_duration_ms: int,
     ):
         super().__init__(application=application)
 
@@ -403,6 +408,7 @@ class BreakScreenWindow(Gtk.Window):
         self.fade_in_target_opacity = 1.0
         self.fade_in_start_time: typing.Optional[float] = None
         self.fade_in_timeout_id: typing.Optional[int] = None
+        self.fade_in_duration_ms = max(fade_in_duration_ms, 1)
 
         for tray_action in tray_actions:
             # TODO: apparently, this would be better served with an icon theme
@@ -470,7 +476,7 @@ class BreakScreenWindow(Gtk.Window):
             return False
 
         elapsed_ms = (time.monotonic() - self.fade_in_start_time) * 1000
-        progress = min(elapsed_ms / self.FADE_IN_DURATION_MS, 1.0)
+        progress = min(elapsed_ms / self.fade_in_duration_ms, 1.0)
         self.set_opacity(self.fade_in_target_opacity * progress)
 
         if progress >= 1.0:

--- a/safeeyes/ui/break_screen.py
+++ b/safeeyes/ui/break_screen.py
@@ -32,8 +32,9 @@ from safeeyes.translations import translate as _
 gi.require_version("Gtk", "4.0")
 from gi.repository import Gdk
 from gi.repository import GdkPixbuf
-from gi.repository import Gtk
 from gi.repository import GdkX11
+from gi.repository import GLib
+from gi.repository import Gtk
 
 BREAK_SCREEN_GLADE = os.path.join(utility.BIN_DIRECTORY, "glade/break_screen.glade")
 
@@ -63,6 +64,7 @@ class BreakScreen:
         self.keycode_shortcut_skip = 9  # Escape
         self.on_postponed = on_postponed
         self.on_skipped = on_skipped
+        self.fade_in_break_screen = False
         self.shortcut_disable_time = 2
         self.strict_break = False
         self.windows = []
@@ -95,6 +97,7 @@ class BreakScreen:
         # it used to be just about keyboard shortcuts - now it also controls whether
         # the buttons are locked
         self.shortcut_disable_time = config.get("shortcut_disable_time", 2)
+        self.fade_in_break_screen = config.get("fade_in_break_screen", True)
         self.strict_break = config.get("strict_break", False)
 
     def skip_break(self) -> None:
@@ -208,9 +211,8 @@ class BreakScreen:
 
             self.windows.append(window)
 
-            if self.context.desktop == "kde":
-                # Fix flickering screen in KDE by setting opacity to 1
-                window.set_opacity(0.9)
+            target_opacity = 0.9 if self.context.desktop == "kde" else 1.0
+            window.configure_opacity(target_opacity, self.fade_in_break_screen)
 
             window.present()
 
@@ -233,6 +235,9 @@ class BreakScreen:
                 surface = window.get_surface()
                 if surface is not None:
                     typing.cast(Gdk.Toplevel, surface).inhibit_system_shortcuts(None)
+
+            if self.fade_in_break_screen:
+                window.start_fade_in()
 
             i = i + 1
 
@@ -350,6 +355,7 @@ class BreakScreen:
     def __destroy_all_screens(self) -> None:
         """Close all the break screens."""
         for win in self.windows:
+            win.stop_fade_in()
             win.destroy()
         del self.windows[:]
 
@@ -370,7 +376,8 @@ class BreakScreenWindow(Gtk.Window):
     box_buttons: Gtk.Box = Gtk.Template.Child()
     toolbar: Gtk.Box = Gtk.Template.Child()
 
-    button_widgets: list[Gtk.Button] = []
+    FADE_IN_DURATION_MS = 3000
+    FADE_IN_STEP_MS = 16
 
     def __init__(
         self,
@@ -392,6 +399,10 @@ class BreakScreenWindow(Gtk.Window):
 
         self.on_close = on_close
         self.img_break.set_content_fit(Gtk.ContentFit.SCALE_DOWN)
+        self.button_widgets: list[Gtk.Button] = []
+        self.fade_in_target_opacity = 1.0
+        self.fade_in_start_time: typing.Optional[float] = None
+        self.fade_in_timeout_id: typing.Optional[int] = None
 
         for tray_action in tray_actions:
             # TODO: apparently, this would be better served with an icon theme
@@ -435,6 +446,38 @@ class BreakScreenWindow(Gtk.Window):
             self.__set_break_image(image_path, monitor_width, monitor_height)
         self.lbl_message.set_label(message)
         self.lbl_widget.set_markup(widget)
+
+    def configure_opacity(self, target_opacity: float, fade_in_enabled: bool) -> None:
+        self.fade_in_target_opacity = target_opacity
+        self.set_opacity(0.0 if fade_in_enabled else target_opacity)
+
+    def start_fade_in(self) -> None:
+        self.stop_fade_in()
+        self.fade_in_start_time = time.monotonic()
+        self.fade_in_timeout_id = GLib.timeout_add(
+            self.FADE_IN_STEP_MS, self.__fade_in_step
+        )
+
+    def stop_fade_in(self) -> None:
+        if self.fade_in_timeout_id is not None:
+            GLib.source_remove(self.fade_in_timeout_id)
+            self.fade_in_timeout_id = None
+
+    def __fade_in_step(self) -> bool:
+        if self.fade_in_start_time is None:
+            self.set_opacity(self.fade_in_target_opacity)
+            self.fade_in_timeout_id = None
+            return False
+
+        elapsed_ms = (time.monotonic() - self.fade_in_start_time) * 1000
+        progress = min(elapsed_ms / self.FADE_IN_DURATION_MS, 1.0)
+        self.set_opacity(self.fade_in_target_opacity * progress)
+
+        if progress >= 1.0:
+            self.fade_in_timeout_id = None
+            return False
+
+        return True
 
     def set_count_down(self, count: str, enable_shortcut: bool) -> None:
         self.lbl_count.set_text(count)
@@ -486,4 +529,5 @@ class BreakScreenWindow(Gtk.Window):
     def on_window_delete(self, *args) -> None:
         """Window close event handler."""
         logging.info("Closing the break screen")
+        self.stop_fade_in()
         self.on_close()

--- a/safeeyes/ui/break_screen.py
+++ b/safeeyes/ui/break_screen.py
@@ -64,7 +64,7 @@ class BreakScreen:
         self.keycode_shortcut_skip = 9  # Escape
         self.on_postponed = on_postponed
         self.on_skipped = on_skipped
-        self.fade_in_break_screen = False
+        self.fade_in_break_screen = True
         self.shortcut_disable_time = 2
         self.strict_break = False
         self.windows = []

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -361,8 +361,7 @@ class SettingsDialog(Gtk.ApplicationWindow):
         self.config.set("random_order", self.switch_random_order.get_active())
         self.config.set("allow_postpone", self.switch_postpone.get_active())
         self.config.set(
-            "fade_in_break_screen",
-            self.switch_fade_in_break_screen.get_active(),
+            "fade_in_break_screen", self.switch_fade_in_break_screen.get_active()
         )
         self.config.set("persist_state", self.switch_persist.get_active())
         for plugin in self.config.get("plugins"):

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -76,6 +76,7 @@ class SettingsDialog(Gtk.ApplicationWindow):
     switch_strict_break: Gtk.Switch = Gtk.Template.Child()
     switch_random_order: Gtk.Switch = Gtk.Template.Child()
     switch_postpone: Gtk.Switch = Gtk.Template.Child()
+    switch_fade_in_break_screen: Gtk.Switch = Gtk.Template.Child()
     switch_persist: Gtk.Switch = Gtk.Template.Child()
     info_bar_long_break: Gtk.InfoBar = Gtk.Template.Child()
 
@@ -134,6 +135,9 @@ class SettingsDialog(Gtk.ApplicationWindow):
         self.switch_strict_break.set_active(config.get("strict_break"))
         self.switch_random_order.set_active(config.get("random_order"))
         self.switch_postpone.set_active(config.get("allow_postpone"))
+        self.switch_fade_in_break_screen.set_active(
+            config.get("fade_in_break_screen", True)
+        )
         self.switch_persist.set_active(config.get("persist_state"))
         self.infobar_long_break_shown = False
 
@@ -356,6 +360,10 @@ class SettingsDialog(Gtk.ApplicationWindow):
         self.config.set("strict_break", self.switch_strict_break.get_active())
         self.config.set("random_order", self.switch_random_order.get_active())
         self.config.set("allow_postpone", self.switch_postpone.get_active())
+        self.config.set(
+            "fade_in_break_screen",
+            self.switch_fade_in_break_screen.get_active(),
+        )
         self.config.set("persist_state", self.switch_persist.get_active())
         for plugin in self.config.get("plugins"):
             if plugin["id"] in self.plugin_items:

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -71,6 +71,7 @@ class SettingsDialog(Gtk.ApplicationWindow):
     spin_long_break_interval: Gtk.SpinButton = Gtk.Template.Child()
     spin_time_to_prepare: Gtk.SpinButton = Gtk.Template.Child()
     spin_postpone_duration: Gtk.SpinButton = Gtk.Template.Child()
+    spin_fade_in_break_screen_duration: Gtk.SpinButton = Gtk.Template.Child()
     dropdown_postpone_unit: Gtk.DropDown = Gtk.Template.Child()
     spin_disable_keyboard_shortcut: Gtk.SpinButton = Gtk.Template.Child()
     switch_strict_break: Gtk.Switch = Gtk.Template.Child()
@@ -124,6 +125,9 @@ class SettingsDialog(Gtk.ApplicationWindow):
         self.spin_long_break_interval.set_value(config.get("long_break_interval"))
         self.spin_time_to_prepare.set_value(config.get("pre_break_warning_time"))
         self.spin_postpone_duration.set_value(config.get("postpone_duration"))
+        self.spin_fade_in_break_screen_duration.set_value(
+            config.get("fade_in_break_screen_duration", 3000)
+        )
         # Set the active item in the dropdown based on the postpone unit
         if config.get("postpone_unit") == "seconds":
             self.dropdown_postpone_unit.set_selected(1)
@@ -344,6 +348,10 @@ class SettingsDialog(Gtk.ApplicationWindow):
         )
         self.config.set(
             "postpone_duration", self.spin_postpone_duration.get_value_as_int()
+        )
+        self.config.set(
+            "fade_in_break_screen_duration",
+            self.spin_fade_in_break_screen_duration.get_value_as_int(),
         )
         self.config.set(
             "postpone_unit",


### PR DESCRIPTION
This will Fix #398.

Now there is an option for the break to fade in gradually (it takes 3 seconds).

Tested in XFCE, Cinnamon and KDE.
---
Here is a video demonstration

https://github.com/user-attachments/assets/d8a9c6da-d2b9-4ab9-905f-726c860b6b59


