### PR TITLE
Show manual and digital clock on break screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ This method has the same caveats about icons/window icons as running from source
 - Customizable user interface
 - Command-line arguments to control the running instance
 - Customizable using plug-ins
+- Displays clock in the break screen
 
 ## Third-party Plugins
 

--- a/safeeyes/config/locale/safeeyes.pot
+++ b/safeeyes/config/locale/safeeyes.pot
@@ -131,6 +131,10 @@ msgid "Allow postponing breaks"
 msgstr ""
 
 # Settings dialog
+msgid "Show clock on the break screen"
+msgstr ""
+
+# Settings dialog
 msgid "Persist the internal state"
 msgstr ""
 

--- a/safeeyes/config/safeeyes.json
+++ b/safeeyes/config/safeeyes.json
@@ -12,6 +12,7 @@
     "persist_state": false,
     "postpone_duration": 5,
     "postpone_unit": "minutes",
+    "show_clock": true,
     "shortcut_disable_time": 2,
     "shortcut_skip": 9,
     "shortcut_postpone": 65,

--- a/safeeyes/config/style/safeeyes_style.css
+++ b/safeeyes/config/style/safeeyes_style.css
@@ -83,6 +83,12 @@
     color: white;
 }
 
+.lbl_clock_time {
+    font-size: 20pt;
+    color: white;
+    font-weight: bold;
+}
+
 .lbl_widget {
     font-size: 9pt;
     color: white;

--- a/safeeyes/glade/break_screen.glade
+++ b/safeeyes/glade/break_screen.glade
@@ -30,60 +30,89 @@
         <property name="row_homogeneous">0</property>
         <property name="column_homogeneous">1</property>
         <child>
-          <object class="GtkBox" id="box_center_parent">
-            <property name="orientation">vertical</property>
-            <property name="spacing">10</property>
+          <object class="GtkOverlay" id="overlay_center">
             <child>
-              <object class="GtkGrid" id="grid_central">
-                <property name="halign">center</property>
-                <property name="valign">center</property>
-                <property name="row_spacing">10</property>
+              <object class="GtkBox" id="box_center_parent">
+                <property name="orientation">vertical</property>
+                <property name="spacing">10</property>
                 <child>
-                  <object class="GtkPicture" id="img_break">
-                    <layout>
-                      <property name="column">0</property>
-                      <property name="row">0</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkGrid" id="grid_parent">
+                  <object class="GtkGrid" id="grid_central">
                     <property name="halign">center</property>
                     <property name="valign">center</property>
-                    <property name="hexpand">1</property>
-                    <property name="row_spacing">15</property>
+                    <property name="row_spacing">10</property>
                     <child>
-                      <object class="GtkLabel" id="lbl_message">
-                        <property name="label">Hello World</property>
-                        <property name="justify">center</property>
-                        <style>
-                          <class name="lbl_message"/>
-                        </style>
+                      <object class="GtkPicture" id="img_break">
                         <layout>
                           <property name="column">0</property>
                           <property name="row">0</property>
-                          <property name="column-span">3</property>
                         </layout>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkLabel" id="lbl_count">
+                      <object class="GtkGrid" id="grid_parent">
                         <property name="halign">center</property>
-                        <property name="label">00</property>
-                        <style>
-                          <class name="lbl_count"/>
-                        </style>
-                        <layout>
-                          <property name="column">1</property>
-                          <property name="row">2</property>
-                        </layout>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkBox" id="box_buttons">
-                        <property name="halign">center</property>
-                        <property name="spacing">50</property>
-                        <property name="homogeneous">1</property>
+                        <property name="valign">center</property>
+                        <property name="hexpand">1</property>
+                        <property name="row_spacing">15</property>
+                        <child>
+                          <object class="GtkLabel" id="lbl_message">
+                            <property name="label">Hello World</property>
+                            <property name="justify">center</property>
+                            <style>
+                              <class name="lbl_message"/>
+                            </style>
+                            <layout>
+                              <property name="column">0</property>
+                              <property name="row">0</property>
+                              <property name="column-span">3</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="lbl_count">
+                            <property name="halign">center</property>
+                            <property name="label">00</property>
+                            <style>
+                              <class name="lbl_count"/>
+                            </style>
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">2</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="box_buttons">
+                            <property name="halign">center</property>
+                            <property name="spacing">50</property>
+                            <property name="homogeneous">1</property>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <layout>
+                              <property name="column">1</property>
+                              <property name="row">3</property>
+                            </layout>
+                          </object>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
                         <child>
                           <placeholder/>
                         </child>
@@ -91,54 +120,30 @@
                           <placeholder/>
                         </child>
                         <layout>
-                          <property name="column">1</property>
-                          <property name="row">3</property>
+                          <property name="column">0</property>
+                          <property name="row">1</property>
+                          <property name="row-span">3</property>
                         </layout>
                       </object>
                     </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <layout>
-                      <property name="column">0</property>
-                      <property name="row">1</property>
-                      <property name="row-span">3</property>
-                    </layout>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="lbl_widget">
+                    <property name="vexpand">1</property>
+                    <property name="label">Widget</property>
+                    <property name="yalign">0.25</property>
+                    <style>
+                      <class name="lbl_widget"/>
+                    </style>
                   </object>
                 </child>
               </object>
             </child>
-            <child>
-              <object class="GtkLabel" id="lbl_widget">
-                <property name="vexpand">1</property>
-                <property name="label">Widget</property>
-                <property name="yalign">1</property>
-                <style>
-                  <class name="lbl_widget"/>
-                </style>
-              </object>
-            </child>
-            <child>
+            <child type="overlay">
               <object class="GtkBox" id="box_clock">
                 <property name="halign">center</property>
+                <property name="valign">end</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">12</property>
                 <property name="margin-bottom">24</property>

--- a/safeeyes/glade/break_screen.glade
+++ b/safeeyes/glade/break_screen.glade
@@ -130,10 +130,33 @@
               <object class="GtkLabel" id="lbl_widget">
                 <property name="vexpand">1</property>
                 <property name="label">Widget</property>
-                <property name="yalign">0.25</property>
+                <property name="yalign">1</property>
                 <style>
                   <class name="lbl_widget"/>
                 </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkBox" id="box_clock">
+                <property name="halign">center</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">12</property>
+                <property name="margin-bottom">24</property>
+                <child>
+                  <object class="GtkDrawingArea" id="clock_face">
+                    <property name="content-height">180</property>
+                    <property name="content-width">180</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="lbl_clock_time">
+                    <property name="halign">center</property>
+                    <property name="label">00:00</property>
+                    <style>
+                      <class name="lbl_clock_time"/>
+                    </style>
+                  </object>
+                </child>
               </object>
             </child>
             <layout>

--- a/safeeyes/glade/settings_dialog.glade
+++ b/safeeyes/glade/settings_dialog.glade
@@ -492,6 +492,28 @@
                                   </object>
                                 </child>
                                 <child>
+                                  <object class="GtkBox" id="box_show_clock">
+                                    <property name="visible">1</property>
+                                    <property name="spacing">5</property>
+                                    <property name="homogeneous">1</property>
+                                    <child>
+                                      <object class="GtkLabel" id="lbl_show_clock">
+                                        <property name="visible">1</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">Show clock on the break screen</property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSwitch" id="switch_show_clock">
+                                        <property name="visible">1</property>
+                                        <property name="can-focus">1</property>
+                                        <property name="halign">end</property>
+                                        <property name="valign">center</property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child>
                                   <object class="GtkBox" id="box1">
                                     <property name="visible">1</property>
                                     <property name="spacing">5</property>

--- a/safeeyes/ui/break_screen.py
+++ b/safeeyes/ui/break_screen.py
@@ -406,7 +406,7 @@ class BreakScreenWindow(Gtk.Window):
         self._clock_display_time: typing.Optional[str] = None
         self.clock_face.set_draw_func(self.__draw_clock_face)
         self.box_clock.set_visible(show_clock)
-        self.lbl_widget.set_yalign(1 if show_clock else 0.25)
+        has_widget = widget.strip() != ""
 
         for tray_action in tray_actions:
             # TODO: apparently, this would be better served with an icon theme
@@ -447,7 +447,12 @@ class BreakScreenWindow(Gtk.Window):
 
         # Set values
         if image_path:
-            self.__set_break_image(image_path, monitor_width, monitor_height)
+            self.__set_break_image(
+                image_path,
+                monitor_width,
+                monitor_height,
+                reserve_clock_space=show_clock and has_widget,
+            )
         self.lbl_message.set_label(message)
         self.lbl_widget.set_markup(widget)
         self.__refresh_clock(force=True)
@@ -561,11 +566,18 @@ class BreakScreenWindow(Gtk.Window):
         tray_action.action()
 
     def __set_break_image(
-        self, image_path: str, monitor_width: int, monitor_height: int
+        self,
+        image_path: str,
+        monitor_width: int,
+        monitor_height: int,
+        reserve_clock_space: bool = False,
     ) -> None:
         """Load the break image and cap it relative to the current monitor size."""
         max_width = max(1, (monitor_width * 8) // 10 - 1)
         max_height = max(1, (monitor_height * 3) // 10 - 1)
+
+        if reserve_clock_space:
+            max_height = min(max_height, max(1, (monitor_height * 22) // 100 - 1))
 
         try:
             loaded = GdkPixbuf.Pixbuf.new_from_file(image_path)

--- a/safeeyes/ui/break_screen.py
+++ b/safeeyes/ui/break_screen.py
@@ -19,8 +19,10 @@
 
 import logging
 import os
+import math
 import time
 import typing
+from datetime import datetime
 
 import gi
 from safeeyes import utility
@@ -65,6 +67,7 @@ class BreakScreen:
         self.on_skipped = on_skipped
         self.shortcut_disable_time = 2
         self.strict_break = False
+        self.show_clock = True
         self.windows = []
         self.show_skip_button = False
         self.show_postpone_button = False
@@ -96,6 +99,7 @@ class BreakScreen:
         # the buttons are locked
         self.shortcut_disable_time = config.get("shortcut_disable_time", 2)
         self.strict_break = config.get("strict_break", False)
+        self.show_clock = config.get("show_clock", True)
 
     def skip_break(self) -> None:
         """Skip the break from the break screen."""
@@ -194,6 +198,7 @@ class BreakScreen:
                 self.show_skip_button,
                 self.on_skip_clicked,
                 self.enable_shortcut,
+                self.show_clock,
             )
 
             if self.context.is_wayland:
@@ -364,10 +369,13 @@ class BreakScreenWindow(Gtk.Window):
     __gtype_name__ = "BreakScreenWindow"
 
     lbl_message: Gtk.Label = Gtk.Template.Child()
+    lbl_clock_time: Gtk.Label = Gtk.Template.Child()
     lbl_count: Gtk.Label = Gtk.Template.Child()
     lbl_widget: Gtk.Label = Gtk.Template.Child()
     img_break: Gtk.Picture = Gtk.Template.Child()
+    clock_face: Gtk.DrawingArea = Gtk.Template.Child()
     box_buttons: Gtk.Box = Gtk.Template.Child()
+    box_clock: Gtk.Box = Gtk.Template.Child()
     toolbar: Gtk.Box = Gtk.Template.Child()
 
     button_widgets: list[Gtk.Button] = []
@@ -387,11 +395,18 @@ class BreakScreenWindow(Gtk.Window):
         show_skip: bool,
         on_skip: typing.Callable[[Gtk.Button], None],
         enable_shortcut: bool,
+        show_clock: bool,
     ):
         super().__init__(application=application)
 
         self.on_close = on_close
         self.img_break.set_content_fit(Gtk.ContentFit.SCALE_DOWN)
+        self.button_widgets = []
+        self._current_time = datetime.now()
+        self._clock_display_time: typing.Optional[str] = None
+        self.clock_face.set_draw_func(self.__draw_clock_face)
+        self.box_clock.set_visible(show_clock)
+        self.lbl_widget.set_yalign(1 if show_clock else 0.25)
 
         for tray_action in tray_actions:
             # TODO: apparently, this would be better served with an icon theme
@@ -435,12 +450,105 @@ class BreakScreenWindow(Gtk.Window):
             self.__set_break_image(image_path, monitor_width, monitor_height)
         self.lbl_message.set_label(message)
         self.lbl_widget.set_markup(widget)
+        self.__refresh_clock(force=True)
 
     def set_count_down(self, count: str, enable_shortcut: bool) -> None:
         self.lbl_count.set_text(count)
 
         for button in self.button_widgets:
             button.set_sensitive(enable_shortcut)
+
+        self.__refresh_clock()
+
+    def __refresh_clock(self, force: bool = False) -> None:
+        self._current_time = datetime.now()
+        clock_display_time = utility.format_time(self._current_time.time())
+
+        if not force and clock_display_time == self._clock_display_time:
+            return
+
+        self._clock_display_time = clock_display_time
+        self.lbl_clock_time.set_text(clock_display_time)
+        self.clock_face.queue_draw()
+
+    def __draw_clock_face(self, area, cr, width: int, height: int) -> None:
+        center_x = width / 2
+        center_y = height / 2
+        radius = (min(width, height) / 2) - 6
+
+        cr.set_source_rgba(1, 1, 1, 0.12)
+        cr.arc(center_x, center_y, radius, 0, 2 * math.pi)
+        cr.fill_preserve()
+        cr.set_source_rgb(1, 1, 1)
+        cr.set_line_width(3)
+        cr.stroke()
+
+        for hour in range(12):
+            angle = math.radians((hour * 30) - 90)
+            outer_radius = radius - 8
+            inner_radius = radius - (22 if hour % 3 == 0 else 15)
+            cr.set_line_width(4 if hour % 3 == 0 else 2)
+            cr.move_to(
+                center_x + math.cos(angle) * inner_radius,
+                center_y + math.sin(angle) * inner_radius,
+            )
+            cr.line_to(
+                center_x + math.cos(angle) * outer_radius,
+                center_y + math.sin(angle) * outer_radius,
+            )
+            cr.stroke()
+
+        minutes = self._current_time.minute
+        hours = (self._current_time.hour % 12) + (minutes / 60)
+
+        self.__draw_clock_hand(
+            cr,
+            center_x,
+            center_y,
+            (hours * 30) - 90,
+            radius * 0.5,
+            6,
+            1,
+            1,
+            1,
+        )
+        self.__draw_clock_hand(
+            cr,
+            center_x,
+            center_y,
+            (minutes * 6) - 90,
+            radius * 0.72,
+            4,
+            1,
+            1,
+            1,
+        )
+        cr.set_source_rgb(1, 1, 1)
+        cr.arc(center_x, center_y, 5, 0, 2 * math.pi)
+        cr.fill()
+
+    def __draw_clock_hand(
+        self,
+        cr,
+        center_x: float,
+        center_y: float,
+        angle_degrees: float,
+        length: float,
+        line_width: float,
+        red: float,
+        green: float,
+        blue: float,
+    ) -> None:
+        angle = math.radians(angle_degrees)
+        cr.set_source_rgb(red, green, blue)
+        cr.set_line_width(line_width)
+        cr.set_line_cap(1)
+        cr.move_to(center_x, center_y)
+        cr.line_to(
+            center_x + math.cos(angle) * length,
+            center_y + math.sin(angle) * length,
+        )
+        cr.stroke()
 
     def __tray_action(self, button, tray_action: TrayAction) -> None:
         """Tray action handler.

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -76,6 +76,7 @@ class SettingsDialog(Gtk.ApplicationWindow):
     switch_strict_break: Gtk.Switch = Gtk.Template.Child()
     switch_random_order: Gtk.Switch = Gtk.Template.Child()
     switch_postpone: Gtk.Switch = Gtk.Template.Child()
+    switch_show_clock: Gtk.Switch = Gtk.Template.Child()
     switch_persist: Gtk.Switch = Gtk.Template.Child()
     info_bar_long_break: Gtk.InfoBar = Gtk.Template.Child()
 
@@ -134,6 +135,7 @@ class SettingsDialog(Gtk.ApplicationWindow):
         self.switch_strict_break.set_active(config.get("strict_break"))
         self.switch_random_order.set_active(config.get("random_order"))
         self.switch_postpone.set_active(config.get("allow_postpone"))
+        self.switch_show_clock.set_active(config.get("show_clock", True))
         self.switch_persist.set_active(config.get("persist_state"))
         self.infobar_long_break_shown = False
 
@@ -356,6 +358,7 @@ class SettingsDialog(Gtk.ApplicationWindow):
         self.config.set("strict_break", self.switch_strict_break.get_active())
         self.config.set("random_order", self.switch_random_order.get_active())
         self.config.set("allow_postpone", self.switch_postpone.get_active())
+        self.config.set("show_clock", self.switch_show_clock.get_active())
         self.config.set("persist_state", self.switch_persist.get_active())
         for plugin in self.config.get("plugins"):
             if plugin["id"] in self.plugin_items:


### PR DESCRIPTION
Fix #635. There is an option to turn the clock on/off. I turned off the settings hand to save system resources (so that it doesn't have to be reanimated every second)

<img width="1864" height="1040" alt="image" src="https://github.com/user-attachments/assets/76cd7a58-9b4d-462b-80fd-01b32fbdab47" />

