### PR TITLE
settings: add ok, cancel, apply buttons

### DIFF
--- a/safeeyes/config/locale/safeeyes.pot
+++ b/safeeyes/config/locale/safeeyes.pot
@@ -616,3 +616,18 @@ msgstr ""
 
 msgid "take a long break now"
 msgstr ""
+
+msgid "Keep editing"
+msgstr ""
+
+msgid "There are unsaved changes. Do you want to save them?"
+msgstr ""
+
+msgid "OK"
+msgstr ""
+
+msgid "Apply"
+msgstr ""
+
+msgid "Cancel"
+msgstr ""

--- a/safeeyes/glade/item_plugin.glade
+++ b/safeeyes/glade/item_plugin.glade
@@ -99,6 +99,7 @@
             <property name="can-focus">1</property>
             <property name="halign">end</property>
             <property name="valign">center</property>
+            <signal name="notify::active" handler="on_switch_enable_activated" swapped="no"/>
           </object>
         </child>
         <child>

--- a/safeeyes/glade/settings_dialog.glade
+++ b/safeeyes/glade/settings_dialog.glade
@@ -188,6 +188,7 @@
                                             <property name="numeric">1</property>
                                             <property name="update-policy">if-valid</property>
                                             <property name="value">1</property>
+                                            <signal name="value-changed" handler="on_spin_short_break_duration_change" swapped="no"/>
                                           </object>
                                         </child>
                                       </object>
@@ -301,6 +302,7 @@
                                             <property name="numeric">1</property>
                                             <property name="update-policy">if-valid</property>
                                             <property name="value">1</property>
+                                            <signal name="value-changed" handler="on_spin_long_break_duration_change" swapped="no"/>
                                           </object>
                                         </child>
                                       </object>
@@ -352,6 +354,7 @@
                                             <property name="numeric">1</property>
                                             <property name="update-policy">if-valid</property>
                                             <property name="value">1</property>
+                                            <signal name="value-changed" handler="on_spin_time_to_prepare_change" swapped="no"/>
                                           </object>
                                         </child>
                                       </object>
@@ -374,6 +377,7 @@
                                             <property name="can-focus">1</property>
                                             <property name="halign">end</property>
                                             <property name="valign">center</property>
+                                            <signal name="notify::active" handler="on_switch_random_order_activated" swapped="no"/>
                                           </object>
                                         </child>
                                       </object>
@@ -396,6 +400,7 @@
                                             <property name="can-focus">1</property>
                                             <property name="halign">end</property>
                                             <property name="valign">center</property>
+                                            <signal name="notify::active" handler="on_switch_strict_break_activated" swapped="no"/>
                                           </object>
                                         </child>
                                       </object>
@@ -449,6 +454,7 @@
                                                 </items>
                                               </object>
                                             </property>
+                                            <signal name="notify::selected-item" handler="on_dropdown_postpone_unit_selected_item" swapped="no"/>
                                           </object>
                                         </child>
                                         <child>
@@ -465,6 +471,7 @@
                                             <property name="valign">center</property>
                                             <property name="value">1</property>
                                             <property name="visible">1</property>
+                                            <signal name="value-changed" handler="on_spin_postpone_duration_change" swapped="no"/>
                                           </object>
                                         </child>
                                       </object>
@@ -493,6 +500,7 @@
                                             <property name="numeric">1</property>
                                             <property name="update-policy">if-valid</property>
                                             <property name="value">1</property>
+                                            <signal name="value-changed" handler="on_spin_shortcut_disable_time_change" swapped="no"/>
                                           </object>
                                         </child>
                                       </object>
@@ -515,6 +523,7 @@
                                             <property name="can-focus">1</property>
                                             <property name="halign">end</property>
                                             <property name="valign">center</property>
+                                            <signal name="notify::active" handler="on_switch_persist_state_activated" swapped="no"/>
                                           </object>
                                         </child>
                                       </object>

--- a/safeeyes/glade/settings_dialog.glade
+++ b/safeeyes/glade/settings_dialog.glade
@@ -93,518 +93,526 @@
     <property name="icon-name">io.github.slgobinath.SafeEyes</property>
     <signal name="close-request" handler="on_window_delete" swapped="no" />
     <child>
-      <object class="GtkStack" id="stack">
-        <property name="visible">1</property>
-        <property name="interpolate-size">1</property>
+      <object class="GtkBox" id="layout_box">
+        <property name="hexpand">1</property>
+        <property name="vexpand">1</property>
+        <property name="orientation">vertical</property>
+        <property name="baseline-position">top</property>
         <child>
-          <object class="GtkStackPage">
-            <property name="name">Settings</property>
-            <property name="title" translatable="yes">Settings</property>
-            <property name="child">
-              <object class="GtkScrolledWindow" id="scrolledwindow_settings">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="hscrollbar-policy">never</property>
-                <property name="has-frame">1</property>
-                <child>
-                  <object class="GtkViewport" id="viewport_settings">
+          <object class="GtkStack" id="stack">
+            <property name="visible">1</property>
+            <property name="interpolate-size">1</property>
+            <child>
+              <object class="GtkStackPage">
+                <property name="name">Settings</property>
+                <property name="title" translatable="yes">Settings</property>
+                <property name="child">
+                  <object class="GtkScrolledWindow" id="scrolledwindow_settings">
                     <property name="visible">1</property>
-                    <child>
-                      <object class="GtkBox" id="box_settings">
-                        <property name="visible">1</property>
-                        <property name="margin-start">5</property>
-                        <property name="margin-end">5</property>
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">15</property>
-                        <child>
-                          <object class="GtkFrame" id="frame_short_breaks">
-                            <property name="visible">1</property>
-                            <child>
-                              <object class="GtkBox" id="box13">
-                                <property name="visible">1</property>
-                                <property name="margin-start">12</property>
-                                <property name="margin-end">10</property>
-                                <property name="margin-top">10</property>
-                                <property name="margin-bottom">10</property>
-                                <property name="orientation">vertical</property>
-                                <property name="spacing">15</property>
-                                <property name="homogeneous">1</property>
-                                <child>
-                                  <object class="GtkBox" id="box7">
-                                    <property name="visible">1</property>
-                                    <property name="spacing">5</property>
-                                    <property name="homogeneous">1</property>
-                                    <child>
-                                      <object class="GtkLabel" id="lbl_interval_between_breaks">
-                                        <property name="halign">start</property>
-                                        <property name="visible">1</property>
-                                        <property name="label" translatable="yes">Interval between two breaks (in minutes)</property>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSpinButton" id="spin_short_break_interval">
-                                        <property name="visible">1</property>
-                                        <property name="can-focus">1</property>
-                                        <property name="halign">end</property>
-                                        <property name="valign">center</property>
-                                        <property name="text">1</property>
-                                        <property name="adjustment">adjust_short_break_interval</property>
-                                        <property name="climb-rate">1</property>
-                                        <property name="numeric">1</property>
-                                        <property name="update-policy">if-valid</property>
-                                        <property name="value">1</property>
-                                        <signal name="value-changed" handler="on_spin_short_break_interval_change" swapped="no"/>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkBox" id="box2">
-                                    <property name="visible">1</property>
-                                    <property name="spacing">5</property>
-                                    <property name="homogeneous">1</property>
-                                    <child>
-                                      <object class="GtkLabel" id="lbl_short_break_duration">
-                                        <property name="halign">start</property>
-                                        <property name="visible">1</property>
-                                        <property name="label" translatable="yes">Break duration (in seconds)</property>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSpinButton" id="spin_short_break_duration">
-                                        <property name="visible">1</property>
-                                        <property name="can-focus">1</property>
-                                        <property name="halign">end</property>
-                                        <property name="valign">center</property>
-                                        <property name="text">1</property>
-                                        <property name="adjustment">adjust_short_break_duration</property>
-                                        <property name="climb-rate">1</property>
-                                        <property name="numeric">1</property>
-                                        <property name="update-policy">if-valid</property>
-                                        <property name="value">1</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                            <child type="label">
-                              <object class="GtkLabel" id="lbl_frames">
-                                <property name="visible">1</property>
-                                <property name="label" translatable="yes">Short Breaks</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkFrame" id="frame_long_breaks">
-                            <property name="visible">1</property>
-                            <child>
-                              <object class="GtkBox" id="box14">
-                                <property name="visible">1</property>
-                                <property name="margin-start">12</property>
-                                <property name="margin-end">10</property>
-                                <property name="margin-top">10</property>
-                                <property name="margin-bottom">10</property>
-                                <property name="orientation">vertical</property>
-                                <property name="spacing">15</property>
-                                <property name="homogeneous">1</property>
-                                <child>
-                                  <object class="GtkInfoBar" id="info_bar_long_break">
-                                    <property name="visible">0</property>
-                                    <property name="show-close-button">1</property>
-                                    <property name="hexpand">1</property>
-                                    <property name="vexpand">1</property>
-                                    <signal name="close" handler="on_info_bar_long_break_close" swapped="no"/>
-                                    <signal name="response" handler="on_info_bar_long_break_close" swapped="no"/>
-                                    <child>
-                                      <object class="GtkBox">
-                                        <property name="spacing">16</property>
-                                        <child>
-                                          <object class="GtkImage" id="image1">
-                                            <property name="visible">1</property>
-                                            <property name="icon-name">dialog-information</property>
-                                          </object>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="label2">
-                                            <property name="visible">1</property>
-                                            <property name="label" translatable="yes">Long break interval must be a multiple of short break interval</property>
-                                            <property name="xalign">0</property>
-                                          </object>
-                                        </child>
-                                      </object>
-                                    </child>
-                                    <style>
-                                      <class name="info_bar_long_break"/>
-                                    </style>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkBox" id="box8">
-                                    <property name="visible">1</property>
-                                    <property name="spacing">5</property>
-                                    <property name="homogeneous">1</property>
-                                    <child>
-                                      <object class="GtkLabel" id="lbl_short_per_long">
-                                        <property name="halign">start</property>
-                                        <property name="visible">1</property>
-                                        <property name="label" translatable="yes">Interval between two breaks (in minutes)</property>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSpinButton" id="spin_long_break_interval">
-                                        <property name="visible">1</property>
-                                        <property name="can-focus">1</property>
-                                        <property name="halign">end</property>
-                                        <property name="valign">center</property>
-                                        <property name="text">1</property>
-                                        <property name="adjustment">adjust_long_break_interval</property>
-                                        <property name="climb-rate">1</property>
-                                        <property name="snap-to-ticks">1</property>
-                                        <property name="numeric">1</property>
-                                        <property name="wrap">1</property>
-                                        <property name="update-policy">if-valid</property>
-                                        <property name="value">1</property>
-                                        <signal name="value-changed" handler="on_spin_long_break_interval_change" swapped="no"/>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkBox" id="box3">
-                                    <property name="visible">1</property>
-                                    <property name="spacing">5</property>
-                                    <property name="homogeneous">1</property>
-                                    <child>
-                                      <object class="GtkLabel" id="lbl_long_break_duration">
-                                        <property name="visible">1</property>
-                                        <property name="halign">start</property>
-                                        <property name="label" translatable="yes">Break duration (in seconds)</property>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSpinButton" id="spin_long_break_duration">
-                                        <property name="visible">1</property>
-                                        <property name="can-focus">1</property>
-                                        <property name="halign">end</property>
-                                        <property name="valign">center</property>
-                                        <property name="text">1</property>
-                                        <property name="adjustment">adjust_long_break_duration</property>
-                                        <property name="climb-rate">1</property>
-                                        <property name="numeric">1</property>
-                                        <property name="update-policy">if-valid</property>
-                                        <property name="value">1</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                            <child type="label">
-                              <object class="GtkLabel" id="lbl_lon_breaks">
-                                <property name="visible">1</property>
-                                <property name="label" translatable="yes">Long Breaks</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkFrame" id="frame_options">
-                            <property name="visible">1</property>
-                            <child>
-                              <object class="GtkBox" id="box12">
-                                <property name="visible">1</property>
-                                <property name="margin-start">12</property>
-                                <property name="margin-end">10</property>
-                                <property name="margin-top">10</property>
-                                <property name="margin-bottom">10</property>
-                                <property name="orientation">vertical</property>
-                                <property name="spacing">15</property>
-                                <property name="homogeneous">1</property>
-                                <child>
-                                  <object class="GtkBox" id="box6">
-                                    <property name="visible">1</property>
-                                    <property name="spacing">5</property>
-                                    <property name="homogeneous">1</property>
-                                    <child>
-                                      <object class="GtkLabel" id="lbl_time_to_prepare">
-                                        <property name="visible">1</property>
-                                        <property name="halign">start</property>
-                                        <property name="label" translatable="yes">Time to prepare for a break (in seconds)</property>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSpinButton" id="spin_time_to_prepare">
-                                        <property name="visible">1</property>
-                                        <property name="can-focus">1</property>
-                                        <property name="halign">end</property>
-                                        <property name="valign">center</property>
-                                        <property name="text">1</property>
-                                        <property name="adjustment">adjust_time_to_prepare</property>
-                                        <property name="climb-rate">1</property>
-                                        <property name="numeric">1</property>
-                                        <property name="update-policy">if-valid</property>
-                                        <property name="value">1</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkBox" id="box16_random_order">
-                                    <property name="visible">1</property>
-                                    <property name="spacing">5</property>
-                                    <property name="homogeneous">1</property>
-                                    <child>
-                                      <object class="GtkLabel" id="lbl_random_order">
-                                        <property name="visible">1</property>
-                                        <property name="halign">start</property>
-                                        <property name="label" translatable="yes">Show breaks in random order</property>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSwitch" id="switch_random_order">
-                                        <property name="visible">1</property>
-                                        <property name="can-focus">1</property>
-                                        <property name="halign">end</property>
-                                        <property name="valign">center</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkBox" id="box9">
-                                    <property name="visible">1</property>
-                                    <property name="spacing">5</property>
-                                    <property name="homogeneous">1</property>
-                                    <child>
-                                      <object class="GtkLabel" id="lbl_strict_break">
-                                        <property name="visible">1</property>
-                                        <property name="halign">start</property>
-                                        <property name="label" translatable="yes">Strict break (No way to skip breaks)</property>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSwitch" id="switch_strict_break">
-                                        <property name="visible">1</property>
-                                        <property name="can-focus">1</property>
-                                        <property name="halign">end</property>
-                                        <property name="valign">center</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkBox" id="box11">
-                                    <property name="visible">1</property>
-                                    <property name="spacing">5</property>
-                                    <property name="homogeneous">1</property>
-                                    <child>
-                                      <object class="GtkLabel" id="lbl_allow_postpone">
-                                        <property name="visible">1</property>
-                                        <property name="halign">start</property>
-                                        <property name="label" translatable="yes">Allow postponing breaks</property>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSwitch" id="switch_postpone">
-                                        <property name="visible">1</property>
-                                        <property name="can-focus">1</property>
-                                        <property name="halign">end</property>
-                                        <property name="valign">center</property>
-                                        <signal name="state-set" handler="on_switch_postpone_activate" swapped="no"/>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkBox" id="box10">
-                                    <property name="spacing">5</property>
-                                    <property name="visible">1</property>
-                                    <child>
-                                      <object class="GtkLabel" id="lbl_postpone_duration">
-                                        <property name="halign">start</property>
-                                        <property name="label" translatable="yes">Postponement duration in</property>
-                                        <property name="visible">1</property>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkDropDown" id="dropdown_postpone_unit">
-                                        <property name="halign">start</property>
-                                        <property name="valign">center</property>
-                                        <property name="hexpand">true</property>
-                                        <property name="vexpand">false</property>
-                                        <property name="selected">0</property>
-                                        <property name="model">
-                                          <object class="GtkStringList">
-                                            <items>
-                                              <item translatable="yes">minutes</item>
-                                              <item translatable="yes">seconds</item>
-                                            </items>
-                                          </object>
-                                        </property>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSpinButton" id="spin_postpone_duration">
-                                        <property name="adjustment">adjust_postpone_duration</property>
-                                        <property name="can-focus">1</property>
-                                        <property name="climb-rate">1</property>
-                                        <property name="halign">end</property>
-                                        <property name="hexpand">True</property>
-                                        <property name="hexpand-set">True</property>
-                                        <property name="numeric">1</property>
-                                        <property name="text">1</property>
-                                        <property name="update-policy">if-valid</property>
-                                        <property name="valign">center</property>
-                                        <property name="value">1</property>
-                                        <property name="visible">1</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkBox" id="box5">
-                                    <property name="visible">1</property>
-                                    <property name="spacing">5</property>
-                                    <property name="homogeneous">1</property>
-                                    <child>
-                                      <object class="GtkLabel" id="lbl_shortcuts">
-                                        <property name="visible">1</property>
-                                        <property name="halign">start</property>
-                                        <property name="label" translatable="yes">Skipping/postponing disabled period (in seconds)</property>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSpinButton" id="spin_disable_keyboard_shortcut">
-                                        <property name="visible">1</property>
-                                        <property name="can-focus">1</property>
-                                        <property name="halign">end</property>
-                                        <property name="valign">center</property>
-                                        <property name="text">1</property>
-                                        <property name="adjustment">adjust_disable_keyboard_shortcut_duration</property>
-                                        <property name="climb-rate">1</property>
-                                        <property name="numeric">1</property>
-                                        <property name="update-policy">if-valid</property>
-                                        <property name="value">1</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkBox" id="box1">
-                                    <property name="visible">1</property>
-                                    <property name="spacing">5</property>
-                                    <property name="homogeneous">1</property>
-                                    <child>
-                                      <object class="GtkLabel" id="lbl_persist_state">
-                                        <property name="visible">1</property>
-                                        <property name="halign">start</property>
-                                        <property name="label" translatable="yes">Persist the internal state</property>
-                                      </object>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSwitch" id="switch_persist">
-                                        <property name="visible">1</property>
-                                        <property name="can-focus">1</property>
-                                        <property name="halign">end</property>
-                                        <property name="valign">center</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                            <child type="label">
-                              <object class="GtkLabel" id="label1">
-                                <property name="visible">1</property>
-                                <property name="label" translatable="yes">Options</property>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkStackPage">
-            <property name="name">page1</property>
-            <property name="title" translatable="yes">Breaks</property>
-            <property name="child">
-              <object class="GtkBox" id="box_break">
-                <property name="visible">1</property>
-                <property name="margin-start">5</property>
-                <property name="margin-end">5</property>
-                <property name="orientation">vertical</property>
-                <child>
-                  <object class="GtkScrolledWindow" id="scrolledwindow_breaks">
-                    <property name="visible">1</property>
-                    <property name="hexpand">1</property>
-                    <property name="vexpand">1</property>
                     <property name="can-focus">1</property>
                     <property name="hscrollbar-policy">never</property>
                     <property name="has-frame">1</property>
                     <child>
-                      <object class="GtkViewport" id="viewport_breaks">
+                      <object class="GtkViewport" id="viewport_settings">
                         <property name="visible">1</property>
                         <child>
-                          <object class="GtkBox" id="box_breaks">
+                          <object class="GtkBox" id="box_settings">
                             <property name="visible">1</property>
-                            <property name="margin-top">10</property>
-                            <property name="margin-bottom">10</property>
+                            <property name="margin-start">5</property>
+                            <property name="margin-end">5</property>
                             <property name="orientation">vertical</property>
+                            <property name="spacing">15</property>
                             <child>
-                              <object class="GtkBox" id="box4">
+                              <object class="GtkFrame" id="frame_short_breaks">
                                 <property name="visible">1</property>
-                                <property name="orientation">vertical</property>
-                                <property name="hexpand">1</property>
-                                <property name="vexpand">1</property>
                                 <child>
-                                  <object class="GtkExpander" id="expander_short_breaks">
+                                  <object class="GtkBox" id="box13">
                                     <property name="visible">1</property>
-                                    <property name="can-focus">1</property>
-                                    <property name="expanded">1</property>
-                                    <child>
-                                      <object class="GtkBox" id="box_short_breaks">
-                                        <property name="visible">1</property>
-                                        <property name="orientation">vertical</property>
-                                        <property name="spacing">5</property>
-                                      </object>
-                                    </child>
-                                    <child type="label">
-                                      <object class="GtkLabel" id="lbl_short_breaks">
-                                        <property name="visible">1</property>
-                                        <property name="label" translatable="yes">Short Breaks</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkSeparator" id="separator_breaks">
-                                    <property name="visible">1</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">10</property>
                                     <property name="margin-top">10</property>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkExpander" id="expander_long_breaks">
-                                    <property name="visible">1</property>
-                                    <property name="can-focus">1</property>
+                                    <property name="margin-bottom">10</property>
+                                    <property name="orientation">vertical</property>
+                                    <property name="spacing">15</property>
+                                    <property name="homogeneous">1</property>
                                     <child>
-                                      <object class="GtkBox" id="box_long_breaks">
+                                      <object class="GtkBox" id="box7">
                                         <property name="visible">1</property>
-                                        <property name="orientation">vertical</property>
                                         <property name="spacing">5</property>
+                                        <property name="homogeneous">1</property>
+                                        <child>
+                                          <object class="GtkLabel" id="lbl_interval_between_breaks">
+                                            <property name="halign">start</property>
+                                            <property name="visible">1</property>
+                                            <property name="label" translatable="yes">Interval between two breaks (in minutes)</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="spin_short_break_interval">
+                                            <property name="visible">1</property>
+                                            <property name="can-focus">1</property>
+                                            <property name="halign">end</property>
+                                            <property name="valign">center</property>
+                                            <property name="text">1</property>
+                                            <property name="adjustment">adjust_short_break_interval</property>
+                                            <property name="climb-rate">1</property>
+                                            <property name="numeric">1</property>
+                                            <property name="update-policy">if-valid</property>
+                                            <property name="value">1</property>
+                                            <signal name="value-changed" handler="on_spin_short_break_interval_change" swapped="no"/>
+                                          </object>
+                                        </child>
                                       </object>
                                     </child>
-                                    <child type="label">
-                                      <object class="GtkLabel" id="lbl_long_breaks">
+                                    <child>
+                                      <object class="GtkBox" id="box2">
                                         <property name="visible">1</property>
-                                        <property name="label" translatable="yes">Long Breaks</property>
+                                        <property name="spacing">5</property>
+                                        <property name="homogeneous">1</property>
+                                        <child>
+                                          <object class="GtkLabel" id="lbl_short_break_duration">
+                                            <property name="halign">start</property>
+                                            <property name="visible">1</property>
+                                            <property name="label" translatable="yes">Break duration (in seconds)</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="spin_short_break_duration">
+                                            <property name="visible">1</property>
+                                            <property name="can-focus">1</property>
+                                            <property name="halign">end</property>
+                                            <property name="valign">center</property>
+                                            <property name="text">1</property>
+                                            <property name="adjustment">adjust_short_break_duration</property>
+                                            <property name="climb-rate">1</property>
+                                            <property name="numeric">1</property>
+                                            <property name="update-policy">if-valid</property>
+                                            <property name="value">1</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="lbl_frames">
+                                    <property name="visible">1</property>
+                                    <property name="label" translatable="yes">Short Breaks</property>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkFrame" id="frame_long_breaks">
+                                <property name="visible">1</property>
+                                <child>
+                                  <object class="GtkBox" id="box14">
+                                    <property name="visible">1</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">10</property>
+                                    <property name="margin-top">10</property>
+                                    <property name="margin-bottom">10</property>
+                                    <property name="orientation">vertical</property>
+                                    <property name="spacing">15</property>
+                                    <property name="homogeneous">1</property>
+                                    <child>
+                                      <object class="GtkInfoBar" id="info_bar_long_break">
+                                        <property name="visible">0</property>
+                                        <property name="show-close-button">1</property>
+                                        <property name="hexpand">1</property>
+                                        <property name="vexpand">1</property>
+                                        <signal name="close" handler="on_info_bar_long_break_close" swapped="no"/>
+                                        <signal name="response" handler="on_info_bar_long_break_close" swapped="no"/>
+                                        <child>
+                                          <object class="GtkBox">
+                                            <property name="spacing">16</property>
+                                            <child>
+                                              <object class="GtkImage" id="image1">
+                                                <property name="visible">1</property>
+                                                <property name="icon-name">dialog-information</property>
+                                              </object>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="label2">
+                                                <property name="visible">1</property>
+                                                <property name="label" translatable="yes">Long break interval must be a multiple of short break interval</property>
+                                                <property name="xalign">0</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </child>
+                                        <style>
+                                          <class name="info_bar_long_break"/>
+                                        </style>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox" id="box8">
+                                        <property name="visible">1</property>
+                                        <property name="spacing">5</property>
+                                        <property name="homogeneous">1</property>
+                                        <child>
+                                          <object class="GtkLabel" id="lbl_short_per_long">
+                                            <property name="halign">start</property>
+                                            <property name="visible">1</property>
+                                            <property name="label" translatable="yes">Interval between two breaks (in minutes)</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="spin_long_break_interval">
+                                            <property name="visible">1</property>
+                                            <property name="can-focus">1</property>
+                                            <property name="halign">end</property>
+                                            <property name="valign">center</property>
+                                            <property name="text">1</property>
+                                            <property name="adjustment">adjust_long_break_interval</property>
+                                            <property name="climb-rate">1</property>
+                                            <property name="snap-to-ticks">1</property>
+                                            <property name="numeric">1</property>
+                                            <property name="wrap">1</property>
+                                            <property name="update-policy">if-valid</property>
+                                            <property name="value">1</property>
+                                            <signal name="value-changed" handler="on_spin_long_break_interval_change" swapped="no"/>
+                                          </object>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox" id="box3">
+                                        <property name="visible">1</property>
+                                        <property name="spacing">5</property>
+                                        <property name="homogeneous">1</property>
+                                        <child>
+                                          <object class="GtkLabel" id="lbl_long_break_duration">
+                                            <property name="visible">1</property>
+                                            <property name="halign">start</property>
+                                            <property name="label" translatable="yes">Break duration (in seconds)</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="spin_long_break_duration">
+                                            <property name="visible">1</property>
+                                            <property name="can-focus">1</property>
+                                            <property name="halign">end</property>
+                                            <property name="valign">center</property>
+                                            <property name="text">1</property>
+                                            <property name="adjustment">adjust_long_break_duration</property>
+                                            <property name="climb-rate">1</property>
+                                            <property name="numeric">1</property>
+                                            <property name="update-policy">if-valid</property>
+                                            <property name="value">1</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="lbl_lon_breaks">
+                                    <property name="visible">1</property>
+                                    <property name="label" translatable="yes">Long Breaks</property>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkFrame" id="frame_options">
+                                <property name="visible">1</property>
+                                <child>
+                                  <object class="GtkBox" id="box12">
+                                    <property name="visible">1</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="margin-end">10</property>
+                                    <property name="margin-top">10</property>
+                                    <property name="margin-bottom">10</property>
+                                    <property name="orientation">vertical</property>
+                                    <property name="spacing">15</property>
+                                    <property name="homogeneous">1</property>
+                                    <child>
+                                      <object class="GtkBox" id="box6">
+                                        <property name="visible">1</property>
+                                        <property name="spacing">5</property>
+                                        <property name="homogeneous">1</property>
+                                        <child>
+                                          <object class="GtkLabel" id="lbl_time_to_prepare">
+                                            <property name="visible">1</property>
+                                            <property name="halign">start</property>
+                                            <property name="label" translatable="yes">Time to prepare for a break (in seconds)</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="spin_time_to_prepare">
+                                            <property name="visible">1</property>
+                                            <property name="can-focus">1</property>
+                                            <property name="halign">end</property>
+                                            <property name="valign">center</property>
+                                            <property name="text">1</property>
+                                            <property name="adjustment">adjust_time_to_prepare</property>
+                                            <property name="climb-rate">1</property>
+                                            <property name="numeric">1</property>
+                                            <property name="update-policy">if-valid</property>
+                                            <property name="value">1</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox" id="box16_random_order">
+                                        <property name="visible">1</property>
+                                        <property name="spacing">5</property>
+                                        <property name="homogeneous">1</property>
+                                        <child>
+                                          <object class="GtkLabel" id="lbl_random_order">
+                                            <property name="visible">1</property>
+                                            <property name="halign">start</property>
+                                            <property name="label" translatable="yes">Show breaks in random order</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSwitch" id="switch_random_order">
+                                            <property name="visible">1</property>
+                                            <property name="can-focus">1</property>
+                                            <property name="halign">end</property>
+                                            <property name="valign">center</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox" id="box9">
+                                        <property name="visible">1</property>
+                                        <property name="spacing">5</property>
+                                        <property name="homogeneous">1</property>
+                                        <child>
+                                          <object class="GtkLabel" id="lbl_strict_break">
+                                            <property name="visible">1</property>
+                                            <property name="halign">start</property>
+                                            <property name="label" translatable="yes">Strict break (No way to skip breaks)</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSwitch" id="switch_strict_break">
+                                            <property name="visible">1</property>
+                                            <property name="can-focus">1</property>
+                                            <property name="halign">end</property>
+                                            <property name="valign">center</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox" id="box11">
+                                        <property name="visible">1</property>
+                                        <property name="spacing">5</property>
+                                        <property name="homogeneous">1</property>
+                                        <child>
+                                          <object class="GtkLabel" id="lbl_allow_postpone">
+                                            <property name="visible">1</property>
+                                            <property name="halign">start</property>
+                                            <property name="label" translatable="yes">Allow postponing breaks</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSwitch" id="switch_postpone">
+                                            <property name="visible">1</property>
+                                            <property name="can-focus">1</property>
+                                            <property name="halign">end</property>
+                                            <property name="valign">center</property>
+                                            <signal name="state-set" handler="on_switch_postpone_activate" swapped="no"/>
+                                          </object>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox" id="box10">
+                                        <property name="spacing">5</property>
+                                        <property name="visible">1</property>
+                                        <child>
+                                          <object class="GtkLabel" id="lbl_postpone_duration">
+                                            <property name="halign">start</property>
+                                            <property name="label" translatable="yes">Postponement duration in</property>
+                                            <property name="visible">1</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkDropDown" id="dropdown_postpone_unit">
+                                            <property name="halign">start</property>
+                                            <property name="valign">center</property>
+                                            <property name="hexpand">true</property>
+                                            <property name="vexpand">false</property>
+                                            <property name="selected">0</property>
+                                            <property name="model">
+                                              <object class="GtkStringList">
+                                                <items>
+                                                  <item translatable="yes">minutes</item>
+                                                  <item translatable="yes">seconds</item>
+                                                </items>
+                                              </object>
+                                            </property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="spin_postpone_duration">
+                                            <property name="adjustment">adjust_postpone_duration</property>
+                                            <property name="can-focus">1</property>
+                                            <property name="climb-rate">1</property>
+                                            <property name="halign">end</property>
+                                            <property name="hexpand">True</property>
+                                            <property name="hexpand-set">True</property>
+                                            <property name="numeric">1</property>
+                                            <property name="text">1</property>
+                                            <property name="update-policy">if-valid</property>
+                                            <property name="valign">center</property>
+                                            <property name="value">1</property>
+                                            <property name="visible">1</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox" id="box5">
+                                        <property name="visible">1</property>
+                                        <property name="spacing">5</property>
+                                        <property name="homogeneous">1</property>
+                                        <child>
+                                          <object class="GtkLabel" id="lbl_shortcuts">
+                                            <property name="visible">1</property>
+                                            <property name="halign">start</property>
+                                            <property name="label" translatable="yes">Skipping/postponing disabled period (in seconds)</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="spin_disable_keyboard_shortcut">
+                                            <property name="visible">1</property>
+                                            <property name="can-focus">1</property>
+                                            <property name="halign">end</property>
+                                            <property name="valign">center</property>
+                                            <property name="text">1</property>
+                                            <property name="adjustment">adjust_disable_keyboard_shortcut_duration</property>
+                                            <property name="climb-rate">1</property>
+                                            <property name="numeric">1</property>
+                                            <property name="update-policy">if-valid</property>
+                                            <property name="value">1</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox" id="box1">
+                                        <property name="visible">1</property>
+                                        <property name="spacing">5</property>
+                                        <property name="homogeneous">1</property>
+                                        <child>
+                                          <object class="GtkLabel" id="lbl_persist_state">
+                                            <property name="visible">1</property>
+                                            <property name="halign">start</property>
+                                            <property name="label" translatable="yes">Persist the internal state</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSwitch" id="switch_persist">
+                                            <property name="visible">1</property>
+                                            <property name="can-focus">1</property>
+                                            <property name="halign">end</property>
+                                            <property name="valign">center</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="label1">
+                                    <property name="visible">1</property>
+                                    <property name="label" translatable="yes">Options</property>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkStackPage">
+                <property name="name">page1</property>
+                <property name="title" translatable="yes">Breaks</property>
+                <property name="child">
+                  <object class="GtkBox" id="box_break">
+                    <property name="visible">1</property>
+                    <property name="margin-start">5</property>
+                    <property name="margin-end">5</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkScrolledWindow" id="scrolledwindow_breaks">
+                        <property name="visible">1</property>
+                        <property name="hexpand">1</property>
+                        <property name="vexpand">1</property>
+                        <property name="can-focus">1</property>
+                        <property name="hscrollbar-policy">never</property>
+                        <property name="has-frame">1</property>
+                        <child>
+                          <object class="GtkViewport" id="viewport_breaks">
+                            <property name="visible">1</property>
+                            <child>
+                              <object class="GtkBox" id="box_breaks">
+                                <property name="visible">1</property>
+                                <property name="margin-top">10</property>
+                                <property name="margin-bottom">10</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkBox" id="box4">
+                                    <property name="visible">1</property>
+                                    <property name="orientation">vertical</property>
+                                    <property name="hexpand">1</property>
+                                    <property name="vexpand">1</property>
+                                    <child>
+                                      <object class="GtkExpander" id="expander_short_breaks">
+                                        <property name="visible">1</property>
+                                        <property name="can-focus">1</property>
+                                        <property name="expanded">1</property>
+                                        <child>
+                                          <object class="GtkBox" id="box_short_breaks">
+                                            <property name="visible">1</property>
+                                            <property name="orientation">vertical</property>
+                                            <property name="spacing">5</property>
+                                          </object>
+                                        </child>
+                                        <child type="label">
+                                          <object class="GtkLabel" id="lbl_short_breaks">
+                                            <property name="visible">1</property>
+                                            <property name="label" translatable="yes">Short Breaks</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSeparator" id="separator_breaks">
+                                        <property name="visible">1</property>
+                                        <property name="margin-top">10</property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkExpander" id="expander_long_breaks">
+                                        <property name="visible">1</property>
+                                        <property name="can-focus">1</property>
+                                        <child>
+                                          <object class="GtkBox" id="box_long_breaks">
+                                            <property name="visible">1</property>
+                                            <property name="orientation">vertical</property>
+                                            <property name="spacing">5</property>
+                                          </object>
+                                        </child>
+                                        <child type="label">
+                                          <object class="GtkLabel" id="lbl_long_breaks">
+                                            <property name="visible">1</property>
+                                            <property name="label" translatable="yes">Long Breaks</property>
+                                          </object>
+                                        </child>
                                       </object>
                                     </child>
                                   </object>
@@ -615,63 +623,63 @@
                         </child>
                       </object>
                     </child>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkBox" id="buttonbox1">
-                    <property name="visible">1</property>
-                    <property name="margin-top">10</property>
-                    <property name="margin-bottom">10</property>
-                    <property name="halign">end</property>
-                    <property name="valign">end</property>
                     <child>
-                      <object class="GtkButton" id="btn_add_break">
-                        <property name="visible">1</property>
-                        <property name="can-focus">1</property>
-                        <property name="receives-default">1</property>
-                        <property name="halign">end</property>
-                        <property name="icon-name">gtk-add</property>
-                        <signal name="clicked" handler="add_break" swapped="no"/>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkSeparator" id="separator_butoon">
-                    <property name="visible">1</property>
-                    <property name="margin-top">10</property>
-                  </object>
-                </child>
-              </object>
-            </property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkStackPage">
-            <property name="name">page2</property>
-            <property name="title" translatable="yes">Plugins</property>
-            <property name="child">
-              <object class="GtkScrolledWindow" id="scrolledwindow_plugins">
-                <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="hscrollbar-policy">never</property>
-                <property name="has-frame">1</property>
-                <child>
-                  <object class="GtkViewport" id="viewport_plugins">
-                    <property name="visible">1</property>
-                    <child>
-                      <object class="GtkBox" id="box_plugins">
+                      <object class="GtkBox" id="buttonbox1">
                         <property name="visible">1</property>
                         <property name="margin-top">10</property>
                         <property name="margin-bottom">10</property>
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">5</property>
+                        <property name="halign">end</property>
+                        <property name="valign">end</property>
+                        <child>
+                          <object class="GtkButton" id="btn_add_break">
+                            <property name="visible">1</property>
+                            <property name="can-focus">1</property>
+                            <property name="receives-default">1</property>
+                            <property name="halign">end</property>
+                            <property name="icon-name">gtk-add</property>
+                            <signal name="clicked" handler="add_break" swapped="no"/>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkSeparator" id="separator_butoon">
+                        <property name="visible">1</property>
+                        <property name="margin-top">10</property>
                       </object>
                     </child>
                   </object>
-                </child>
+                </property>
               </object>
-            </property>
+            </child>
+            <child>
+              <object class="GtkStackPage">
+                <property name="name">page2</property>
+                <property name="title" translatable="yes">Plugins</property>
+                <property name="child">
+                  <object class="GtkScrolledWindow" id="scrolledwindow_plugins">
+                    <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="hscrollbar-policy">never</property>
+                    <property name="has-frame">1</property>
+                    <child>
+                      <object class="GtkViewport" id="viewport_plugins">
+                        <property name="visible">1</property>
+                        <child>
+                          <object class="GtkBox" id="box_plugins">
+                            <property name="visible">1</property>
+                            <property name="margin-top">10</property>
+                            <property name="margin-bottom">10</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">5</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </property>
+              </object>
+            </child>
           </object>
         </child>
       </object>

--- a/safeeyes/glade/settings_dialog.glade
+++ b/safeeyes/glade/settings_dialog.glade
@@ -730,6 +730,28 @@
               </object>
             </child>
             <child>
+              <object class="GtkButton" id="btn_apply">
+                <property name="sensitive">0</property>
+                <signal name="clicked" handler="on_apply_clicked" swapped="no"/>
+                <child>
+                  <object class="GtkBox">
+                    <property name="spacing">6</property>
+                    <property name="halign">center</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="icon-name">dialog-ok-apply-symbolic</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="label" translatable="1">Apply</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
               <object class="GtkButton" id="btn_cancel">
                 <signal name="clicked" handler="on_cancel_clicked" swapped="no"/>
                 <child>

--- a/safeeyes/glade/settings_dialog.glade
+++ b/safeeyes/glade/settings_dialog.glade
@@ -691,6 +691,67 @@
             </child>
           </object>
         </child>
+        <child>
+          <object class="GtkSeparator">
+            <property name="margin_top">5</property>
+            <property name="margin_bottom">5</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox" id="buttonbox">
+            <property name="valign">start</property>
+            <property name="halign">end</property>
+            <property name="margin-end">5</property>
+            <property name="margin-bottom">5</property>
+            <property name="hexpand">1</property>
+            <property name="vexpand">0</property>
+            <property name="homogeneous">1</property>
+            <property name="spacing">5</property>
+            <child>
+              <object class="GtkButton" id="btn_ok">
+                <signal name="clicked" handler="on_ok_clicked" swapped="no"/>
+                <property name="receives-default">1</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="spacing">6</property>
+                    <property name="halign">center</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="icon-name">dialog-ok-apply-symbolic</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="label" translatable="1">OK</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkButton" id="btn_cancel">
+                <signal name="clicked" handler="on_cancel_clicked" swapped="no"/>
+                <child>
+                  <object class="GtkBox">
+                    <property name="spacing">6</property>
+                    <property name="halign">center</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="icon-name">dialog-cancel-symbolic</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="label" translatable="1">Cancel</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
       </object>
     </child>
     <child type="titlebar">

--- a/safeeyes/safeeyes.py
+++ b/safeeyes/safeeyes.py
@@ -358,7 +358,7 @@ class SafeEyes(Gtk.Application):
         if self._settings_dialog is None:
             logging.info("Show Settings dialog")
             self._settings_dialog = SettingsDialog(
-                self, self.config.clone(), self.save_settings
+                self, self.config, self.save_settings, self._on_settings_close
             )
 
         if activation_token is not None:
@@ -475,16 +475,13 @@ class SafeEyes(Gtk.Application):
         self.safe_eyes_core.postpone()
         self.plugins_manager.stop_break()
 
-    def save_settings(self, config):
+    def _on_settings_close(self) -> None:
+        self._settings_dialog = None
+
+    def save_settings(self, config: Config) -> None:
         """Listen to Settings dialog Save action and write to the config
         file.
         """
-        self._settings_dialog = None
-
-        if self.config == config:
-            # Config is not modified
-            return
-
         logging.info("Saving settings to safeeyes.json")
         # Stop the Safe Eyes core
         if self.active:
@@ -497,7 +494,7 @@ class SafeEyes(Gtk.Application):
 
         self.restart(config)
 
-    def restart(self, config, set_active=False):
+    def restart(self, config: Config, set_active=False):
         logging.info("Initialize SafeEyesCore with modified settings")
 
         # Restart the core and initialize the components

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import copy
 import math
 import os
 import typing
@@ -146,16 +147,7 @@ class SettingsDialog(Gtk.ApplicationWindow):
         box: "BreakItem" = BreakItem(
             break_config,
             is_short,
-            on_properties=lambda: self.__show_break_properties_dialog(
-                break_config,
-                is_short,
-                self.config,
-                on_close=lambda cfg: box.set_break_name(cfg["name"]),
-                on_add=lambda is_short, break_config: self.__create_break_item(
-                    break_config, is_short
-                ),
-                on_remove=lambda: parent_box.remove(box),
-            ),
+            on_properties=self.__show_break_properties_dialog,
             on_delete=self.__request_delete_break,
         )
 
@@ -224,6 +216,35 @@ class SettingsDialog(Gtk.ApplicationWindow):
             self.config.get("long_breaks").remove(break_item.break_config)
             self.box_long_breaks.remove(break_item)
 
+    def __update_break(
+        self, break_item: "BreakItem", new_break_config: dict, new_is_short: bool
+    ) -> None:
+        old_is_short = break_item.is_short
+        break_item.is_short = new_is_short
+        old_break_config = break_item.break_config
+        break_item.break_config = new_break_config
+
+        if old_is_short and not new_is_short:
+            # Changed from short to long
+            self.config.get("short_breaks").remove(old_break_config)
+            self.config.get("long_breaks").append(new_break_config)
+            self.box_short_breaks.remove(break_item)
+            self.box_long_breaks.append(break_item)
+        elif not old_is_short and new_is_short:
+            # Changed from long to short
+            self.config.get("long_breaks").remove(old_break_config)
+            self.config.get("short_breaks").append(new_break_config)
+            self.box_long_breaks.remove(break_item)
+            self.box_short_breaks.append(break_item)
+        else:
+            break_list = self.config.get("long_breaks")
+            if new_is_short:
+                break_list = self.config.get("short_breaks")
+
+            break_list[break_list.index(old_break_config)] = new_break_config
+
+        break_item.update_break_name()
+
     def __create_plugin_item(self, plugin_config: dict) -> "PluginItem":
         """Create an entry for plugin to be listed in the plugin tab."""
         box = PluginItem(
@@ -244,25 +265,14 @@ class SettingsDialog(Gtk.ApplicationWindow):
         dialog = PluginSettingsDialog(self, plugin_config)
         dialog.show()
 
-    def __show_break_properties_dialog(
-        self,
-        break_config: dict,
-        is_short: bool,
-        parent: Config,
-        on_close: typing.Callable[[dict], None],
-        on_add: typing.Callable[[bool, dict], None],
-        on_remove: typing.Callable[[], None],
-    ) -> None:
+    def __show_break_properties_dialog(self, break_item: "BreakItem") -> None:
         """Show the BreakProperties dialog."""
         dialog = BreakSettingsDialog(
             self,
-            break_config,
-            is_short,
-            parent,
+            break_item,
+            self.config,
             self.plugin_map,
-            on_close,
-            on_add,
-            on_remove,
+            on_update_break=self.__update_break,
         )
         dialog.show()
 
@@ -382,7 +392,7 @@ class BreakItem(Gtk.Box):
         self,
         break_config: dict,
         is_short: bool,
-        on_properties: typing.Callable[[], None],
+        on_properties: typing.Callable[["BreakItem"], None],
         on_delete: typing.Callable[["BreakItem"], None],
     ):
         super().__init__()
@@ -393,14 +403,14 @@ class BreakItem(Gtk.Box):
         self.on_properties = on_properties
         self.on_delete = on_delete
 
-        self.lbl_name.set_label(_(break_config["name"]))
+        self.update_break_name()
 
-    def set_break_name(self, break_name: str) -> None:
-        self.lbl_name.set_label(_(break_name))
+    def update_break_name(self) -> None:
+        self.lbl_name.set_label(_(self.break_config["name"]))
 
     @Gtk.Template.Callback()
     def on_properties_clicked(self, button) -> None:
-        self.on_properties()
+        self.on_properties(self)
 
     @Gtk.Template.Callback()
     def on_delete_clicked(self, button) -> None:
@@ -590,26 +600,27 @@ class BreakSettingsDialog(Gtk.Window):
     grid_plugins: Gtk.Grid = Gtk.Template.Child()
     lst_break_types: Gtk.ComboBox = Gtk.Template.Child()
 
+    on_update_break: typing.Callable[["BreakItem", dict, bool], None]
+    break_item: "BreakItem"
+    new_break_config: dict
+
     def __init__(
         self,
         parent: Gtk.Window,
-        break_config: dict,
-        is_short: bool,
-        parent_config: Config,
+        break_item: "BreakItem",
+        parent_config: Config,  # this is read-only
         plugin_map: dict[str, str],
-        on_close: typing.Callable[[dict], None],
-        on_add: typing.Callable[[bool, dict], None],
-        on_remove: typing.Callable[[], None],
+        on_update_break: typing.Callable[["BreakItem", dict, bool], None],
     ):
         super().__init__(transient_for=parent)
 
-        self.break_config = break_config
-        self.parent_config = parent_config
+        self.break_item = break_item
         self.plugin_check_buttons = {}
-        self.on_close = on_close
-        self.is_short = is_short
-        self.on_add = on_add
-        self.on_remove = on_remove
+        self.on_update_break = on_update_break
+        self.new_break_config = copy.deepcopy(break_item.break_config)
+
+        break_config = break_item.break_config
+        is_short = break_item.is_short
 
         interval_overriden = break_config.get("interval", None) is not None
         duration_overriden = break_config.get("duration", None) is not None
@@ -652,9 +663,9 @@ class BreakSettingsDialog(Gtk.Window):
                 col += 1
                 row = 0
 
-        if "image" in self.break_config:
+        if "image" in break_config:
             pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_scale(
-                self.break_config["image"], 16, 16, True
+                break_config["image"], 16, 16, True
             )
             image = Gtk.Image.new_from_pixbuf(pixbuf)
             self.btn_image.set_child(image)
@@ -713,14 +724,14 @@ class BreakSettingsDialog(Gtk.Window):
             pass
 
         if response is not None:
-            self.break_config["image"] = response.get_path()
+            self.new_break_config["image"] = response.get_path()
             pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_scale(
-                self.break_config["image"], 16, 16, True
+                self.new_break_config["image"], 16, 16, True
             )
             image = Gtk.Image.new_from_pixbuf(pixbuf)
             self.btn_image.set_child(image)
         else:
-            self.break_config.pop("image", None)
+            self.new_break_config.pop("image", None)
             self.btn_image.set_icon_name("gtk-missing-image")
 
     @Gtk.Template.Callback()
@@ -728,38 +739,26 @@ class BreakSettingsDialog(Gtk.Window):
         """Event handler for Properties dialog close action."""
         break_name = self.txt_break.get_text().strip()
         if break_name:
-            self.break_config["name"] = break_name
+            self.new_break_config["name"] = break_name
         if self.switch_override_interval.get_active():
-            self.break_config["interval"] = int(self.spin_interval.get_value())
+            self.new_break_config["interval"] = int(self.spin_interval.get_value())
         else:
-            self.break_config.pop("interval", None)
+            self.new_break_config.pop("interval", None)
         if self.switch_override_duration.get_active():
-            self.break_config["duration"] = int(self.spin_duration.get_value())
+            self.new_break_config["duration"] = int(self.spin_duration.get_value())
         else:
-            self.break_config.pop("duration", None)
+            self.new_break_config.pop("duration", None)
         if self.switch_override_plugins.get_active():
             selected_plugins = []
             for plugin_id in self.plugin_check_buttons:
                 if self.plugin_check_buttons[plugin_id].get_active():
                     selected_plugins.append(plugin_id)
-            self.break_config["plugins"] = selected_plugins
+            self.new_break_config["plugins"] = selected_plugins
         else:
-            self.break_config.pop("plugins", None)
+            self.new_break_config.pop("plugins", None)
 
-        if self.is_short and self.cmb_type.get_active() == 1:
-            # Changed from short to long
-            self.parent_config.get("short_breaks").remove(self.break_config)
-            self.parent_config.get("long_breaks").append(self.break_config)
-            self.on_remove()
-            self.on_add(not self.is_short, self.break_config)
-        elif not self.is_short and self.cmb_type.get_active() == 0:
-            # Changed from long to short
-            self.parent_config.get("long_breaks").remove(self.break_config)
-            self.parent_config.get("short_breaks").append(self.break_config)
-            self.on_remove()
-            self.on_add(not self.is_short, self.break_config)
-        else:
-            self.on_close(self.break_config)
+        new_is_short = self.cmb_type.get_active() == 0
+        self.on_update_break(self.break_item, self.new_break_config, new_is_short)
         self.destroy()
 
     def show(self) -> None:

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -268,9 +268,26 @@ class SettingsDialog(Gtk.ApplicationWindow):
         box.set_visible(True)
         return box
 
+    def __on_update_plugin_config(self, plugin_id: str, new_settings: dict) -> None:
+        index = self.__index_of_plugin(self.config.get("plugins"), plugin_id)
+        # this preserves any settings that are not visible in the ui
+        # and only editable in the json file directly
+        self.config.get("plugins")[index]["settings"].update(new_settings)
+
+    @staticmethod
+    def __index_of_plugin(plugins: list[dict], plugin_id: str) -> int:
+        return list(map(lambda p: p["id"] == plugin_id, plugins)).index(True)
+
     def __show_plugins_properties_dialog(self, plugin_config: dict) -> None:
         """Show the PluginProperties dialog."""
-        dialog = PluginSettingsDialog(self, plugin_config)
+        index = self.__index_of_plugin(self.config.get("plugins"), plugin_config["id"])
+        plugin_settings = self.config.get("plugins")[index]["settings"]
+        dialog = PluginSettingsDialog(
+            self,
+            plugin_config,
+            plugin_settings,
+            on_update_plugin_config=self.__on_update_plugin_config,
+        )
         dialog.show()
 
     def __show_break_properties_dialog(self, break_item: "BreakItem") -> None:
@@ -544,30 +561,36 @@ class PluginSettingsDialog(Gtk.Window):
     __gtype_name__ = "PluginSettingsDialog"
 
     box_settings: Gtk.Box = Gtk.Template.Child()
+    on_update_plugin_config: typing.Callable[[str, dict], None]
 
-    def __init__(self, parent: Gtk.Window, config: typing.Any):
+    plugin_id: str
+
+    def __init__(
+        self,
+        parent: Gtk.Window,
+        config: dict,
+        plugin_settings: dict,
+        on_update_plugin_config: typing.Callable[[str, dict], None],
+    ):
         super().__init__(transient_for=parent)
 
-        self.config = config
+        self.plugin_id = config["id"]
         self.property_controls = []
+        self.on_update_plugin_config = on_update_plugin_config
 
-        for setting in config.get("settings"):
+        for setting in config.get("settings", []):
             box: typing.Union[IntItem, BoolItem, TextItem]
             if setting["type"].upper() == "INT":
                 box = IntItem(
                     setting["label"],
-                    config["active_plugin_config"][setting["id"]],
+                    plugin_settings[setting["id"]],
                     setting.get("min", 0),
                     setting.get("max", 120),
                 )
             elif setting["type"].upper() == "TEXT":
-                box = TextItem(
-                    setting["label"], config["active_plugin_config"][setting["id"]]
-                )
+                box = TextItem(setting["label"], plugin_settings[setting["id"]])
             elif setting["type"].upper() == "BOOL":
-                box = BoolItem(
-                    setting["label"], config["active_plugin_config"][setting["id"]]
-                )
+                box = BoolItem(setting["label"], plugin_settings[setting["id"]])
             else:
                 continue
 
@@ -577,10 +600,10 @@ class PluginSettingsDialog(Gtk.Window):
     @Gtk.Template.Callback()
     def on_window_delete(self, *args) -> None:
         """Event handler for Properties dialog close action."""
+        new_settings = {}
         for property_control in self.property_controls:
-            self.config["active_plugin_config"][property_control["key"]] = (
-                property_control["box"].get_value()
-            )
+            new_settings[property_control["key"]] = property_control["box"].get_value()
+        self.on_update_plugin_config(self.plugin_id, new_settings)
         self.destroy()
 
     def show(self) -> None:

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -80,6 +80,8 @@ class SettingsDialog(Gtk.ApplicationWindow):
     switch_persist: Gtk.Switch = Gtk.Template.Child()
     info_bar_long_break: Gtk.InfoBar = Gtk.Template.Child()
 
+    btn_apply: Gtk.Button = Gtk.Template.Child()
+
     plugin_items: dict[str, "PluginItem"]
     plugin_map: dict[str, str]
     original_config: Config
@@ -113,6 +115,11 @@ class SettingsDialog(Gtk.ApplicationWindow):
 
         self.last_short_break_interval = config.get("short_break_interval")
 
+        # Remove breaks from the container
+        self.__clear_children(self.box_short_breaks)
+        self.__clear_children(self.box_long_breaks)
+        self.__clear_children(self.box_plugins)
+
         for short_break in config.get("short_breaks"):
             self.__create_break_item(short_break, True)
         for long_break in config.get("long_breaks"):
@@ -143,6 +150,8 @@ class SettingsDialog(Gtk.ApplicationWindow):
         self.info_bar_long_break.hide()
         self.infobar_long_break_shown = False
 
+        self.btn_apply.set_sensitive(False)
+
         self.initializing = False
 
     def __create_break_item(self, break_config: dict, is_short: bool) -> None:
@@ -169,10 +178,6 @@ class SettingsDialog(Gtk.ApplicationWindow):
             response_id = dialog.choose_finish(result)
             if response_id == 1:
                 new_config = Config.reset_config()
-                # Remove breaks from the container
-                self.__clear_children(self.box_short_breaks)
-                self.__clear_children(self.box_long_breaks)
-                self.__clear_children(self.box_plugins)
                 # Initialize again
                 self.__initialize(new_config)
 
@@ -223,6 +228,8 @@ class SettingsDialog(Gtk.ApplicationWindow):
             self.config.get("long_breaks").remove(break_item.break_config)
             self.box_long_breaks.remove(break_item)
 
+        self._set_apply_sensitive()
+
     def __update_break(
         self, break_item: "BreakItem", new_break_config: dict, new_is_short: bool
     ) -> None:
@@ -252,6 +259,8 @@ class SettingsDialog(Gtk.ApplicationWindow):
 
         break_item.update_break_name()
 
+        self._set_apply_sensitive()
+
     def __add_break(self, break_config: dict, is_short: bool) -> None:
         self.__create_break_item(break_config, is_short)
 
@@ -259,6 +268,8 @@ class SettingsDialog(Gtk.ApplicationWindow):
             self.config.get("short_breaks").append(break_config)
         else:
             self.config.get("long_breaks").append(break_config)
+
+        self._set_apply_sensitive()
 
     def __create_plugin_item(self, plugin_config: dict) -> "PluginItem":
         """Create an entry for plugin to be listed in the plugin tab."""
@@ -282,11 +293,15 @@ class SettingsDialog(Gtk.ApplicationWindow):
         index = self.__index_of_plugin(self.config.get("plugins"), plugin_id)
         self.config.get("plugins")[index]["enabled"] = active
 
+        self._set_apply_sensitive()
+
     def __on_update_plugin_config(self, plugin_id: str, new_settings: dict) -> None:
         index = self.__index_of_plugin(self.config.get("plugins"), plugin_id)
         # this preserves any settings that are not visible in the ui
         # and only editable in the json file directly
         self.config.get("plugins")[index]["settings"].update(new_settings)
+
+        self._set_apply_sensitive()
 
     @staticmethod
     def __index_of_plugin(plugins: list[dict], plugin_id: str) -> int:
@@ -319,6 +334,9 @@ class SettingsDialog(Gtk.ApplicationWindow):
         """Show the SettingsDialog."""
         self.present()
 
+    def _set_apply_sensitive(self) -> None:
+        self.btn_apply.set_sensitive(self.config != self.original_config)
+
     @Gtk.Template.Callback()
     def on_switch_postpone_activate(self, switch, state) -> None:
         """Event handler to the state change of the postpone switch.
@@ -331,6 +349,7 @@ class SettingsDialog(Gtk.ApplicationWindow):
 
         if not self.initializing:
             self.config.set("allow_postpone", self.switch_postpone.get_active())
+            self._set_apply_sensitive()
 
     @Gtk.Template.Callback()
     def on_dropdown_postpone_unit_selected_item(self, dropdown, _pspec) -> None:
@@ -343,6 +362,7 @@ class SettingsDialog(Gtk.ApplicationWindow):
                     Gtk.StringObject, self.dropdown_postpone_unit.get_selected_item()
                 ).get_string(),
             )
+            self._set_apply_sensitive()
 
     @Gtk.Template.Callback()
     def on_spin_postpone_duration_change(self, spin_button, *value) -> None:
@@ -350,6 +370,7 @@ class SettingsDialog(Gtk.ApplicationWindow):
             self.config.set(
                 "postpone_duration", self.spin_postpone_duration.get_value_as_int()
             )
+            self._set_apply_sensitive()
 
     @Gtk.Template.Callback()
     def on_spin_short_break_interval_change(self, spin_button, *value) -> None:
@@ -377,6 +398,7 @@ class SettingsDialog(Gtk.ApplicationWindow):
             self.config.set(
                 "long_break_interval", self.spin_long_break_interval.get_value_as_int()
             )
+            self._set_apply_sensitive()
 
     @Gtk.Template.Callback()
     def on_spin_short_break_duration_change(self, spin_button, *value) -> None:
@@ -385,6 +407,7 @@ class SettingsDialog(Gtk.ApplicationWindow):
                 "short_break_duration",
                 self.spin_short_break_duration.get_value_as_int(),
             )
+            self._set_apply_sensitive()
 
     @Gtk.Template.Callback()
     def on_spin_long_break_interval_change(self, spin_button, *value) -> None:
@@ -397,6 +420,7 @@ class SettingsDialog(Gtk.ApplicationWindow):
             self.config.set(
                 "long_break_interval", self.spin_long_break_interval.get_value_as_int()
             )
+            self._set_apply_sensitive()
 
     @Gtk.Template.Callback()
     def on_spin_long_break_duration_change(self, spin_button, *value) -> None:
@@ -404,6 +428,7 @@ class SettingsDialog(Gtk.ApplicationWindow):
             self.config.set(
                 "long_break_duration", self.spin_long_break_duration.get_value_as_int()
             )
+            self._set_apply_sensitive()
 
     @Gtk.Template.Callback()
     def on_info_bar_long_break_close(self, infobar, *user_data) -> None:
@@ -416,16 +441,19 @@ class SettingsDialog(Gtk.ApplicationWindow):
             self.config.set(
                 "pre_break_warning_time", self.spin_time_to_prepare.get_value_as_int()
             )
+            self._set_apply_sensitive()
 
     @Gtk.Template.Callback()
     def on_switch_random_order_activated(self, switch, _gparam) -> None:
         if not self.initializing:
             self.config.set("random_order", self.switch_random_order.get_active())
+            self._set_apply_sensitive()
 
     @Gtk.Template.Callback()
     def on_switch_strict_break_activated(self, switch, _gparam) -> None:
         if not self.initializing:
             self.config.set("strict_break", self.switch_strict_break.get_active())
+            self._set_apply_sensitive()
 
     @Gtk.Template.Callback()
     def on_spin_shortcut_disable_time_change(self, spin_button, *value) -> None:
@@ -434,11 +462,13 @@ class SettingsDialog(Gtk.ApplicationWindow):
                 "shortcut_disable_time",
                 self.spin_disable_keyboard_shortcut.get_value_as_int(),
             )
+            self._set_apply_sensitive()
 
     @Gtk.Template.Callback()
     def on_switch_persist_state_activated(self, switch, _gparam) -> None:
         if not self.initializing:
             self.config.set("persist_state", self.switch_persist.get_active())
+            self._set_apply_sensitive()
 
     @Gtk.Template.Callback()
     def add_break(self, button) -> None:
@@ -457,6 +487,13 @@ class SettingsDialog(Gtk.ApplicationWindow):
         self.on_close()
 
         self.destroy()
+
+    @Gtk.Template.Callback()
+    def on_apply_clicked(self, *args) -> None:
+        if self.config != self.original_config:
+            self.on_save_settings(self.config)  # Call the provided save method
+
+        self.__initialize(self.config)
 
     @Gtk.Template.Callback()
     def on_cancel_clicked(self, *args) -> None:

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -450,14 +450,56 @@ class SettingsDialog(Gtk.ApplicationWindow):
         dialog.show()
 
     @Gtk.Template.Callback()
-    def on_window_delete(self, *args) -> None:
-        """Event handler for Settings dialog close action."""
+    def on_ok_clicked(self, *args) -> None:
         if self.config != self.original_config:
             self.on_save_settings(self.config)  # Call the provided save method
 
         self.on_close()
 
         self.destroy()
+
+    @Gtk.Template.Callback()
+    def on_cancel_clicked(self, *args) -> None:
+        # Should we ask here for confirmation to discard if there are changes?
+        self.on_close()
+
+        self.destroy()
+
+    @Gtk.Template.Callback()
+    def on_window_delete(self, *args) -> bool:
+        """Called when the close button in the title bar is clicked."""
+        if self.config == self.original_config:
+            # No changes, just close the window
+            self.on_close()
+            self.destroy()
+            return False
+
+        def __confirmation_dialog_response(dialog, result) -> None:
+            response_id = dialog.choose_finish(result)
+            if response_id == 0:  # Save
+                self.on_save_settings(self.config)  # Call the provided save method
+                self.on_close()
+                self.destroy()
+            elif response_id == 1:  # Discard
+                self.on_close()
+                self.destroy()
+            elif response_id == 2:  # Keep editing
+                pass
+
+        messagedialog = Gtk.AlertDialog()
+        messagedialog.set_modal(True)
+        messagedialog.set_buttons([_("Save"), _("Discard"), _("Keep editing")])
+        messagedialog.set_message(
+            _("There are unsaved changes. Do you want to save them?")
+        )
+
+        messagedialog.set_cancel_button(0)
+        messagedialog.set_default_button(0)
+
+        messagedialog.choose(self, None, __confirmation_dialog_response)
+
+        # This cancels the close request
+        return True
 
 
 @Gtk.Template(filename=SETTINGS_BREAK_ITEM_GLADE)

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -156,11 +156,7 @@ class SettingsDialog(Gtk.ApplicationWindow):
                 ),
                 on_remove=lambda: parent_box.remove(box),
             ),
-            on_delete=lambda: self.__delete_break(
-                break_config,
-                is_short,
-                lambda: parent_box.remove(box),
-            ),
+            on_delete=self.__request_delete_break,
         )
 
         box.set_visible(True)
@@ -198,19 +194,13 @@ class SettingsDialog(Gtk.ApplicationWindow):
         while (child := widget.get_last_child()) is not None:
             widget.remove(child)
 
-    def __delete_break(
-        self, break_config: dict, is_short: bool, on_remove: typing.Callable[[], None]
-    ) -> None:
+    def __request_delete_break(self, break_item: "BreakItem") -> None:
         """Remove the break after a confirmation."""
 
         def __confirmation_dialog_response(dialog, result) -> None:
             response_id = dialog.choose_finish(result)
             if response_id == 1:
-                if is_short:
-                    self.config.get("short_breaks").remove(break_config)
-                else:
-                    self.config.get("long_breaks").remove(break_config)
-                on_remove()
+                self.__delete_break(break_item)
 
         messagedialog = Gtk.AlertDialog()
         messagedialog.set_modal(True)
@@ -222,6 +212,17 @@ class SettingsDialog(Gtk.ApplicationWindow):
         messagedialog.set_default_button(0)
 
         messagedialog.choose(self, None, __confirmation_dialog_response)
+
+    def __delete_break(
+        self,
+        break_item: "BreakItem",
+    ) -> None:
+        if break_item.is_short:
+            self.config.get("short_breaks").remove(break_item.break_config)
+            self.box_short_breaks.remove(break_item)
+        else:
+            self.config.get("long_breaks").remove(break_item.break_config)
+            self.box_long_breaks.remove(break_item)
 
     def __create_plugin_item(self, plugin_config: dict) -> "PluginItem":
         """Create an entry for plugin to be listed in the plugin tab."""
@@ -382,7 +383,7 @@ class BreakItem(Gtk.Box):
         break_config: dict,
         is_short: bool,
         on_properties: typing.Callable[[], None],
-        on_delete: typing.Callable[[], None],
+        on_delete: typing.Callable[["BreakItem"], None],
     ):
         super().__init__()
 
@@ -403,7 +404,7 @@ class BreakItem(Gtk.Box):
 
     @Gtk.Template.Callback()
     def on_delete_clicked(self, button) -> None:
-        self.on_delete()
+        self.on_delete(self)
 
 
 @Gtk.Template(filename=SETTINGS_PLUGIN_ITEM_GLADE)

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -96,20 +96,15 @@ class SettingsDialog(Gtk.ApplicationWindow):
         self.on_save_settings = on_save_settings
         self.plugin_items = {}
         self.plugin_map = {}
-        self.last_short_break_interval = config.get("short_break_interval")
-        self.initializing = True
-        self.infobar_long_break_shown = False
-
-        self.info_bar_long_break.hide()
 
         # Set the current values of input fields
         self.__initialize(config)
 
-        self.initializing = False
-
     def __initialize(self, config: Config) -> None:
-        # Don't show infobar for changes made internally
-        self.infobar_long_break_shown = True
+        self.initializing = True
+
+        self.last_short_break_interval = config.get("short_break_interval")
+
         for short_break in config.get("short_breaks"):
             self.__create_break_item(short_break, True)
         for long_break in config.get("long_breaks"):
@@ -136,7 +131,11 @@ class SettingsDialog(Gtk.ApplicationWindow):
         self.switch_random_order.set_active(config.get("random_order"))
         self.switch_postpone.set_active(config.get("allow_postpone"))
         self.switch_persist.set_active(config.get("persist_state"))
+
+        self.info_bar_long_break.hide()
         self.infobar_long_break_shown = False
+
+        self.initializing = False
 
     def __create_break_item(self, break_config: dict, is_short: bool) -> None:
         """Create an entry for break to be listed in the break tab."""
@@ -258,6 +257,9 @@ class SettingsDialog(Gtk.ApplicationWindow):
         box = PluginItem(
             plugin_config,
             on_properties=lambda: self.__show_plugins_properties_dialog(plugin_config),
+            on_plugin_enabled_changed=lambda active: self._on_plugin_enabled_changed(
+                plugin_config["id"], active
+            ),
         )
 
         self.plugin_items[plugin_config["id"]] = box
@@ -267,6 +269,10 @@ class SettingsDialog(Gtk.ApplicationWindow):
 
         box.set_visible(True)
         return box
+
+    def _on_plugin_enabled_changed(self, plugin_id: str, active: bool) -> None:
+        index = self.__index_of_plugin(self.config.get("plugins"), plugin_id)
+        self.config.get("plugins")[index]["enabled"] = active
 
     def __on_update_plugin_config(self, plugin_id: str, new_settings: dict) -> None:
         index = self.__index_of_plugin(self.config.get("plugins"), plugin_id)
@@ -315,6 +321,28 @@ class SettingsDialog(Gtk.ApplicationWindow):
         self.spin_postpone_duration.set_sensitive(self.switch_postpone.get_active())
         self.dropdown_postpone_unit.set_sensitive(self.switch_postpone.get_active())
 
+        if not self.initializing:
+            self.config.set("allow_postpone", self.switch_postpone.get_active())
+
+    @Gtk.Template.Callback()
+    def on_dropdown_postpone_unit_selected_item(self, dropdown, _pspec) -> None:
+        if not self.initializing:
+            self.config.set(
+                "postpone_unit",
+                # the model is a GtkStringList - so get_selected_item will return a
+                # StringObject
+                typing.cast(
+                    Gtk.StringObject, self.dropdown_postpone_unit.get_selected_item()
+                ).get_string(),
+            )
+
+    @Gtk.Template.Callback()
+    def on_spin_postpone_duration_change(self, spin_button, *value) -> None:
+        if not self.initializing:
+            self.config.set(
+                "postpone_duration", self.spin_postpone_duration.get_value_as_int()
+            )
+
     @Gtk.Template.Callback()
     def on_spin_short_break_interval_change(self, spin_button, *value) -> None:
         """Event handler for value change of short break interval."""
@@ -333,6 +361,23 @@ class SettingsDialog(Gtk.ApplicationWindow):
             self.infobar_long_break_shown = True
             self.info_bar_long_break.show()
 
+        if not self.initializing:
+            self.config.set(
+                "short_break_interval",
+                self.spin_short_break_interval.get_value_as_int(),
+            )
+            self.config.set(
+                "long_break_interval", self.spin_long_break_interval.get_value_as_int()
+            )
+
+    @Gtk.Template.Callback()
+    def on_spin_short_break_duration_change(self, spin_button, *value) -> None:
+        if not self.initializing:
+            self.config.set(
+                "short_break_duration",
+                self.spin_short_break_duration.get_value_as_int(),
+            )
+
     @Gtk.Template.Callback()
     def on_spin_long_break_interval_change(self, spin_button, *value) -> None:
         """Event handler for value change of long break interval."""
@@ -340,10 +385,52 @@ class SettingsDialog(Gtk.ApplicationWindow):
             self.infobar_long_break_shown = True
             self.info_bar_long_break.show()
 
+        if not self.initializing:
+            self.config.set(
+                "long_break_interval", self.spin_long_break_interval.get_value_as_int()
+            )
+
+    @Gtk.Template.Callback()
+    def on_spin_long_break_duration_change(self, spin_button, *value) -> None:
+        if not self.initializing:
+            self.config.set(
+                "long_break_duration", self.spin_long_break_duration.get_value_as_int()
+            )
+
     @Gtk.Template.Callback()
     def on_info_bar_long_break_close(self, infobar, *user_data) -> None:
         """Event handler for info bar close action."""
         self.info_bar_long_break.hide()
+
+    @Gtk.Template.Callback()
+    def on_spin_time_to_prepare_change(self, spin_button, *value) -> None:
+        if not self.initializing:
+            self.config.set(
+                "pre_break_warning_time", self.spin_time_to_prepare.get_value_as_int()
+            )
+
+    @Gtk.Template.Callback()
+    def on_switch_random_order_activated(self, switch, _gparam) -> None:
+        if not self.initializing:
+            self.config.set("random_order", self.switch_random_order.get_active())
+
+    @Gtk.Template.Callback()
+    def on_switch_strict_break_activated(self, switch, _gparam) -> None:
+        if not self.initializing:
+            self.config.set("strict_break", self.switch_strict_break.get_active())
+
+    @Gtk.Template.Callback()
+    def on_spin_shortcut_disable_time_change(self, spin_button, *value) -> None:
+        if not self.initializing:
+            self.config.set(
+                "shortcut_disable_time",
+                self.spin_disable_keyboard_shortcut.get_value_as_int(),
+            )
+
+    @Gtk.Template.Callback()
+    def on_switch_persist_state_activated(self, switch, _gparam) -> None:
+        if not self.initializing:
+            self.config.set("persist_state", self.switch_persist.get_active())
 
     @Gtk.Template.Callback()
     def add_break(self, button) -> None:
@@ -357,44 +444,6 @@ class SettingsDialog(Gtk.ApplicationWindow):
     @Gtk.Template.Callback()
     def on_window_delete(self, *args) -> None:
         """Event handler for Settings dialog close action."""
-        self.config.set(
-            "short_break_duration", self.spin_short_break_duration.get_value_as_int()
-        )
-        self.config.set(
-            "long_break_duration", self.spin_long_break_duration.get_value_as_int()
-        )
-        self.config.set(
-            "short_break_interval", self.spin_short_break_interval.get_value_as_int()
-        )
-        self.config.set(
-            "long_break_interval", self.spin_long_break_interval.get_value_as_int()
-        )
-        self.config.set(
-            "pre_break_warning_time", self.spin_time_to_prepare.get_value_as_int()
-        )
-        self.config.set(
-            "postpone_duration", self.spin_postpone_duration.get_value_as_int()
-        )
-        self.config.set(
-            "postpone_unit",
-            # the model is a GtkStringList - so get_selected_item will return a
-            # StringObject
-            typing.cast(
-                Gtk.StringObject, self.dropdown_postpone_unit.get_selected_item()
-            ).get_string(),
-        )
-        self.config.set(
-            "shortcut_disable_time",
-            self.spin_disable_keyboard_shortcut.get_value_as_int(),
-        )
-        self.config.set("strict_break", self.switch_strict_break.get_active())
-        self.config.set("random_order", self.switch_random_order.get_active())
-        self.config.set("allow_postpone", self.switch_postpone.get_active())
-        self.config.set("persist_state", self.switch_persist.get_active())
-        for plugin in self.config.get("plugins"):
-            if plugin["id"] in self.plugin_items:
-                plugin["enabled"] = self.plugin_items[plugin["id"]].is_enabled()
-
         self.on_save_settings(self.config)  # Call the provided save method
         self.destroy()
 
@@ -450,11 +499,19 @@ class PluginItem(Gtk.Box):
     btn_disable_errored: Gtk.Button = Gtk.Template.Child()
     btn_plugin_extra_link: Gtk.LinkButton = Gtk.Template.Child()
     img_plugin_icon: Gtk.Image = Gtk.Template.Child()
+    on_properties: typing.Callable[[], None]
+    on_plugin_enabled_changed: typing.Callable[[bool], None]
 
-    def __init__(self, plugin_config: dict, on_properties: typing.Callable[[], None]):
+    def __init__(
+        self,
+        plugin_config: dict,
+        on_properties: typing.Callable[[], None],
+        on_plugin_enabled_changed: typing.Callable[[bool], None],
+    ):
         super().__init__()
 
         self.on_properties = on_properties
+        self.on_plugin_enabled_changed = on_plugin_enabled_changed
         self.plugin_config = plugin_config
 
         self.lbl_plugin_name.set_label(_(plugin_config["meta"]["name"]))
@@ -487,8 +544,9 @@ class PluginItem(Gtk.Box):
         if plugin_config["icon"]:
             self.img_plugin_icon.set_from_file(plugin_config["icon"])
 
-    def is_enabled(self) -> bool:
-        return self.switch_enable.get_active()
+    @Gtk.Template.Callback()
+    def on_switch_enable_activated(self, switch, _pspec) -> None:
+        self.on_plugin_enabled_changed(self.switch_enable.get_active())
 
     @Gtk.Template.Callback()
     def on_disable_errored(self, button) -> None:

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -245,6 +245,14 @@ class SettingsDialog(Gtk.ApplicationWindow):
 
         break_item.update_break_name()
 
+    def __add_break(self, break_config: dict, is_short: bool) -> None:
+        self.__create_break_item(break_config, is_short)
+
+        if is_short:
+            self.config.get("short_breaks").append(break_config)
+        else:
+            self.config.get("long_breaks").append(break_config)
+
     def __create_plugin_item(self, plugin_config: dict) -> "PluginItem":
         """Create an entry for plugin to be listed in the plugin tab."""
         box = PluginItem(
@@ -325,10 +333,7 @@ class SettingsDialog(Gtk.ApplicationWindow):
         """Event handler for add break button."""
         dialog = NewBreakDialog(
             self,
-            self.config,
-            lambda is_short, break_config: self.__create_break_item(
-                break_config, is_short
-            ),
+            on_add=self.__add_break,
         )
         dialog.show()
 
@@ -775,15 +780,15 @@ class NewBreakDialog(Gtk.Window):
     txt_break: Gtk.Entry = Gtk.Template.Child()
     cmb_type: Gtk.ComboBox = Gtk.Template.Child()
 
+    on_add: typing.Callable[[dict, bool], None]
+
     def __init__(
         self,
         parent: Gtk.Window,
-        parent_config: Config,
-        on_add: typing.Callable[[bool, dict], None],
+        on_add: typing.Callable[[dict, bool], None],
     ):
         super().__init__(transient_for=parent)
 
-        self.parent_config = parent_config
         self.on_add = on_add
 
     @Gtk.Template.Callback()
@@ -796,12 +801,7 @@ class NewBreakDialog(Gtk.Window):
         """Event handler for Properties dialog close action."""
         break_config = {"name": self.txt_break.get_text().strip()}
 
-        if self.cmb_type.get_active() == 0:
-            self.parent_config.get("short_breaks").append(break_config)
-            self.on_add(True, break_config)
-        else:
-            self.parent_config.get("long_breaks").append(break_config)
-            self.on_add(False, break_config)
+        self.on_add(break_config, self.cmb_type.get_active() == 0)
         self.destroy()
 
     @Gtk.Template.Callback()

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -144,7 +144,8 @@ class SettingsDialog(Gtk.ApplicationWindow):
             parent_box = self.box_short_breaks
 
         box: "BreakItem" = BreakItem(
-            break_name=break_config["name"],
+            break_config,
+            is_short,
             on_properties=lambda: self.__show_break_properties_dialog(
                 break_config,
                 is_short,
@@ -369,20 +370,29 @@ class SettingsDialog(Gtk.ApplicationWindow):
 class BreakItem(Gtk.Box):
     __gtype_name__ = "BreakItem"
 
+    # These are intentionally public - they are accessed by BreakSettingsDialog
+    break_config: dict
+    is_short: bool
+
+    # These are just public because the template needs them
     lbl_name: Gtk.Label = Gtk.Template.Child()
 
     def __init__(
         self,
-        break_name: str,
+        break_config: dict,
+        is_short: bool,
         on_properties: typing.Callable[[], None],
         on_delete: typing.Callable[[], None],
     ):
         super().__init__()
 
+        self.break_config = break_config
+        self.is_short = is_short
+
         self.on_properties = on_properties
         self.on_delete = on_delete
 
-        self.lbl_name.set_label(_(break_name))
+        self.lbl_name.set_label(_(break_config["name"]))
 
     def set_break_name(self, break_name: str) -> None:
         self.lbl_name.set_label(_(break_name))

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -82,18 +82,23 @@ class SettingsDialog(Gtk.ApplicationWindow):
 
     plugin_items: dict[str, "PluginItem"]
     plugin_map: dict[str, str]
+    original_config: Config
     config: Config
+
+    on_save_settings: typing.Callable[[Config], None]
+    on_close: typing.Callable[[], None]
 
     def __init__(
         self,
         application: Gtk.Application,
         config: Config,
         on_save_settings: typing.Callable[[Config], None],
+        on_close: typing.Callable[[], None],
     ):
         super().__init__(application=application)
 
-        self.config = config
         self.on_save_settings = on_save_settings
+        self.on_close = on_close
         self.plugin_items = {}
         self.plugin_map = {}
 
@@ -102,6 +107,9 @@ class SettingsDialog(Gtk.ApplicationWindow):
 
     def __initialize(self, config: Config) -> None:
         self.initializing = True
+
+        self.original_config = config
+        self.config = config.clone()
 
         self.last_short_break_interval = config.get("short_break_interval")
 
@@ -160,13 +168,13 @@ class SettingsDialog(Gtk.ApplicationWindow):
         def __confirmation_dialog_response(dialog, result) -> None:
             response_id = dialog.choose_finish(result)
             if response_id == 1:
-                self.config = Config.reset_config()
+                new_config = Config.reset_config()
                 # Remove breaks from the container
                 self.__clear_children(self.box_short_breaks)
                 self.__clear_children(self.box_long_breaks)
                 self.__clear_children(self.box_plugins)
                 # Initialize again
-                self.__initialize(self.config)
+                self.__initialize(new_config)
 
         messagedialog = Gtk.AlertDialog()
         messagedialog.set_modal(True)
@@ -444,7 +452,11 @@ class SettingsDialog(Gtk.ApplicationWindow):
     @Gtk.Template.Callback()
     def on_window_delete(self, *args) -> None:
         """Event handler for Settings dialog close action."""
-        self.on_save_settings(self.config)  # Call the provided save method
+        if self.config != self.original_config:
+            self.on_save_settings(self.config)  # Call the provided save method
+
+        self.on_close()
+
         self.destroy()
 
 

--- a/safeeyes/utility.py
+++ b/safeeyes/utility.py
@@ -270,7 +270,6 @@ def load_plugins_config(safeeyes_config):
         config["id"] = plugin["id"]
         config["icon"] = icon
         config["enabled"] = plugin["enabled"]
-        config["active_plugin_config"] = plugin.get("settings")
 
         configs.append(config)
     return configs


### PR DESCRIPTION
## Description

This PR adds an OK, Apply and Cancel button to the settings dialog.
The Apply button is only sensitive/clickable if there are changes, which the dialog now tracks.
When closing the dialog using the close button while there are unsaved changes, there is now a popup asking whether they should be saved or discarded.

This all makes the dialog more intuitive, in my opinion. It makes it more clear when changes are being saved, and allows the user to undo effectively undo changes (by clicking Cancel instead of OK/Apply).

This PR also does quite a bit of refactoring to the settings dialog to enable the change tracking in the first place. Please let me know if I should split those refactorings into a separate PR.

This PR is best reviewed commit by commit.

<img width="689" height="679" alt="image" src="https://github.com/user-attachments/assets/61ad14d6-6f68-438c-9d5d-7f810dec0e25" />
