### PR TITLE
Allow running from source (when not installed) by using version number from local metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,6 @@ To manually change the version number, update the following places (Open the pro
     - [pyproject.toml](https://github.com/slgobinath/safeeyes/blob/master/pyproject.toml#L4)
     - [pyproject.toml](https://github.com/slgobinath/safeeyes/blob/master/pyproject.toml#L35)
     - [io.github.slgobinath.SafeEyes.metainfo.xml](https://github.com/slgobinath/safeeyes/blob/master/safeeyes/platform/io.github.slgobinath.SafeEyes.metainfo.xml#L56)
-    - [about_dialog.glade](https://github.com/slgobinath/safeeyes/blob/master/safeeyes/glade/about_dialog.glade#L74)
 4. Update the [changelog](https://github.com/slgobinath/safeeyes/blob/master/debian/changelog) (for Ubuntu PPA release). *This is automated* if you use the `./update-version.sh` script mentioned above, but you may want to manually add more lines to describe what's new in this release.
 5. Commit the changes to `master`
 6. Create a pull-request from `master` to `release`

--- a/safeeyes/glade/about_dialog.glade
+++ b/safeeyes/glade/about_dialog.glade
@@ -75,7 +75,6 @@ along with this program.  If not, see &lt;https://www.gnu.org/licenses/&gt;.</pr
                 <property name="valign">center</property>
                 <property name="margin-top">10</property>
                 <property name="margin-bottom">10</property>
-                <property name="label">Safe Eyes 3.4.0</property>
                 <property name="justify">center</property>
                 <property name="hexpand">1</property>
                 <property name="vexpand">1</property>

--- a/safeeyes/safeeyes.py
+++ b/safeeyes/safeeyes.py
@@ -28,11 +28,6 @@ from pathlib import Path
 import re
 import typing
 
-try:
-    import tomllib
-except ModuleNotFoundError:
-    tomllib = None
-
 import gi
 from safeeyes import context, utility
 from safeeyes.ui.about_dialog import AboutDialog
@@ -54,18 +49,23 @@ def _safeeyes_version() -> str:
 
     # Running from a source checkout: use the local project metadata.
     if pyproject_path.is_file():
-        if tomllib is not None:
-            try:
-                pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
-                version = pyproject["project"]["version"]
-                return f"{version}+development"
-            except (OSError, ValueError, KeyError, TypeError):
-                # Fall back to regex parsing for compatibility and resilience.
-                pass
+        pyproject_text = pyproject_path.read_text(encoding="utf-8")
+
+        try:
+            import tomllib
+
+            pyproject = tomllib.loads(pyproject_text)
+            version = pyproject["project"]["version"]
+            return f"{version}+development"
+        except ModuleNotFoundError:
+            pass
+        except (ValueError, KeyError, TypeError):
+            # Fall back to regex parsing for compatibility and resilience.
+            pass
 
         match = re.search(
             r'(?ms)^\[project\].*?^version\s*=\s*"([^"]+)"',
-            pyproject_path.read_text(encoding="utf-8"),
+            pyproject_text,
         )
         if match is None:
             raise RuntimeError("Could not parse project version from pyproject.toml")

--- a/safeeyes/safeeyes.py
+++ b/safeeyes/safeeyes.py
@@ -28,6 +28,11 @@ from pathlib import Path
 import re
 import typing
 
+try:
+    import tomllib
+except ModuleNotFoundError:
+    tomllib = None
+
 import gi
 from safeeyes import context, utility
 from safeeyes.ui.about_dialog import AboutDialog
@@ -49,11 +54,20 @@ def _safeeyes_version() -> str:
         return metadata.version("safeeyes")
     except metadata.PackageNotFoundError:
         # Running from a source checkout without installation metadata.
+        pyproject_path = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+        if tomllib is not None:
+            try:
+                pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+                version = pyproject["project"]["version"]
+                return f"{version}+development"
+            except (OSError, ValueError, KeyError, TypeError):
+                # Fall back to regex parsing for compatibility and resilience.
+                pass
+
         match = re.search(
             r'(?ms)^\[project\].*?^version\s*=\s*"([^"]+)"',
-            (Path(__file__).resolve().parent.parent / "pyproject.toml").read_text(
-                encoding="utf-8"
-            ),
+            pyproject_path.read_text(encoding="utf-8"),
         )
         if match is None:
             raise RuntimeError("Could not parse project version from pyproject.toml")

--- a/safeeyes/safeeyes.py
+++ b/safeeyes/safeeyes.py
@@ -24,6 +24,8 @@ import atexit
 import gettext
 import logging
 from importlib import metadata
+from pathlib import Path
+import re
 import typing
 
 import gi
@@ -41,7 +43,27 @@ from safeeyes.ui.settings_dialog import SettingsDialog
 gi.require_version("Gtk", "4.0")
 from gi.repository import Gtk, Gio, GLib
 
-SAFE_EYES_VERSION = metadata.version("safeeyes")
+
+def _safeeyes_version() -> str:
+    try:
+        return metadata.version("safeeyes")
+    except metadata.PackageNotFoundError:
+        # Running from a source checkout without installation metadata.
+        match = re.search(
+            r'(?ms)^\[project\].*?^version\s*=\s*"([^"]+)"',
+            (Path(__file__).resolve().parent.parent / "pyproject.toml").read_text(
+                encoding="utf-8"
+            ),
+        )
+        if match is None:
+            raise RuntimeError("Could not parse project version from pyproject.toml")
+
+        version = match.group(1)
+
+        return f"{version}+development"
+
+
+SAFE_EYES_VERSION = _safeeyes_version()
 
 
 class SafeEyes(Gtk.Application):

--- a/safeeyes/safeeyes.py
+++ b/safeeyes/safeeyes.py
@@ -50,12 +50,10 @@ from gi.repository import Gtk, Gio, GLib
 
 
 def _safeeyes_version() -> str:
-    try:
-        return metadata.version("safeeyes")
-    except metadata.PackageNotFoundError:
-        # Running from a source checkout without installation metadata.
-        pyproject_path = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    pyproject_path = Path(__file__).resolve().parent.parent / "pyproject.toml"
 
+    # Running from a source checkout: use the local project metadata.
+    if pyproject_path.is_file():
         if tomllib is not None:
             try:
                 pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
@@ -72,9 +70,13 @@ def _safeeyes_version() -> str:
         if match is None:
             raise RuntimeError("Could not parse project version from pyproject.toml")
 
-        version = match.group(1)
+        return f"{match.group(1)}+development"
 
-        return f"{version}+development"
+    # Installed package: use distribution metadata.
+    try:
+        return metadata.version("safeeyes")
+    except metadata.PackageNotFoundError as error:
+        raise RuntimeError("Could not determine Safe Eyes version") from error
 
 
 SAFE_EYES_VERSION = _safeeyes_version()

--- a/update-version.sh
+++ b/update-version.sh
@@ -93,16 +93,6 @@ if [ -f "$AUR_PKGBUILD" ]; then
     echo "Updated $AUR_PKGBUILD"
 fi
 
-# Update glade about dialog label if present
-GLADE_ABOUT="safeeyes/glade/about_dialog.glade"
-if [ -f "$GLADE_ABOUT" ]; then
-    # replace 'Safe Eyes x.y.z' inside <property name="label">...<
-    sed -i "s/\(<property name=\"label\">Safe Eyes \).*\(<\/property>\)/\1$version\2/" "$GLADE_ABOUT" || true
-    echo "Updated $GLADE_ABOUT"
-fi
-
-
-
 # Prepend changelog entry (Debian format)
 tmpfile=$(mktemp)
 cat > "$tmpfile" <<EOF


### PR DESCRIPTION
Fixes #876

---
When not installed, safeeyes was failing to load as it could not find the version number. But now it loads the version number from python metadata.