### PR TITLE
Add option to skip system shortcuts inhibition on Wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ You can install with `pip`
 ```bash
 pip3 install --user safeeyes
 ```
-For smartpause in Wayland, install the `python3-pywayland` package (in case the installer does not automatically install it as a dependency). For smart pause plugin in X11, you may have to install the latest xprintidle from: [alonid/xprintidle](https://copr.fedorainfracloud.org/coprs/alonid/xprintidle/).
+For smartpause in Wayland, install the `python3-pywayland` package (in case the installer does not automatically install it as a dependency). If you are using sway, install `swayidle` instead. For smart pause plugin in X11, you may have to install the latest xprintidle from: [alonid/xprintidle](https://copr.fedorainfracloud.org/coprs/alonid/xprintidle/).
 
 Alternatively, use the [Flatpak version](https://github.com/slgobinath/safeeyes?tab=readme-ov-file#flatpak), which comes preinstalls with dependencies and features automatic updates.
 
@@ -133,7 +133,7 @@ Ensure to meet the following dependencies:
 - `python3-croniter`
 - `python3-packaging`
 - `python3-xlib` (required on x11)
-- **Optional**: Either `python3-pywayland` (provides smartpause in Wayland) or `xprintidle` (provides smartpause in x11).
+- **Optional**: Either `python3-pywayland` (provides smartpause on Wayland), `swayidle` (provides smartpause on sway), or `xprintidle` (provides smartpause on x11).
 
 **To install Safe Eyes from PyPI:**
 
@@ -159,7 +159,7 @@ Note that on Wayland, this may still not be enough to get window icons working p
 
 On Wayland, Safe Eyes calls `inhibit_system_shortcuts` while a break is showing, so that system-level shortcuts (e.g. Alt+Tab or the Super key) do not interfere with the break. Depending on the compositor (notably GNOME), this can trigger a permission dialog every time a break starts. GNOME does not support remembering this permission persistently (the [related issue](https://gitlab.gnome.org/GNOME/gnome-connections/-/work_items/85) has been open since 2021), so Safe Eyes offers an option to skip requesting it entirely.
 
-To avoid that, set `skip_system_shortcuts_inhibition` to `true` in `~/.config/safeeyes/safeeyes.json` (it defaults to `false`), or enable the "Suppress GNOME shortcut permission dialog" switch in the Plugins section of the settings dialog (this option is only shown on Wayland). With it enabled, Safe Eyes will not request shortcut inhibition: system shortcuts stay active during breaks, while the break screen's own skip/postpone shortcuts keep working. This setting only affects Wayland; on X11 the keyboard is handled differently and is not affected.
+To avoid that, set `skip_system_shortcuts_inhibition` to `true` in `~/.config/safeeyes/safeeyes.json` (it defaults to `false`), or enable the "Suppress GNOME shortcut permission dialog" switch in the Plugins section of the settings dialog (this switch is only shown on GNOME Wayland; other Wayland compositors such as KWin or sway grant shortcut inhibition silently, so you can still set the option manually in the config file if you want to skip it there as well). With it enabled, Safe Eyes will not request shortcut inhibition: system shortcuts stay active during breaks, while the break screen's own skip/postpone shortcuts keep working. This setting only affects Wayland; on X11 the keyboard is handled differently and is not affected.
 
 
 ### Install in a virtual environment

--- a/README.md
+++ b/README.md
@@ -155,6 +155,12 @@ Safe Eyes installers install the required icons to `/usr/share/icons/hicolor`. W
 
 Note that on Wayland, this may still not be enough to get window icons working properly, as Wayland requires the .desktop file to match the running application, which is hard to do when running from source. If at all possible, prefer using an installed package.
 
+#### Wayland and system shortcuts during breaks
+
+On Wayland, Safe Eyes calls `inhibit_system_shortcuts` while a break is showing, so that system-level shortcuts (e.g. Alt+Tab or the Super key) do not interfere with the break. Depending on the compositor (notably GNOME), this can trigger a permission dialog every time a break starts. GNOME does not support remembering this permission persistently (the [related issue](https://gitlab.gnome.org/GNOME/gnome-connections/-/work_items/85) has been open since 2021), so Safe Eyes offers an option to skip requesting it entirely.
+
+To avoid that, set `skip_system_shortcuts_inhibition` to `true` in `~/.config/safeeyes/safeeyes.json` (it defaults to `false`), or enable the "Suppress GNOME shortcut permission dialog" switch in the Plugins section of the settings dialog (this option is only shown on Wayland). With it enabled, Safe Eyes will not request shortcut inhibition: system shortcuts stay active during breaks, while the break screen's own skip/postpone shortcuts keep working. This setting only affects Wayland; on X11 the keyboard is handled differently and is not affected.
+
 
 ### Install in a virtual environment
 

--- a/safeeyes/config/locale/ar/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/ar/LC_MESSAGES/safeeyes.po
@@ -662,6 +662,10 @@ msgstr ""
 msgid "Fade in duration (in milliseconds)"
 msgstr ""
 
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
 # Commandline arg description
 #~ msgid "print the status of running safeeyes instance and exit"
 #~ msgstr "أظهر حالة برنامج Safe Eyes المشتغل حاليا و أخرج"

--- a/safeeyes/config/locale/bg/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/bg/LC_MESSAGES/safeeyes.po
@@ -642,6 +642,10 @@ msgstr ""
 msgid "Fade in duration (in milliseconds)"
 msgstr ""
 
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
 # Short break
 #~ msgid "Tightly close your eyes"
 #~ msgstr "Затворете плътно очи"

--- a/safeeyes/config/locale/bn/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/bn/LC_MESSAGES/safeeyes.po
@@ -649,6 +649,10 @@ msgstr "আস্তে আস্তে বিরতি ফুটে উঠু�
 msgid "Fade in duration (in milliseconds)"
 msgstr "ফুটে ওঠার সময় (মিলিসেকেন্ডে)"
 
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
 # Commandline arg description
 #~ msgid "print the status of running safeeyes instance and exit"
 #~ msgstr "চলমান Safe Eyes-এর অবস্থা দেখিয়ে বেরিয়ে যান"

--- a/safeeyes/config/locale/bn_IN/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/bn_IN/LC_MESSAGES/safeeyes.po
@@ -649,6 +649,10 @@ msgstr "আস্তে আস্তে বিরতি ফুটে উঠু�
 msgid "Fade in duration (in milliseconds)"
 msgstr "ফুটে ওঠার সময় (মিলিসেকেন্ডে)"
 
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
 # Commandline arg description
 #~ msgid "print the status of running safeeyes instance and exit"
 #~ msgstr "চলমান Safe Eyes-এর অবস্থা দেখিয়ে বেরিয়ে যান"

--- a/safeeyes/config/locale/ca/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/ca/LC_MESSAGES/safeeyes.po
@@ -654,6 +654,10 @@ msgstr ""
 msgid "Fade in duration (in milliseconds)"
 msgstr ""
 
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
 # Commandline arg description
 #~ msgid "print the status of running safeeyes instance and exit"
 #~ msgstr "Mostra l'estat de la instància de Safe Eyes en funcionament i surt"

--- a/safeeyes/config/locale/cs/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/cs/LC_MESSAGES/safeeyes.po
@@ -658,6 +658,10 @@ msgstr "Postupné ztmavování při začátku přestávek"
 msgid "Fade in duration (in milliseconds)"
 msgstr "Doba ztmavování (v milisekundách)"
 
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
 # Commandline arg description
 #~ msgid "print the status of running safeeyes instance and exit"
 #~ msgstr "Popis argumentu příkazového řádku"

--- a/safeeyes/config/locale/da/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/da/LC_MESSAGES/safeeyes.po
@@ -643,6 +643,10 @@ msgstr ""
 msgid "Fade in duration (in milliseconds)"
 msgstr ""
 
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
 # Commandline arg description
 #~ msgid "print the status of running safeeyes instance and exit"
 #~ msgstr "print status for at køre Safe Eyes instans og afslut"

--- a/safeeyes/config/locale/de/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/de/LC_MESSAGES/safeeyes.po
@@ -664,6 +664,10 @@ msgstr ""
 msgid "Fade in duration (in milliseconds)"
 msgstr ""
 
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
 # Commandline arg description
 #~ msgid "print the status of running safeeyes instance and exit"
 #~ msgstr "Status der laufenden Safe Eyes-Instanz ausgeben und beenden"

--- a/safeeyes/config/locale/eo/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/eo/LC_MESSAGES/safeeyes.po
@@ -645,6 +645,10 @@ msgstr ""
 msgid "Fade in duration (in milliseconds)"
 msgstr ""
 
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
 # Commandline arg description
 #~ msgid "print the status of running safeeyes instance and exit"
 #~ msgstr "montri la staton de la rulanta apero de Safe Eyes kaj eliri"

--- a/safeeyes/config/locale/es/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/es/LC_MESSAGES/safeeyes.po
@@ -655,6 +655,10 @@ msgstr ""
 msgid "Fade in duration (in milliseconds)"
 msgstr ""
 
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
 # Commandline arg description
 #~ msgid "print the status of running safeeyes instance and exit"
 #~ msgstr "mostrar el estado del ejemplar de Safe Eyes en ejecución y salir"

--- a/safeeyes/config/locale/et/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/et/LC_MESSAGES/safeeyes.po
@@ -654,6 +654,10 @@ msgstr "Puhepausi alates ristsulata rakenduse vaade"
 msgid "Fade in duration (in milliseconds)"
 msgstr "Ristsulatuse kestus (millisekundites)"
 
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
 # Commandline arg description
 #~ msgid "print the status of running safeeyes instance and exit"
 #~ msgstr "väljasta hetkel töötava Safe Eyes instantsi staatus ja välju"

--- a/safeeyes/config/locale/eu/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/eu/LC_MESSAGES/safeeyes.po
@@ -648,6 +648,10 @@ msgstr ""
 msgid "Fade in duration (in milliseconds)"
 msgstr ""
 
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
 # Commandline arg description
 #~ msgid "print the status of running safeeyes instance and exit"
 #~ msgstr "inprimatu uneko Safe Eyes instantziaren egoera eta irten"

--- a/safeeyes/config/locale/fa/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/fa/LC_MESSAGES/safeeyes.po
@@ -646,6 +646,10 @@ msgstr ""
 msgid "Fade in duration (in milliseconds)"
 msgstr ""
 
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
 # Commandline arg description
 #~ msgid "print the status of running safeeyes instance and exit"
 #~ msgstr "چاپ وضعیت نمونهٔ محافظ چشم در جال اجرا و خروج"

--- a/safeeyes/config/locale/fi/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/fi/LC_MESSAGES/safeeyes.po
@@ -629,3 +629,7 @@ msgstr ""
 
 msgid "Fade in duration (in milliseconds)"
 msgstr ""
+
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""

--- a/safeeyes/config/locale/fr/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/fr/LC_MESSAGES/safeeyes.po
@@ -688,3 +688,7 @@ msgstr "Durée du fondu (en millisecondes)"
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "Fréquence de réinitialisation (en heures)"
+
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""

--- a/safeeyes/config/locale/he/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/he/LC_MESSAGES/safeeyes.po
@@ -648,6 +648,10 @@ msgstr "כניסה הדרגתית למסך ההפסקה בעת התחלתה"
 msgid "Fade in duration (in milliseconds)"
 msgstr "משך זמן עמעום (במילישניות)"
 
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
 # Commandline arg description
 #~ msgid "print the status of running safeeyes instance and exit"
 #~ msgstr "print the status of running Safe Eyes instance and exit"

--- a/safeeyes/config/locale/hi/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/hi/LC_MESSAGES/safeeyes.po
@@ -642,6 +642,10 @@ msgstr ""
 msgid "Fade in duration (in milliseconds)"
 msgstr ""
 
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
 # Commandline arg description
 #~ msgid "print the status of running safeeyes instance and exit"
 #~ msgstr "सेफ आईज दृष्टांत स्थिति को मुद्रित करें और बाहर निकलें"

--- a/safeeyes/config/locale/hu/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/hu/LC_MESSAGES/safeeyes.po
@@ -644,6 +644,10 @@ msgstr ""
 msgid "Fade in duration (in milliseconds)"
 msgstr ""
 
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
 # Commandline arg description
 #~ msgid "print the status of running safeeyes instance and exit"
 #~ msgstr "futó safeeyes példány állapotának kiírása, majd kilépés"

--- a/safeeyes/config/locale/id/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/id/LC_MESSAGES/safeeyes.po
@@ -655,6 +655,10 @@ msgstr ""
 msgid "Fade in duration (in milliseconds)"
 msgstr ""
 
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
 # Commandline arg description
 #~ msgid "print the status of running safeeyes instance and exit"
 #~ msgstr "cetak status menjalankan instance Safe Eyes dan keluar"

--- a/safeeyes/config/locale/it/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/it/LC_MESSAGES/safeeyes.po
@@ -659,6 +659,10 @@ msgstr "Dissolvenza in entrata all'inizio delle pause"
 msgid "Fade in duration (in milliseconds)"
 msgstr "Durata della dissolvenza in entrata (in millisecondi)"
 
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
 # Commandline arg description
 #~ msgid "print the status of running safeeyes instance and exit"
 #~ msgstr "stampa lo stato di esecuzione di Safe Eyes ed esci"

--- a/safeeyes/config/locale/kn/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/kn/LC_MESSAGES/safeeyes.po
@@ -639,6 +639,10 @@ msgstr ""
 msgid "Fade in duration (in milliseconds)"
 msgstr ""
 
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
 # Commandline arg description
 #~ msgid "print the status of running safeeyes instance and exit"
 #~ msgstr "ಚಾಲನೆಯಲ್ಲಿರುವ ಸೇಫ್ಐಸ್ ಸ್ಥಿತಿಯನ್ನು ಮುದ್ರಿಸಿ ಮತ್ತು ನಿರ್ಗಮಿಸಿ"

--- a/safeeyes/config/locale/ko/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/ko/LC_MESSAGES/safeeyes.po
@@ -639,6 +639,10 @@ msgstr ""
 msgid "Fade in duration (in milliseconds)"
 msgstr ""
 
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
 # Commandline arg description
 #~ msgid "print the status of running safeeyes instance and exit"
 #~ msgstr "실행 중인 세이프아이즈 객체를 종료하고 상태 출력"

--- a/safeeyes/config/locale/lt/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/lt/LC_MESSAGES/safeeyes.po
@@ -684,3 +684,7 @@ msgstr "Laipsniško ryškėjimo trukmė (milisekundėmis)"
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "Statistikos atstatymo intervalas (valandomis)"
+
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""

--- a/safeeyes/config/locale/lv/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/lv/LC_MESSAGES/safeeyes.po
@@ -565,6 +565,10 @@ msgstr ""
 msgid "Fade in duration (in milliseconds)"
 msgstr ""
 
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
 #~ msgid "print the status of running safeeyes instance and exit"
 #~ msgstr "drukāt darbojošās Safe Eyes instances statusu un iziet"
 

--- a/safeeyes/config/locale/mk/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/mk/LC_MESSAGES/safeeyes.po
@@ -643,3 +643,7 @@ msgstr ""
 
 msgid "Fade in duration (in milliseconds)"
 msgstr ""
+
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""

--- a/safeeyes/config/locale/mr/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/mr/LC_MESSAGES/safeeyes.po
@@ -642,6 +642,10 @@ msgstr ""
 msgid "Fade in duration (in milliseconds)"
 msgstr ""
 
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
 # Commandline arg description
 #~ msgid "print the status of running safeeyes instance and exit"
 #~ msgstr "सुरक्षित डोळ्यांची उदाहरणे चालविण्याची स्थिती प्रिंट करा आणि बाहेर पडा"

--- a/safeeyes/config/locale/nb/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/nb/LC_MESSAGES/safeeyes.po
@@ -646,6 +646,10 @@ msgstr ""
 msgid "Fade in duration (in milliseconds)"
 msgstr ""
 
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
 # Commandline arg description
 #~ msgid "print the status of running safeeyes instance and exit"
 #~ msgstr "skriv ut status for kjørende Øyetrygg-instans og avslutt"

--- a/safeeyes/config/locale/nl/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/nl/LC_MESSAGES/safeeyes.po
@@ -660,6 +660,10 @@ msgstr "Vervagingseffect tonen aan begin van pauze"
 msgid "Fade in duration (in milliseconds)"
 msgstr "Vervaagduur (in milliseconden)"
 
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
 # Commandline arg description
 #~ msgid "print the status of running safeeyes instance and exit"
 #~ msgstr "de status van de draaiende Safe Eyes-instantie printen en afsluiten"

--- a/safeeyes/config/locale/pl/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/pl/LC_MESSAGES/safeeyes.po
@@ -660,6 +660,10 @@ msgstr ""
 msgid "Fade in duration (in milliseconds)"
 msgstr ""
 
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
 # Commandline arg description
 #~ msgid "print the status of running safeeyes instance and exit"
 #~ msgstr "wydrukuj status uruchomionej instancji Safe Eyes i zakończ"

--- a/safeeyes/config/locale/pt/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/pt/LC_MESSAGES/safeeyes.po
@@ -653,6 +653,10 @@ msgstr ""
 msgid "Fade in duration (in milliseconds)"
 msgstr ""
 
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
 # Commandline arg description
 #~ msgid "print the status of running safeeyes instance and exit"
 #~ msgstr "mostrar o estado de execução do Safe Eyes e sair"

--- a/safeeyes/config/locale/pt_BR/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/pt_BR/LC_MESSAGES/safeeyes.po
@@ -651,6 +651,10 @@ msgstr ""
 msgid "Fade in duration (in milliseconds)"
 msgstr ""
 
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
 # Commandline arg description
 #~ msgid "print the status of running safeeyes instance and exit"
 #~ msgstr "mostrar o estado de execução do Safe Eyes e sair"

--- a/safeeyes/config/locale/ru/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/ru/LC_MESSAGES/safeeyes.po
@@ -683,3 +683,7 @@ msgstr ""
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "Интервал для сброса статистики (в часах)"
+
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""

--- a/safeeyes/config/locale/safeeyes.pot
+++ b/safeeyes/config/locale/safeeyes.pot
@@ -622,3 +622,7 @@ msgstr ""
 
 msgid "Fade in duration (in milliseconds)"
 msgstr ""
+
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""

--- a/safeeyes/config/locale/sk/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/sk/LC_MESSAGES/safeeyes.po
@@ -652,6 +652,10 @@ msgstr ""
 msgid "Fade in duration (in milliseconds)"
 msgstr ""
 
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
 # Commandline arg description
 #~ msgid "print the status of running safeeyes instance and exit"
 #~ msgstr "vypíše, či Safe Eyes beží a skončí"

--- a/safeeyes/config/locale/sr/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/sr/LC_MESSAGES/safeeyes.po
@@ -670,3 +670,7 @@ msgstr ""
 # Short break
 #~ msgid "Tightly close your eyes"
 #~ msgstr "Чврсто затворите очи"
+
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""

--- a/safeeyes/config/locale/sv/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/sv/LC_MESSAGES/safeeyes.po
@@ -645,6 +645,10 @@ msgid "Fade in duration (in milliseconds)"
 msgstr ""
 
 # Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
+# Settings dialog
 #~ msgid "Keyboard shortcuts disabled period (in seconds)"
 #~ msgstr "Kortkommandon inaktiverad period (i sekunder)"
 

--- a/safeeyes/config/locale/ta/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/ta/LC_MESSAGES/safeeyes.po
@@ -653,6 +653,10 @@ msgid "Fade in duration (in milliseconds)"
 msgstr ""
 
 # Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
+# Settings dialog
 #~ msgid "Keyboard shortcuts disabled period (in seconds)"
 #~ msgstr "விசைப்பலகை குறுக்குவழிகள் முடக்கப்பட்டிருக்கும் காலம் (விநாடிகளில்)"
 

--- a/safeeyes/config/locale/tr/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/tr/LC_MESSAGES/safeeyes.po
@@ -652,6 +652,10 @@ msgid "Fade in duration (in milliseconds)"
 msgstr ""
 
 # Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
+# Settings dialog
 #~ msgid "Keyboard shortcuts disabled period (in seconds)"
 #~ msgstr "Klavye kısayollarının etkisiz kalma süresi (saniye)"
 

--- a/safeeyes/config/locale/ug/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/ug/LC_MESSAGES/safeeyes.po
@@ -637,3 +637,7 @@ msgstr ""
 
 msgid "Fade in duration (in milliseconds)"
 msgstr ""
+
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""

--- a/safeeyes/config/locale/uk/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/uk/LC_MESSAGES/safeeyes.po
@@ -670,3 +670,7 @@ msgstr ""
 # plugin/healthstats
 #~ msgid "Interval to reset statistics (in hours)"
 #~ msgstr "Інтервал скидання статистики (в годинах)"
+
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""

--- a/safeeyes/config/locale/uz_Latn/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/uz_Latn/LC_MESSAGES/safeeyes.po
@@ -637,3 +637,7 @@ msgstr ""
 
 msgid "Fade in duration (in milliseconds)"
 msgstr ""
+
+# Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""

--- a/safeeyes/config/locale/vi/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/vi/LC_MESSAGES/safeeyes.po
@@ -645,6 +645,10 @@ msgid "Fade in duration (in milliseconds)"
 msgstr ""
 
 # Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
+# Settings dialog
 #~ msgid "Keyboard shortcuts disabled period (in seconds)"
 #~ msgstr ""
 #~ "Th.gian khóa phím tắt để tránh tắt nhầm Nhắc nhở khi nó hiện lên (bằng "

--- a/safeeyes/config/locale/zh_CN/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/zh_CN/LC_MESSAGES/safeeyes.po
@@ -644,6 +644,10 @@ msgid "Fade in duration (in milliseconds)"
 msgstr "淡入时长（毫秒）"
 
 # Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
+# Settings dialog
 #~ msgid "Keyboard shortcuts disabled period (in seconds)"
 #~ msgstr "禁用键盘快捷键的时长（秒）"
 

--- a/safeeyes/config/locale/zh_TW/LC_MESSAGES/safeeyes.po
+++ b/safeeyes/config/locale/zh_TW/LC_MESSAGES/safeeyes.po
@@ -644,6 +644,10 @@ msgid "Fade in duration (in milliseconds)"
 msgstr "淡入持續時間 (毫秒)"
 
 # Settings dialog
+msgid "Suppress GNOME shortcut permission dialog"
+msgstr ""
+
+# Settings dialog
 #~ msgid "Keyboard shortcuts disabled period (in seconds)"
 #~ msgstr "鍵盤快速鍵停用期間(秒)"
 

--- a/safeeyes/config/safeeyes.json
+++ b/safeeyes/config/safeeyes.json
@@ -1,6 +1,6 @@
 {
     "meta": {
-        "config_version": "6.0.5"
+        "config_version": "6.0.6"
     },
     "random_order": true,
     "allow_postpone": false,
@@ -18,6 +18,7 @@
     "fade_in_break_screen": true,
     "fade_in_break_screen_duration": 1500,
     "strict_break": false,
+    "skip_system_shortcuts_inhibition": false,
     "short_breaks": [{
             "name": "Gently close your eyes"
         },

--- a/safeeyes/glade/settings_dialog.glade
+++ b/safeeyes/glade/settings_dialog.glade
@@ -707,21 +707,55 @@
             <property name="name">page2</property>
             <property name="title" translatable="yes">Plugins</property>
             <property name="child">
-              <object class="GtkScrolledWindow" id="scrolledwindow_plugins">
+              <object class="GtkBox" id="box_plugins_page">
                 <property name="visible">1</property>
-                <property name="can-focus">1</property>
-                <property name="hscrollbar-policy">never</property>
-                <property name="has-frame">1</property>
+                <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkViewport" id="viewport_plugins">
+                  <object class="GtkScrolledWindow" id="scrolledwindow_plugins">
                     <property name="visible">1</property>
+                    <property name="can-focus">1</property>
+                    <property name="hscrollbar-policy">never</property>
+                    <property name="has-frame">1</property>
+                    <property name="hexpand">1</property>
+                    <property name="vexpand">1</property>
                     <child>
-                      <object class="GtkBox" id="box_plugins">
+                      <object class="GtkViewport" id="viewport_plugins">
                         <property name="visible">1</property>
-                        <property name="margin-top">10</property>
-                        <property name="margin-bottom">10</property>
-                        <property name="orientation">vertical</property>
-                        <property name="spacing">5</property>
+                        <child>
+                          <object class="GtkBox" id="box_plugins">
+                            <property name="visible">1</property>
+                            <property name="margin-top">10</property>
+                            <property name="margin-bottom">10</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">5</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkBox" id="box_skip_shortcut_inhibition">
+                    <property name="visible">1</property>
+                    <property name="margin-start">5</property>
+                    <property name="margin-end">5</property>
+                    <property name="margin-top">10</property>
+                    <property name="margin-bottom">10</property>
+                    <property name="spacing">5</property>
+                    <property name="homogeneous">1</property>
+                    <child>
+                      <object class="GtkLabel" id="lbl_skip_shortcut_inhibition">
+                        <property name="visible">1</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">Suppress GNOME shortcut permission dialog</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkSwitch" id="switch_skip_shortcut_inhibition">
+                        <property name="visible">1</property>
+                        <property name="can-focus">1</property>
+                        <property name="halign">end</property>
+                        <property name="valign">center</property>
                       </object>
                     </child>
                   </object>

--- a/safeeyes/tests/test_configuration.py
+++ b/safeeyes/tests/test_configuration.py
@@ -1,0 +1,121 @@
+# Safe Eyes is a utility to remind you to take break frequently
+# to protect your eyes from eye strain.
+
+# Copyright (C) 2017  Gobinath
+# Copyright (C) 2026  Mel Dafert <m@dafert.at>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+import pathlib
+import pytest
+
+from safeeyes import configuration
+from safeeyes import utility
+
+
+class TestConfigLoad:
+    """Test Config.load() and the config_version-based merge mechanism."""
+
+    def write_config(self, tmp_path: pathlib.Path, filename: str, config: dict) -> str:
+        config_path = tmp_path / filename
+        config_path.write_text(json.dumps(config))
+        return str(config_path)
+
+    @staticmethod
+    def _noop_create_startup_entry(cls, force=False):
+        return None
+
+    def mock_config_paths(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: pathlib.Path,
+        user_config: dict,
+        system_config: dict,
+    ) -> None:
+        user_path = self.write_config(tmp_path, "user_config.json", user_config)
+        system_path = self.write_config(tmp_path, "system_config.json", system_config)
+
+        monkeypatch.setattr(utility, "CONFIG_FILE_PATH", user_path)
+        monkeypatch.setattr(utility, "SYSTEM_CONFIG_FILE_PATH", system_path)
+
+        # Avoid touching the real plugin directories and the autostart entry.
+        monkeypatch.setattr(utility, "merge_plugins", lambda config: None)
+        monkeypatch.setattr(
+            configuration.Config,
+            "_create_startup_entry",
+            classmethod(self._noop_create_startup_entry),
+        )
+
+    def test_load_merges_new_key_from_system_config(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+    ) -> None:
+        """An older user config gets the new skip_system_shortcuts_inhibition key
+        merged in while keeping customizations.
+        """
+        old_user_config = {
+            "meta": {"config_version": "6.0.5"},
+            "strict_break": True,
+            "short_break_interval": 20,
+        }
+        system_config = {
+            "meta": {"config_version": "6.0.6"},
+            "skip_system_shortcuts_inhibition": False,
+            "strict_break": False,
+            "short_break_interval": 15,
+        }
+
+        self.mock_config_paths(monkeypatch, tmp_path, old_user_config, system_config)
+
+        cfg = configuration.Config.load()
+
+        # The new key is added with its default value...
+        assert cfg.get("skip_system_shortcuts_inhibition", None) is False
+        # ...while the user's custom values are preserved.
+        assert cfg.get("strict_break", None) is True
+        assert cfg.get("short_break_interval", None) == 20
+
+        # The merged config is written back to disk with the new version.
+        written = json.loads((tmp_path / "user_config.json").read_text())
+        assert written["meta"]["config_version"] == "6.0.6"
+        assert written["skip_system_shortcuts_inhibition"] is False
+        assert written["strict_break"] is True
+        assert written["short_break_interval"] == 20
+
+    def test_load_same_version_does_not_merge(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+    ) -> None:
+        """A user config already on the current version is left untouched."""
+        user_config = {
+            "meta": {"config_version": "6.0.6"},
+            "strict_break": True,
+        }
+        system_config = {
+            "meta": {"config_version": "6.0.6"},
+            "skip_system_shortcuts_inhibition": False,
+            "strict_break": False,
+        }
+
+        self.mock_config_paths(monkeypatch, tmp_path, user_config, system_config)
+
+        cfg = configuration.Config.load()
+
+        # No merge happened: the key is only available via the system config
+        # fallback, and the user's value is still used.
+        assert cfg.get("skip_system_shortcuts_inhibition", None) is False
+        assert cfg.get("strict_break", None) is True
+
+        # The user config on disk was not rewritten.
+        written = json.loads((tmp_path / "user_config.json").read_text())
+        assert written == user_config

--- a/safeeyes/tests/test_utility.py
+++ b/safeeyes/tests/test_utility.py
@@ -1,0 +1,122 @@
+# Safe Eyes is a utility to remind you to take break frequently
+# to protect your eyes from eye strain.
+
+# Copyright (C) 2016  Gobinath
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from safeeyes import utility
+
+
+class TestDesktopEnvironment:
+    """Test desktop_environment() desktop detection."""
+
+    @staticmethod
+    def set_session(
+        monkeypatch: pytest.MonkeyPatch,
+        desktop_session: str | None,
+        current_desktop: str | None,
+    ) -> None:
+        """Set the session env vars and reset the cached detection."""
+        monkeypatch.setattr(utility, "DESKTOP_ENVIRONMENT", None)
+        if desktop_session is None:
+            monkeypatch.delenv("DESKTOP_SESSION", raising=False)
+        else:
+            monkeypatch.setenv("DESKTOP_SESSION", desktop_session)
+        if current_desktop is None:
+            monkeypatch.delenv("XDG_CURRENT_DESKTOP", raising=False)
+        else:
+            monkeypatch.setenv("XDG_CURRENT_DESKTOP", current_desktop)
+        # Make sure no other session hints interfere
+        monkeypatch.delenv("GNOME_DESKTOP_SESSION_ID", raising=False)
+        monkeypatch.delenv("KDE_FULL_SESSION", raising=False)
+
+    def test_gnome_session(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A plain GNOME session (Fedora/Arch) is detected as gnome."""
+        self.set_session(monkeypatch, "gnome", "GNOME")
+        assert utility.desktop_environment() == "gnome"
+
+    def test_gnome_wayland_session(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """GNOME Wayland (gnome-wayland) is detected as gnome."""
+        self.set_session(monkeypatch, "gnome-wayland", "GNOME")
+        assert utility.desktop_environment() == "gnome"
+
+    def test_ubuntu_gnome_session(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Ubuntu GNOME is detected as gnome via XDG_CURRENT_DESKTOP."""
+        self.set_session(monkeypatch, "ubuntu", "ubuntu:GNOME")
+        assert utility.desktop_environment() == "gnome"
+
+    def test_ubuntu_unity_session(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Ubuntu without a GNOME XDG_CURRENT_DESKTOP keeps the unity fallback."""
+        self.set_session(monkeypatch, "ubuntu", "Unity")
+        assert utility.desktop_environment() == "unity"
+
+    def test_kde_plasma_session(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """KDE Plasma is detected as kde."""
+        self.set_session(monkeypatch, "plasma", "KDE")
+        assert utility.desktop_environment() == "kde"
+
+    def test_gnome_via_current_desktop_only(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """GNOME is detected from XDG_CURRENT_DESKTOP even without DESKTOP_SESSION."""
+        self.set_session(monkeypatch, None, "GNOME")
+        assert utility.desktop_environment() == "gnome"
+
+    def test_sway_session(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A real sway session (DESKTOP_SESSION=sway) is detected as sway."""
+        self.set_session(monkeypatch, "sway", "sway")
+        assert utility.desktop_environment() == "sway"
+
+    def test_sway_via_current_desktop_only(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Sway is detected from XDG_CURRENT_DESKTOP without DESKTOP_SESSION."""
+        self.set_session(monkeypatch, None, "sway")
+        assert utility.desktop_environment() == "sway"
+
+    def test_ubuntu_gnome_via_current_desktop_only(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Ubuntu GNOME is detected even without DESKTOP_SESSION."""
+        self.set_session(monkeypatch, None, "ubuntu:GNOME")
+        assert utility.desktop_environment() == "gnome"
+
+
+class TestIsGnomeWayland:
+    """Test is_gnome_wayland() gating helper."""
+
+    @staticmethod
+    def set_environment(
+        monkeypatch: pytest.MonkeyPatch, is_wayland: bool, desktop: str
+    ) -> None:
+        monkeypatch.setattr(utility, "is_wayland", lambda: is_wayland)
+        monkeypatch.setattr(utility, "desktop_environment", lambda: desktop)
+
+    def test_gnome_wayland(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """True on GNOME Wayland."""
+        self.set_environment(monkeypatch, True, "gnome")
+        assert utility.is_gnome_wayland() is True
+
+    def test_kde_wayland(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """False on KDE Wayland."""
+        self.set_environment(monkeypatch, True, "kde")
+        assert utility.is_gnome_wayland() is False
+
+    def test_gnome_x11(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """False on GNOME X11."""
+        self.set_environment(monkeypatch, False, "gnome")
+        assert utility.is_gnome_wayland() is False

--- a/safeeyes/ui/break_screen.py
+++ b/safeeyes/ui/break_screen.py
@@ -67,6 +67,7 @@ class BreakScreen:
         self.fade_in_break_screen_duration = 1500
         self.shortcut_disable_time = 2
         self.strict_break = False
+        self.skip_system_shortcuts_inhibition = False
         self.windows = []
         self.show_skip_button = False
         self.show_postpone_button = False
@@ -102,6 +103,9 @@ class BreakScreen:
             "fade_in_break_screen_duration", 1500
         )
         self.strict_break = config.get("strict_break", False)
+        self.skip_system_shortcuts_inhibition = config.get(
+            "skip_system_shortcuts_inhibition", False
+        )
 
     def skip_break(self) -> None:
         """Skip the break from the break screen."""
@@ -234,7 +238,7 @@ class BreakScreen:
             if not self.context.is_wayland:
                 self.__window_set_keep_above_x11(window)
 
-            if self.context.is_wayland:
+            if self.context.is_wayland and not self.skip_system_shortcuts_inhibition:
                 # this may or may not be granted by the window system
                 surface = window.get_surface()
                 if surface is not None:

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -84,6 +84,8 @@ class SettingsDialog(Gtk.ApplicationWindow):
     plugin_items: dict[str, "PluginItem"]
     plugin_map: dict[str, str]
     config: Config
+    box_skip_shortcut_inhibition: Gtk.Box = Gtk.Template.Child()
+    switch_skip_shortcut_inhibition: Gtk.Switch = Gtk.Template.Child()
 
     def __init__(
         self,
@@ -137,6 +139,14 @@ class SettingsDialog(Gtk.ApplicationWindow):
             config.get("shortcut_disable_time")
         )
         self.switch_strict_break.set_active(config.get("strict_break"))
+        # This setting is only relevant on Wayland, where Safe Eyes calls
+        # inhibit_system_shortcuts() and GNOME may show a permission dialog for it
+        if not utility.is_wayland():
+            self.box_skip_shortcut_inhibition.set_visible(False)
+        else:
+            self.switch_skip_shortcut_inhibition.set_active(
+                config.get("skip_system_shortcuts_inhibition", False)
+            )
         self.switch_random_order.set_active(config.get("random_order"))
         self.switch_postpone.set_active(config.get("allow_postpone"))
         self.switch_fade_in_break_screen.set_active(
@@ -366,6 +376,11 @@ class SettingsDialog(Gtk.ApplicationWindow):
             self.spin_disable_keyboard_shortcut.get_value_as_int(),
         )
         self.config.set("strict_break", self.switch_strict_break.get_active())
+        if utility.is_wayland():
+            self.config.set(
+                "skip_system_shortcuts_inhibition",
+                self.switch_skip_shortcut_inhibition.get_active(),
+            )
         self.config.set("random_order", self.switch_random_order.get_active())
         self.config.set("allow_postpone", self.switch_postpone.get_active())
         self.config.set(

--- a/safeeyes/ui/settings_dialog.py
+++ b/safeeyes/ui/settings_dialog.py
@@ -139,9 +139,11 @@ class SettingsDialog(Gtk.ApplicationWindow):
             config.get("shortcut_disable_time")
         )
         self.switch_strict_break.set_active(config.get("strict_break"))
-        # This setting is only relevant on Wayland, where Safe Eyes calls
-        # inhibit_system_shortcuts() and GNOME may show a permission dialog for it
-        if not utility.is_wayland():
+        # This setting is only relevant on GNOME Wayland, where Safe Eyes calls
+        # inhibit_system_shortcuts() and GNOME may show a permission dialog for it.
+        # Other Wayland compositors (e.g. KWin, sway) grant the inhibition
+        # silently, so the switch is hidden there.
+        if not utility.is_gnome_wayland():
             self.box_skip_shortcut_inhibition.set_visible(False)
         else:
             self.switch_skip_shortcut_inhibition.set_active(
@@ -376,7 +378,9 @@ class SettingsDialog(Gtk.ApplicationWindow):
             self.spin_disable_keyboard_shortcut.get_value_as_int(),
         )
         self.config.set("strict_break", self.switch_strict_break.get_active())
-        if utility.is_wayland():
+        # Only write back the value when the switch is actually shown, so that
+        # users on other Wayland desktops keep their manual config file edits.
+        if utility.is_gnome_wayland():
             self.config.set(
                 "skip_system_shortcuts_inhibition",
                 self.switch_skip_shortcut_inhibition.get_active(),

--- a/safeeyes/utility.py
+++ b/safeeyes/utility.py
@@ -302,6 +302,7 @@ def desktop_environment():
             "trinity",
             "kde",
             "hyprland",
+            "sway",
         ]:
             env = desktop_session
         elif desktop_session.startswith("xubuntu") or (
@@ -316,8 +317,12 @@ def desktop_environment():
             or os.environ.get("KDE_FULL_SESSION") == "true"
         ):
             env = "kde"
-        elif os.environ.get("GNOME_DESKTOP_SESSION_ID") or desktop_session.startswith(
-            "gnome"
+        elif (
+            os.environ.get("GNOME_DESKTOP_SESSION_ID")
+            or desktop_session.startswith("gnome")
+            # Ubuntu sets DESKTOP_SESSION=ubuntu, but XDG_CURRENT_DESKTOP is
+            # "ubuntu:GNOME", so it is a GNOME session as well
+            or (current_desktop is not None and "gnome" in current_desktop.lower())
         ):
             env = "gnome"
         elif desktop_session.startswith("ubuntu"):
@@ -325,6 +330,8 @@ def desktop_environment():
     elif current_desktop is not None:
         if current_desktop.startswith("sway"):
             env = "sway"
+        elif "gnome" in current_desktop.lower():
+            env = "gnome"
     DESKTOP_ENVIRONMENT = env
     return env
 
@@ -353,6 +360,16 @@ def is_wayland():
     else:
         IS_WAYLAND = bool(re.search(b"wayland", output, re.IGNORECASE))
     return IS_WAYLAND
+
+
+def is_gnome_wayland() -> bool:
+    """Return whether Safe Eyes is running on a GNOME Wayland session.
+
+    GNOME is the only major Wayland compositor that may show a permission
+    dialog when shortcut inhibition is requested, so some options are gated
+    on it.
+    """
+    return is_wayland() and desktop_environment() == "gnome"
 
 
 def execute_command(command, args=[]):


### PR DESCRIPTION
## Summary

On Wayland, Safe Eyes calls `inhibit_system_shortcuts` while a break is showing. On GNOME this can trigger a permission dialog every time a break starts, because GNOME does not support remembering this permission persistently (the [related issue](https://gitlab.gnome.org/GNOME/gnome-connections/-/work_items/85) has been open since 2021).

This PR adds a new config option **`skip_system_shortcuts_inhibition`** (default `false`) that, when enabled, skips calling the API entirely.

Related: #845

## Changes

- **safeeyes/config/safeeyes.json**: new key `skip_system_shortcuts_inhibition` (default `false`), `meta.config_version` bumped 6.0.5 → 6.0.6 so existing user configs auto-merge the new key
- **safeeyes/ui/break_screen.py**: read the option in `initialize()` and guard the `inhibit_system_shortcuts` call on Wayland
- **safeeyes/ui/settings_dialog.glade + settings_dialog.py**: new "Suppress GNOME shortcut permission dialog" switch in the Plugins tab (only shown on Wayland, only saved on Wayland)
- **translations**: new string added to `safeeyes.pot` and all 43 locale files
- **tests**: `safeeyes/tests/test_configuration.py` covering the config version merge behavior
- **README.md**: documented the option under a new Wayland subsection

## Behavior

With the option enabled, Safe Eyes will not request shortcut inhibition: system shortcuts stay active during breaks, while the break screen's own skip/postpone shortcuts keep working. This setting only affects Wayland; X11 is unaffected.

## Validation

- `pytest safeeyes/tests`: 26 tests pass
- `ruff check` and `ruff format --check`: clean
- `mypy safeeyes` on changed files: clean
- `validate_po.py`: pot and translations consistent
